### PR TITLE
firmware lib skeleton

### DIFF
--- a/firmware/boards/osc-dev-v006/app/Cargo.toml
+++ b/firmware/boards/osc-dev-v006/app/Cargo.toml
@@ -4,11 +4,14 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-# osc-ch32 is the app's HAL/runtime façade. It owns device.x, ISR shims,
-# and qingke-rt glue. Apps may pull tinyboot-ch32 directly only for the
-# `app_version!` metadata macro; UART processing, boot selection, and
-# everything else are owned by osc-ch32 and must not be reached around
-# it. Apps must not pull ch32-hal directly.
+# osc-ch32 is the app's HAL façade — owns device.x, ISR shims, sensor
+# conversion, init sequencing. App-level deps in this list are kept to
+# the bare minimum the app entry point needs:
+#   - qingke-rt: `#[entry]` macro and the RV2 vector table.
+#   - tinyboot-ch32: `app_version!` metadata macro only — UART processing,
+#     boot selection, and everything else are owned by osc-ch32.
+# Apps must not pull ch32-hal directly.
 osc-ch32      = { path = "../../../ch32", default-features = false }
+qingke-rt     = { version = "0.6", features = ["v2"] }
 tinyboot-ch32 = { git = "https://github.com/OpenServoCore/tinyboot.git", tag = "v0.4.1", default-features = false, features = ["ch32v006x8x6", "system-flash"] }
 panic-halt    = "1"

--- a/firmware/boards/osc-dev-v006/app/Cargo.toml
+++ b/firmware/boards/osc-dev-v006/app/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-# osc-ch32 is the project's only HAL/runtime façade for app crates. It
-# owns the device.x, ISR shims, qingke-rt glue, and tinyboot app metadata
-# hand-off — apps must not pull ch32-hal or tinyboot-ch32 directly.
-osc-ch32   = { path = "../../../ch32", default-features = false }
-panic-halt = "1"
+# osc-ch32 is the app's HAL/runtime façade. It owns device.x, ISR shims,
+# and qingke-rt glue. Apps may pull tinyboot-ch32 directly only for the
+# `app_version!` metadata macro; UART processing, boot selection, and
+# everything else are owned by osc-ch32 and must not be reached around
+# it. Apps must not pull ch32-hal directly.
+osc-ch32      = { path = "../../../ch32", default-features = false }
+tinyboot-ch32 = { git = "https://github.com/OpenServoCore/tinyboot.git", tag = "v0.4.1", default-features = false, features = ["ch32v006x8x6", "system-flash"] }
+panic-halt    = "1"

--- a/firmware/boards/osc-dev-v006/app/memory.x
+++ b/firmware/boards/osc-dev-v006/app/memory.x
@@ -1,12 +1,13 @@
 MEMORY
 {
-    RAM      : ORIGIN = 0x20000000, LENGTH = 8K
-    CODE     : ORIGIN = 0x00000000, LENGTH = 62K - 256 * 3
-    BOOT     : ORIGIN = 0x1FFF0000, LENGTH = 3K + 256
-    APP      : ORIGIN = 0x08000000, LENGTH = 62K - 256 * 3
-    EEPROM_A : ORIGIN = 0x0800F500, LENGTH = 256
-    EEPROM_B : ORIGIN = 0x0800F600, LENGTH = 256
-    META     : ORIGIN = 0x0800F700, LENGTH = 256
+    RAM      : ORIGIN = 0x20000000,                        LENGTH = 8K
+    CODE     : ORIGIN = 0x00000000,                        LENGTH = 62K - 4K - 1K - 256
+    BOOT     : ORIGIN = 0x1FFF0000,                        LENGTH = 3K + 256
+    APP      : ORIGIN = 0x08000000,                        LENGTH = 62K - 4K - 1K - 256
+    CONFIG_A : ORIGIN = 0x08000000 + 62K - 4K - 1K - 256,  LENGTH = 512
+    CONFIG_B : ORIGIN = 0x08000000 + 62K - 4K - 512 - 256, LENGTH = 512
+    CALIB    : ORIGIN = 0x08000000 + 62K - 4K - 256,       LENGTH = 4K
+    META     : ORIGIN = 0x08000000 + 62K - 256,            LENGTH = 256
 }
 
 REGION_ALIAS("FLASH",         CODE);

--- a/firmware/boards/osc-dev-v006/boot/memory.x
+++ b/firmware/boards/osc-dev-v006/boot/memory.x
@@ -1,12 +1,13 @@
 MEMORY
 {
-    RAM      : ORIGIN = 0x20000000, LENGTH = 8K
-    CODE     : ORIGIN = 0x00000000, LENGTH = 3K + 256
-    BOOT     : ORIGIN = 0x1FFF0000, LENGTH = 3K + 256
-    APP      : ORIGIN = 0x08000000, LENGTH = 62K - 768
-    EEPROM_A : ORIGIN = 0x0800F500, LENGTH = 256
-    EEPROM_B : ORIGIN = 0x0800F600, LENGTH = 256
-    META     : ORIGIN = 0x0800F700, LENGTH = 256
+    RAM      : ORIGIN = 0x20000000,                        LENGTH = 8K
+    CODE     : ORIGIN = 0x00000000,                        LENGTH = 3K + 256
+    BOOT     : ORIGIN = 0x1FFF0000,                        LENGTH = 3K + 256
+    APP      : ORIGIN = 0x08000000,                        LENGTH = 62K - 4K - 1K - 256
+    CONFIG_A : ORIGIN = 0x08000000 + 62K - 4K - 1K - 256,  LENGTH = 512
+    CONFIG_B : ORIGIN = 0x08000000 + 62K - 4K - 512 - 256, LENGTH = 512
+    CALIB    : ORIGIN = 0x08000000 + 62K - 4K - 256,       LENGTH = 4K
+    META     : ORIGIN = 0x08000000 + 62K - 256,            LENGTH = 256
 }
 
 REGION_ALIAS("FLASH",         CODE);

--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -13,6 +13,7 @@ embedded-storage = "0.3"
 portable-atomic  = { version = "1", default-features = false, features = ["critical-section"] }
 critical-section = "1.2"
 bitflags         = "2"
+crc              = { version = "3", default-features = false }
 
 osc-units    = { path = "units" }
 dxl-protocol = { path = "dxl-protocol" }

--- a/firmware/lib/core/src/board.rs
+++ b/firmware/lib/core/src/board.rs
@@ -1,0 +1,45 @@
+use osc_units::Effort;
+
+pub trait Board {
+    fn caps(&self) -> Capabilities;
+    fn write_motor(&mut self, cmd: MotorCmd);
+}
+
+/// Commanded motor state. The chip-side `Board` impl maps these to the
+/// H-bridge IO pattern + the driver chip's enable line.
+#[derive(Copy, Clone, Debug)]
+pub enum MotorCmd {
+    /// `drv_en` LOW. Driver powered down; outputs hi-Z. Boot/fault state.
+    Disabled,
+    /// `drv_en` HIGH, both half-bridges hi-Z. Motor free-wheels.
+    Coast,
+    /// `drv_en` HIGH, both low-side FETs on. Short-circuit braking.
+    Brake,
+    /// `drv_en` HIGH, PWM drive with selected current decay during off-window.
+    Drive { duty: Effort, decay: DecayMode },
+}
+
+impl MotorCmd {
+    pub const ZERO: Self = Self::Disabled;
+}
+
+/// Current decay during the PWM off-window.
+#[derive(Copy, Clone, Debug)]
+pub enum DecayMode {
+    /// Opposite leg floats during off-window. Faster current decay.
+    Fast,
+    /// Opposite leg actively shorts during off-window. Slower decay.
+    Slow,
+}
+
+bitflags::bitflags! {
+    /// Host-visible feature flags. Mirrors `capability_flags` in `ConfigIdentity`.
+    /// Reports protocol-relevant features only — sensor type (pot, magnetic, …)
+    /// is a `BoardCfg` concern; the host only sees `present_position` in microrads.
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct Capabilities: u32 {
+        /// Motor-side encoder is wired. When set, firmware uses it for velocity
+        /// feedback; when clear, velocity is estimated from the BEMF model.
+        const HAS_MOTOR_ENCODER = 1 << 0;
+    }
+}

--- a/firmware/lib/core/src/kernel.rs
+++ b/firmware/lib/core/src/kernel.rs
@@ -1,0 +1,30 @@
+use crate::{Board, SampleFrame, Shared};
+
+/// Real-time control kernel. Runs in the PWM ISR; one `on_tick` per period.
+pub struct Kernel<B: Board> {
+    pub board: B,
+    pub state: KernelState,
+    pub stream_decimation_counter: u8,
+    pub stream_duration_remaining_ticks: u32,
+}
+
+#[derive(Default)]
+pub struct KernelState {
+    pub pid_integrator: i32,
+    pub pid_prev_error: i32,
+}
+
+impl<B: Board> Kernel<B> {
+    pub fn new(board: B) -> Self {
+        Self {
+            board,
+            state: KernelState::default(),
+            stream_decimation_counter: 1,
+            stream_duration_remaining_ticks: 0,
+        }
+    }
+
+    pub fn on_tick(&mut self, _frame: SampleFrame, _shared: &Shared) {
+        todo!()
+    }
+}

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -1,1 +1,25 @@
 #![no_std]
+#![feature(sync_unsafe_cell)]
+
+pub mod board;
+pub mod kernel;
+pub mod page;
+pub mod regions;
+pub mod sample_frame;
+pub mod services;
+pub mod shared;
+pub mod stream_coord;
+
+pub use board::{Board, Capabilities, DecayMode, MotorCmd};
+pub use kernel::{Kernel, KernelState};
+pub use page::{PageHeader, PageMagic};
+pub use regions::{
+    BemfCalibBlock, CalibRegs, ConfigComms, ConfigControl, ConfigControlPosition, ConfigIdentity,
+    ConfigLimits, ConfigPosLimits, ConfigRegs, ConfigSafety, ConfigStall, ConfigThermal,
+    ControlLifecycle, ControlRegs, ControlStreaming, ControlTable, PotLutBlock, TelemetryConverted,
+    TelemetryFault, TelemetryIntermediaries, TelemetryRaw, TelemetryRegs,
+};
+pub use sample_frame::{RawSamples, SampleFrame};
+pub use services::Services;
+pub use shared::Shared;
+pub use stream_coord::StreamCoord;

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod board;
 pub mod kernel;
 pub mod page;
 pub mod regions;
+pub mod regmap;
 pub mod sample_frame;
 pub mod services;
 pub mod shared;
@@ -19,6 +20,7 @@ pub use regions::{
     ControlLifecycle, ControlRegs, ControlStreaming, ControlTable, PotLutBlock, TelemetryConverted,
     TelemetryFault, TelemetryIntermediaries, TelemetryRaw, TelemetryRegs,
 };
+pub use regmap::{Access, BlockDesc, RegmapError};
 pub use sample_frame::{RawSamples, SampleFrame};
 pub use services::Services;
 pub use shared::Shared;

--- a/firmware/lib/core/src/page.rs
+++ b/firmware/lib/core/src/page.rs
@@ -1,5 +1,7 @@
 //! Trailing 32 B header on every persistent page (CONFIG copy, CALIB block).
-//! `crc32` is IEEE over the leading `used_size` body bytes.
+//! `crc32` is IEEE over the leading `used_size` body bytes. `seq` is a
+//! monotonic per-region commit counter; A/B picks the higher-`seq` valid
+//! page on load.
 
 #[repr(u32)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -30,7 +32,7 @@ impl PageMagic {
 #[repr(C)]
 pub struct PageHeader {
     pub magic: u32,
-    pub revision: u32,
+    pub seq: u32,
     pub hw_rev_at_commit: u32,
     pub used_size: u16,
     /// Bit 0 = `page_active` (CONFIG A/B). Other bits reserved.
@@ -46,7 +48,7 @@ impl PageHeader {
     pub const fn const_erased() -> Self {
         Self {
             magic: PageMagic::Erased as u32,
-            revision: 0xFFFF_FFFF,
+            seq: 0xFFFF_FFFF,
             hw_rev_at_commit: 0xFFFF_FFFF,
             used_size: 0xFFFF,
             flags: 0xFF,

--- a/firmware/lib/core/src/page.rs
+++ b/firmware/lib/core/src/page.rs
@@ -1,0 +1,69 @@
+//! Trailing 32 B header on every persistent page (CONFIG copy, CALIB block).
+//! `crc32` is IEEE over the leading `used_size` body bytes.
+
+#[repr(u32)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum PageMagic {
+    Erased = u32::from_le_bytes([0xFF, 0xFF, 0xFF, 0xFF]),
+    Config = u32::from_le_bytes(*b"OSCF"),
+    CalibPotLut = u32::from_le_bytes(*b"OSCP"),
+    CalibBemf = u32::from_le_bytes(*b"OSCB"),
+}
+
+impl PageMagic {
+    pub const fn from_u32(v: u32) -> Option<Self> {
+        const ERASED: u32 = PageMagic::Erased as u32;
+        const CONFIG: u32 = PageMagic::Config as u32;
+        const POTLUT: u32 = PageMagic::CalibPotLut as u32;
+        const BEMF: u32 = PageMagic::CalibBemf as u32;
+        match v {
+            ERASED => Some(Self::Erased),
+            CONFIG => Some(Self::Config),
+            POTLUT => Some(Self::CalibPotLut),
+            BEMF => Some(Self::CalibBemf),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct PageHeader {
+    pub magic: u32,
+    pub revision: u32,
+    pub hw_rev_at_commit: u32,
+    pub used_size: u16,
+    /// Bit 0 = `page_active` (CONFIG A/B). Other bits reserved.
+    pub flags: u8,
+    pub _rsvd_align: u8,
+    pub _rsvd: [u8; 12],
+    pub crc32: u32,
+}
+
+impl PageHeader {
+    /// In-RAM mirror of fresh-erased flash (every byte 0xFF). `magic` reads
+    /// back as `PageMagic::Erased`, so load treats the slot as "no valid data".
+    pub const fn const_erased() -> Self {
+        Self {
+            magic: PageMagic::Erased as u32,
+            revision: 0xFFFF_FFFF,
+            hw_rev_at_commit: 0xFFFF_FFFF,
+            used_size: 0xFFFF,
+            flags: 0xFF,
+            _rsvd_align: 0xFF,
+            _rsvd: [0xFF; 12],
+            crc32: 0xFFFF_FFFF,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn page_header_is_32_bytes() {
+        assert_eq!(size_of::<PageHeader>(), 32);
+    }
+}

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -1,0 +1,80 @@
+//! CALIB region — single-copy persistent calibration with per-block CRC.
+
+use crate::page::PageHeader;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct PotLutBlock {
+    pub raw_min: u16,
+    pub raw_max: u16,
+    pub lut: [i32; 55],
+    pub header: PageHeader,
+}
+
+/// Compact (40 B); flash-side block is 256 B with header at flash offset 0xE0.
+/// Save/load bridges layouts via the per-block descriptor.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct BemfCalibBlock {
+    pub ke_uvs_per_rad: u16,
+    pub r_motor_mohm: u16,
+    pub calib_v_bus_mv: u16,
+    pub calib_i_ma: u16,
+    pub header: PageHeader,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct CalibRegs {
+    pub pot_lut: PotLutBlock,
+    pub bemf: BemfCalibBlock,
+}
+
+impl PotLutBlock {
+    pub const fn const_new() -> Self {
+        Self {
+            raw_min: 0,
+            raw_max: 0,
+            lut: [0; 55],
+            header: PageHeader::const_erased(),
+        }
+    }
+}
+
+impl BemfCalibBlock {
+    pub const fn const_new() -> Self {
+        Self {
+            ke_uvs_per_rad: 0,
+            r_motor_mohm: 0,
+            calib_v_bus_mv: 0,
+            calib_i_ma: 0,
+            header: PageHeader::const_erased(),
+        }
+    }
+}
+
+impl CalibRegs {
+    pub const fn const_new() -> Self {
+        Self {
+            pot_lut: PotLutBlock::const_new(),
+            bemf: BemfCalibBlock::const_new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regions::CALIB_BLOCK_SIZE;
+    use core::mem::size_of;
+
+    #[test]
+    fn pot_lut_exact_block() {
+        assert_eq!(size_of::<PotLutBlock>(), CALIB_BLOCK_SIZE);
+    }
+
+    #[test]
+    fn bemf_fits_block() {
+        assert!(size_of::<BemfCalibBlock>() <= CALIB_BLOCK_SIZE);
+    }
+}

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -1,6 +1,9 @@
 //! CALIB region — single-copy persistent calibration with per-block CRC.
 
 use crate::page::PageHeader;
+use crate::regions::CALIB_BLOCK_SIZE;
+use crate::regmap::{Access, BlockDesc};
+use core::mem::{offset_of, size_of};
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -29,6 +32,29 @@ pub struct CalibRegs {
     pub pot_lut: PotLutBlock,
     pub bemf: BemfCalibBlock,
 }
+
+/// Body sizes (struct without the trailing PageHeader). Regmap only
+/// exposes the body to the host; the embedded header is internal CRC
+/// bookkeeping accessed by the persistence layer, not the protocol.
+const POT_LUT_BODY: u16 = (size_of::<PotLutBlock>() - size_of::<PageHeader>()) as u16;
+const BEMF_BODY: u16 = (size_of::<BemfCalibBlock>() - size_of::<PageHeader>()) as u16;
+
+/// Protocol-address slot map for CALIB. Each block slot is 256 B; only
+/// the body bytes are host-visible (the trailing PageHeader is reserved).
+pub const CALIB_BLOCKS: &[BlockDesc] = &[
+    BlockDesc {
+        addr_offset: 0 * CALIB_BLOCK_SIZE as u16,
+        size: POT_LUT_BODY,
+        struct_offset: offset_of!(CalibRegs, pot_lut) as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 1 * CALIB_BLOCK_SIZE as u16,
+        size: BEMF_BODY,
+        struct_offset: offset_of!(CalibRegs, bemf) as u16,
+        access: Access::Rw,
+    },
+];
 
 impl PotLutBlock {
     pub const fn const_new() -> Self {

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -1,6 +1,9 @@
 //! CONFIG region — persistent A/B-mirrored runtime config.
 
 use crate::page::PageHeader;
+use crate::regions::CONFIG_BLOCK_SIZE;
+use crate::regmap::{Access, BlockDesc};
+use core::mem::{offset_of, size_of};
 
 #[derive(Copy, Clone)]
 #[repr(C)]
@@ -195,6 +198,55 @@ impl ConfigControl {
         }
     }
 }
+
+/// Protocol-address slot map for CONFIG. Block N starts at
+/// `CONFIG_BASE_ADDR + N * CONFIG_BLOCK_SIZE`. Unlisted indices are
+/// reserved and return AccessError.
+pub const CONFIG_BLOCKS: &[BlockDesc] = &[
+    BlockDesc {
+        addr_offset: 0 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<ConfigIdentity>() as u16,
+        struct_offset: offset_of!(ConfigRegs, identity) as u16,
+        access: Access::Ro,
+    },
+    BlockDesc {
+        addr_offset: 1 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<ConfigComms>() as u16,
+        struct_offset: offset_of!(ConfigRegs, comms) as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 2 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<ConfigPosLimits>() as u16,
+        struct_offset: (offset_of!(ConfigRegs, limits) + offset_of!(ConfigLimits, pos)) as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 3 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<ConfigStall>() as u16,
+        struct_offset: (offset_of!(ConfigRegs, safety) + offset_of!(ConfigSafety, stall)) as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 4 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<ConfigThermal>() as u16,
+        struct_offset: (offset_of!(ConfigRegs, safety) + offset_of!(ConfigSafety, thermal)) as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 5 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<ConfigControlPosition>() as u16,
+        struct_offset: (offset_of!(ConfigRegs, control) + offset_of!(ConfigControl, position))
+            as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 15 * CONFIG_BLOCK_SIZE as u16,
+        size: size_of::<PageHeader>() as u16,
+        struct_offset: offset_of!(ConfigRegs, header) as u16,
+        access: Access::Ro,
+    },
+];
 
 impl ConfigRegs {
     pub const fn const_new() -> Self {

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -1,0 +1,227 @@
+//! CONFIG region — persistent A/B-mirrored runtime config.
+
+use crate::page::PageHeader;
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigIdentity {
+    pub model_number: u16,
+    pub firmware_version: u16,
+    pub hardware_revision: u32,
+    pub capability_flags: u32,
+}
+
+/// Writes gated on torque (FAULT_CFG_LOCK).
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigComms {
+    pub id: u8,
+    pub baud_rate_idx: u8,
+    pub return_delay_us: u16,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigLimits {
+    pub pos: ConfigPosLimits,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigPosLimits {
+    pub pos_min_phys_urad: i32,
+    pub pos_max_phys_urad: i32,
+    pub pos_min_soft_urad: i32,
+    pub pos_max_soft_urad: i32,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigSafety {
+    pub stall: ConfigStall,
+    pub thermal: ConfigThermal,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigStall {
+    pub stall_response: u8,
+    pub _rsvd_align: u8,
+    pub stall_effort_threshold: i16,
+    pub stall_motion_threshold_urad: u32,
+    pub stall_time_threshold_ms: u16,
+    pub comply_release_window_ms: u16,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigThermal {
+    pub motor_thermal_k_q88: u16,
+    pub motor_thermal_tau_ms: u16,
+    pub winding_cutoff_dc: i16,
+    pub winding_recover_dc: i16,
+    pub v_undervolt_mv: u16,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigControl {
+    pub position: ConfigControlPosition,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigControlPosition {
+    pub pid_kp_q88: u16,
+    pub pid_ki_q88: u16,
+    pub pid_kd_q88: u16,
+    pub _rsvd_align: u16,
+    pub pid_i_limit: i32,
+    pub pos_deadband_urad: u32,
+    pub pwm_deadband_pct: u8,
+    pub v_comp_enable: u8,
+    pub max_effort: i16,
+    pub v_nominal_mv: u16,
+}
+
+/// Compact mirror of active blocks; on-disk page is full 512 B with reserved gaps.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ConfigRegs {
+    pub identity: ConfigIdentity,
+    pub comms: ConfigComms,
+    pub limits: ConfigLimits,
+    pub safety: ConfigSafety,
+    pub control: ConfigControl,
+    /// Host-RO. Writes into the header range return Access Error.
+    pub header: PageHeader,
+}
+
+impl ConfigIdentity {
+    pub const fn const_new() -> Self {
+        Self {
+            model_number: 0,
+            firmware_version: 0,
+            hardware_revision: 0,
+            capability_flags: 0,
+        }
+    }
+}
+
+impl ConfigComms {
+    pub const fn const_new() -> Self {
+        Self {
+            id: 0,
+            baud_rate_idx: 0,
+            return_delay_us: 0,
+        }
+    }
+}
+
+impl ConfigPosLimits {
+    pub const fn const_new() -> Self {
+        Self {
+            pos_min_phys_urad: 0,
+            pos_max_phys_urad: 0,
+            pos_min_soft_urad: 0,
+            pos_max_soft_urad: 0,
+        }
+    }
+}
+
+impl ConfigLimits {
+    pub const fn const_new() -> Self {
+        Self {
+            pos: ConfigPosLimits::const_new(),
+        }
+    }
+}
+
+impl ConfigStall {
+    pub const fn const_new() -> Self {
+        Self {
+            stall_response: 0,
+            _rsvd_align: 0,
+            stall_effort_threshold: 0,
+            stall_motion_threshold_urad: 0,
+            stall_time_threshold_ms: 0,
+            comply_release_window_ms: 0,
+        }
+    }
+}
+
+impl ConfigThermal {
+    pub const fn const_new() -> Self {
+        Self {
+            motor_thermal_k_q88: 0,
+            motor_thermal_tau_ms: 0,
+            winding_cutoff_dc: 0,
+            winding_recover_dc: 0,
+            v_undervolt_mv: 0,
+        }
+    }
+}
+
+impl ConfigSafety {
+    pub const fn const_new() -> Self {
+        Self {
+            stall: ConfigStall::const_new(),
+            thermal: ConfigThermal::const_new(),
+        }
+    }
+}
+
+impl ConfigControlPosition {
+    pub const fn const_new() -> Self {
+        Self {
+            pid_kp_q88: 0,
+            pid_ki_q88: 0,
+            pid_kd_q88: 0,
+            _rsvd_align: 0,
+            pid_i_limit: 0,
+            pos_deadband_urad: 0,
+            pwm_deadband_pct: 0,
+            v_comp_enable: 0,
+            max_effort: 0,
+            v_nominal_mv: 0,
+        }
+    }
+}
+
+impl ConfigControl {
+    pub const fn const_new() -> Self {
+        Self {
+            position: ConfigControlPosition::const_new(),
+        }
+    }
+}
+
+impl ConfigRegs {
+    pub const fn const_new() -> Self {
+        Self {
+            identity: ConfigIdentity::const_new(),
+            comms: ConfigComms::const_new(),
+            limits: ConfigLimits::const_new(),
+            safety: ConfigSafety::const_new(),
+            control: ConfigControl::const_new(),
+            header: PageHeader::const_erased(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regions::CONFIG_BLOCK_SIZE;
+    use core::mem::size_of;
+
+    #[test]
+    fn leaf_blocks_fit_block() {
+        assert!(size_of::<ConfigIdentity>()        <= CONFIG_BLOCK_SIZE);
+        assert!(size_of::<ConfigComms>()           <= CONFIG_BLOCK_SIZE);
+        assert!(size_of::<ConfigPosLimits>()       <= CONFIG_BLOCK_SIZE);
+        assert!(size_of::<ConfigStall>()           <= CONFIG_BLOCK_SIZE);
+        assert!(size_of::<ConfigThermal>()         <= CONFIG_BLOCK_SIZE);
+        assert!(size_of::<ConfigControlPosition>() <= CONFIG_BLOCK_SIZE);
+    }
+}

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -1,5 +1,9 @@
 //! CONTROL region — RW volatile runtime commands from the host.
 
+use crate::regions::CONTROL_BLOCK_SIZE;
+use crate::regmap::{Access, BlockDesc};
+use core::mem::{offset_of, size_of};
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct ControlLifecycle {
@@ -52,6 +56,22 @@ impl ControlStreaming {
         }
     }
 }
+
+/// Protocol-address slot map for CONTROL. Both blocks are host-RW.
+pub const CONTROL_BLOCKS: &[BlockDesc] = &[
+    BlockDesc {
+        addr_offset: 0 * CONTROL_BLOCK_SIZE as u16,
+        size: size_of::<ControlLifecycle>() as u16,
+        struct_offset: offset_of!(ControlRegs, lifecycle) as u16,
+        access: Access::Rw,
+    },
+    BlockDesc {
+        addr_offset: 1 * CONTROL_BLOCK_SIZE as u16,
+        size: size_of::<ControlStreaming>() as u16,
+        struct_offset: offset_of!(ControlRegs, streaming) as u16,
+        access: Access::Rw,
+    },
+];
 
 impl ControlRegs {
     pub const fn const_new() -> Self {

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -1,0 +1,76 @@
+//! CONTROL region — RW volatile runtime commands from the host.
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ControlLifecycle {
+    pub torque_enable: u8,
+    pub mode: u8,
+    pub _rsvd_align: [u8; 2],
+    pub goal_position: i32,
+    pub goal_velocity: i32,
+    pub goal_effort: i16,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ControlStreaming {
+    pub stream_enable: u8,
+    pub stream_decimation: u8,
+    pub stream_duration_ms: u16,
+    pub stream_field_mask: u32,
+    pub stream_dropped: u32,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct ControlRegs {
+    pub lifecycle: ControlLifecycle,
+    pub streaming: ControlStreaming,
+}
+
+impl ControlLifecycle {
+    pub const fn const_new() -> Self {
+        Self {
+            torque_enable: 0,
+            mode: 0,
+            _rsvd_align: [0; 2],
+            goal_position: 0,
+            goal_velocity: 0,
+            goal_effort: 0,
+        }
+    }
+}
+
+impl ControlStreaming {
+    pub const fn const_new() -> Self {
+        Self {
+            stream_enable: 0,
+            stream_decimation: 0,
+            stream_duration_ms: 0,
+            stream_field_mask: 0,
+            stream_dropped: 0,
+        }
+    }
+}
+
+impl ControlRegs {
+    pub const fn const_new() -> Self {
+        Self {
+            lifecycle: ControlLifecycle::const_new(),
+            streaming: ControlStreaming::const_new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regions::CONTROL_BLOCK_SIZE;
+    use core::mem::size_of;
+
+    #[test]
+    fn leaf_blocks_fit_block() {
+        assert!(size_of::<ControlLifecycle>() <= CONTROL_BLOCK_SIZE);
+        assert!(size_of::<ControlStreaming>() <= CONTROL_BLOCK_SIZE);
+    }
+}

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -1,0 +1,115 @@
+//! Control table — the host-visible register state.
+//!
+//! Each region's struct holds only active blocks; reserved slots have no SRAM
+//! mirror and the router returns Access Error. Struct layout is decoupled from
+//! the protocol address space — the router uses per-region block descriptors
+//! to translate, and flash save/load uses the same descriptors.
+//!
+//!   CONFIG    0x0000..=0x01FF  (512 B)  — persistent A/B
+//!   TELEMETRY 0x0200..=0x02FF  (256 B)  — RO from host
+//!   CONTROL   0x0300..=0x08FF  (1536 B) — RW volatile
+//!   CALIB     0x0900..=0x18FF  (4096 B) — single-copy + per-block CRC
+//!
+//! Owners form transient `&mut RegionT` via `&mut *cell.get()`; cross-domain
+//! readers use raw-pointer per-field reads, never form `&T`.
+
+use core::cell::SyncUnsafeCell;
+
+pub mod calib;
+pub mod config;
+pub mod control;
+pub mod telemetry;
+
+pub use calib::{BemfCalibBlock, CalibRegs, PotLutBlock};
+pub use config::{
+    ConfigComms, ConfigControl, ConfigControlPosition, ConfigIdentity, ConfigLimits,
+    ConfigPosLimits, ConfigRegs, ConfigSafety, ConfigStall, ConfigThermal,
+};
+pub use control::{ControlLifecycle, ControlRegs, ControlStreaming};
+pub use telemetry::{
+    TelemetryConverted, TelemetryFault, TelemetryIntermediaries, TelemetryRaw, TelemetryRegs,
+};
+
+use crate::page::PageHeader;
+
+pub const PAGE_HEADER_SIZE: usize = core::mem::size_of::<PageHeader>();
+
+pub const CONFIG_REGION_SIZE: usize = 512;
+pub const CONFIG_BLOCK_SIZE: usize = 32;
+pub const CONFIG_BLOCK_COUNT: usize = CONFIG_REGION_SIZE / CONFIG_BLOCK_SIZE;
+pub const CONFIG_BODY_SIZE: usize = CONFIG_REGION_SIZE - PAGE_HEADER_SIZE;
+
+pub const TELEMETRY_REGION_SIZE: usize = 256;
+pub const TELEMETRY_BLOCK_SIZE: usize = 32;
+pub const TELEMETRY_BLOCK_COUNT: usize = TELEMETRY_REGION_SIZE / TELEMETRY_BLOCK_SIZE;
+
+pub const CONTROL_REGION_SIZE: usize = 1536;
+pub const CONTROL_BLOCK_SIZE: usize = 32;
+pub const CONTROL_BLOCK_COUNT: usize = CONTROL_REGION_SIZE / CONTROL_BLOCK_SIZE;
+
+pub const CALIB_REGION_SIZE: usize = 4096;
+pub const CALIB_BLOCK_SIZE: usize = 256;
+pub const CALIB_BLOCK_COUNT: usize = CALIB_REGION_SIZE / CALIB_BLOCK_SIZE;
+pub const CALIB_BLOCK_BODY_SIZE: usize = CALIB_BLOCK_SIZE - PAGE_HEADER_SIZE;
+
+pub const CONFIG_BASE_ADDR: u16 = 0x0000;
+pub const TELEMETRY_BASE_ADDR: u16 = 0x0200;
+pub const CONTROL_BASE_ADDR: u16 = 0x0300;
+pub const CALIB_BASE_ADDR: u16 = 0x0900;
+
+#[repr(C)]
+pub struct ControlTable {
+    pub config: SyncUnsafeCell<ConfigRegs>,
+    pub telemetry: SyncUnsafeCell<TelemetryRegs>,
+    pub control: SyncUnsafeCell<ControlRegs>,
+    pub calib: SyncUnsafeCell<CalibRegs>,
+}
+
+impl ControlTable {
+    pub const fn const_new() -> Self {
+        Self {
+            config: SyncUnsafeCell::new(ConfigRegs::const_new()),
+            telemetry: SyncUnsafeCell::new(TelemetryRegs::const_new()),
+            control: SyncUnsafeCell::new(ControlRegs::const_new()),
+            calib: SyncUnsafeCell::new(CalibRegs::const_new()),
+        }
+    }
+
+    /// Called once in `install` before PFIC IRQs are enabled — sole writer.
+    pub fn load_config_from_flash<F: embedded_storage::nor_flash::ReadNorFlash>(
+        &self,
+        _flash: &mut F,
+        _page_a_addr: u32,
+        _page_b_addr: u32,
+    ) {
+        todo!()
+    }
+
+    /// Called once in `install` before PFIC IRQs are enabled — sole writer.
+    pub fn load_calib_from_flash<F: embedded_storage::nor_flash::ReadNorFlash>(
+        &self,
+        _flash: &mut F,
+        _calib_base_addr: u32,
+    ) {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn region_structs_fit_regions() {
+        assert!(size_of::<ConfigRegs>()    <= CONFIG_REGION_SIZE);
+        assert!(size_of::<TelemetryRegs>() <= TELEMETRY_REGION_SIZE);
+        assert!(size_of::<ControlRegs>()   <= CONTROL_REGION_SIZE);
+        assert!(size_of::<CalibRegs>()     <= CALIB_REGION_SIZE);
+    }
+
+    #[test]
+    fn control_table_sram_footprint() {
+        assert!(size_of::<ControlTable>() <= 1024);
+    }
+}

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -1,8 +1,8 @@
 //! Control table — the host-visible register state.
 //!
 //! Each region's struct holds only active blocks; reserved slots have no SRAM
-//! mirror and the router returns Access Error. Struct layout is decoupled from
-//! the protocol address space — the router uses per-region block descriptors
+//! mirror and regmap returns Access Error. Struct layout is decoupled from
+//! the protocol address space — regmap uses per-region block descriptors
 //! to translate, and flash save/load uses the same descriptors.
 //!
 //!   CONFIG    0x0000..=0x01FF  (512 B)  — persistent A/B

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -1,5 +1,9 @@
 //! TELEMETRY region — RO from the host's perspective; written by the kernel.
 
+use crate::regions::TELEMETRY_BLOCK_SIZE;
+use crate::regmap::{Access, BlockDesc};
+use core::mem::{offset_of, size_of};
+
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct TelemetryConverted {
@@ -106,6 +110,35 @@ impl TelemetryRaw {
         }
     }
 }
+
+/// Protocol-address slot map for TELEMETRY. All blocks RO from host.
+/// `fault_flags` clear-byte carve-out is enforced one layer up, not here.
+pub const TELEMETRY_BLOCKS: &[BlockDesc] = &[
+    BlockDesc {
+        addr_offset: 0 * TELEMETRY_BLOCK_SIZE as u16,
+        size: size_of::<TelemetryConverted>() as u16,
+        struct_offset: offset_of!(TelemetryRegs, converted) as u16,
+        access: Access::Ro,
+    },
+    BlockDesc {
+        addr_offset: 1 * TELEMETRY_BLOCK_SIZE as u16,
+        size: size_of::<TelemetryIntermediaries>() as u16,
+        struct_offset: offset_of!(TelemetryRegs, intermediaries) as u16,
+        access: Access::Ro,
+    },
+    BlockDesc {
+        addr_offset: 2 * TELEMETRY_BLOCK_SIZE as u16,
+        size: size_of::<TelemetryFault>() as u16,
+        struct_offset: offset_of!(TelemetryRegs, fault) as u16,
+        access: Access::Ro,
+    },
+    BlockDesc {
+        addr_offset: 3 * TELEMETRY_BLOCK_SIZE as u16,
+        size: size_of::<TelemetryRaw>() as u16,
+        struct_offset: offset_of!(TelemetryRegs, raw) as u16,
+        access: Access::Ro,
+    },
+];
 
 impl TelemetryRegs {
     pub const fn const_new() -> Self {

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -1,0 +1,134 @@
+//! TELEMETRY region — RO from the host's perspective; written by the kernel.
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TelemetryConverted {
+    pub present_position: i32,
+    pub present_velocity: i32,
+    pub present_current: i16,
+    pub present_temp: i16,
+    pub present_vbus_mv: u16,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TelemetryIntermediaries {
+    pub vbus_filt_mv: u16,
+    pub t_winding_dc: i16,
+    pub pwm_duty_actual: i16,
+    pub _rsvd_align: u16,
+    pub pid_error_last: i32,
+    pub pid_output_last: i32,
+    pub internal_goal: i32,
+    pub sample_tick: u32,
+}
+
+/// `fault_flags` has a writable-RO carve-out: host writing 0x00 clears
+/// non-latched bits.
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TelemetryFault {
+    pub mode_active: u8,
+    pub fault_flags: u8,
+    pub fault_code: u8,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TelemetryRaw {
+    pub raw_pos: u16,
+    pub raw_current: u16,
+    pub raw_temp: u16,
+    pub raw_vbus: u16,
+    pub raw_vmotor_a: u16,
+    pub raw_vmotor_b: u16,
+    pub raw_enc_a: u16,
+    pub raw_enc_b: u16,
+}
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TelemetryRegs {
+    pub converted: TelemetryConverted,
+    pub intermediaries: TelemetryIntermediaries,
+    pub fault: TelemetryFault,
+    pub raw: TelemetryRaw,
+}
+
+impl TelemetryConverted {
+    pub const fn const_new() -> Self {
+        Self {
+            present_position: 0,
+            present_velocity: 0,
+            present_current: 0,
+            present_temp: 0,
+            present_vbus_mv: 0,
+        }
+    }
+}
+
+impl TelemetryIntermediaries {
+    pub const fn const_new() -> Self {
+        Self {
+            vbus_filt_mv: 0,
+            t_winding_dc: 0,
+            pwm_duty_actual: 0,
+            _rsvd_align: 0,
+            pid_error_last: 0,
+            pid_output_last: 0,
+            internal_goal: 0,
+            sample_tick: 0,
+        }
+    }
+}
+
+impl TelemetryFault {
+    pub const fn const_new() -> Self {
+        Self {
+            mode_active: 0,
+            fault_flags: 0,
+            fault_code: 0,
+        }
+    }
+}
+
+impl TelemetryRaw {
+    pub const fn const_new() -> Self {
+        Self {
+            raw_pos: 0,
+            raw_current: 0,
+            raw_temp: 0,
+            raw_vbus: 0,
+            raw_vmotor_a: 0,
+            raw_vmotor_b: 0,
+            raw_enc_a: 0,
+            raw_enc_b: 0,
+        }
+    }
+}
+
+impl TelemetryRegs {
+    pub const fn const_new() -> Self {
+        Self {
+            converted: TelemetryConverted::const_new(),
+            intermediaries: TelemetryIntermediaries::const_new(),
+            fault: TelemetryFault::const_new(),
+            raw: TelemetryRaw::const_new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regions::TELEMETRY_BLOCK_SIZE;
+    use core::mem::size_of;
+
+    #[test]
+    fn leaf_blocks_fit_block() {
+        assert!(size_of::<TelemetryConverted>()      <= TELEMETRY_BLOCK_SIZE);
+        assert!(size_of::<TelemetryIntermediaries>() <= TELEMETRY_BLOCK_SIZE);
+        assert!(size_of::<TelemetryFault>()          <= TELEMETRY_BLOCK_SIZE);
+        assert!(size_of::<TelemetryRaw>()            <= TELEMETRY_BLOCK_SIZE);
+    }
+}

--- a/firmware/lib/core/src/regmap.rs
+++ b/firmware/lib/core/src/regmap.rs
@@ -1,0 +1,373 @@
+//! Regmap — byte-addressed access to the control table.
+//!
+//! Translates host (addr, len) byte ranges into reads/writes against the
+//! in-RAM control-table mirror. Each region declares a `&[BlockDesc]`
+//! table mapping protocol-address block slots to (struct offset, active
+//! size, access). The walker traverses the table once per request:
+//!
+//! * Bytes outside any region → `OutOfRange`.
+//! * Bytes inside a region but in a reserved slot, or in the unused tail
+//!   of an active block → `AccessError`.
+//! * Writes covering any RO byte → `AccessError`. Writes are validated
+//!   before any byte is committed, so a failed write leaves the table
+//!   untouched.
+//!
+//! Requests must lie entirely within one region. Cross-region spans
+//! return `OutOfRange`.
+//!
+//! Reads use raw pointer copies and never form `&RegionT`. Writes form
+//! a transient `&mut`-equivalent via `SyncUnsafeCell::get()`; callers
+//! must hold the appropriate single-writer guarantee for the region
+//! (CONFIG/CONTROL/CALIB written only from `services`, TELEMETRY written
+//! only from `kernel`).
+//!
+//! The same descriptor tables drive flash save/load, so the protocol
+//! layout, the SRAM mirror, and the on-flash page format stay consistent
+//! through one source of truth.
+
+use crate::ControlTable;
+use crate::regions::calib::CALIB_BLOCKS;
+use crate::regions::config::CONFIG_BLOCKS;
+use crate::regions::control::CONTROL_BLOCKS;
+use crate::regions::telemetry::TELEMETRY_BLOCKS;
+use crate::regions::{
+    CALIB_BASE_ADDR, CALIB_REGION_SIZE, CONFIG_BASE_ADDR, CONFIG_REGION_SIZE, CONTROL_BASE_ADDR,
+    CONTROL_REGION_SIZE, TELEMETRY_BASE_ADDR, TELEMETRY_REGION_SIZE,
+};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RegmapError {
+    /// Range is empty, wraps, or falls outside every region.
+    OutOfRange,
+    /// Range hits a reserved slot, the unused tail of a block, or a RO
+    /// byte on a write.
+    AccessError,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Access {
+    Ro,
+    Rw,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct BlockDesc {
+    /// Byte offset in the region's protocol address space.
+    pub addr_offset: u16,
+    /// Active byte length. Bytes from `addr_offset+size` up to the next
+    /// block slot are reserved.
+    pub size: u16,
+    /// Byte offset in the region struct (memcpy target/source).
+    pub struct_offset: u16,
+    pub access: Access,
+}
+
+impl ControlTable {
+    /// Copy `dst.len()` bytes starting at `addr` into `dst`.
+    pub fn read_bytes(&self, addr: u16, dst: &mut [u8]) -> Result<(), RegmapError> {
+        if dst.is_empty() {
+            return Ok(());
+        }
+        let end = (addr as usize)
+            .checked_add(dst.len())
+            .ok_or(RegmapError::OutOfRange)?;
+
+        if range_in(addr, end, CONFIG_BASE_ADDR, CONFIG_REGION_SIZE) {
+            let base = self.config.get() as *const u8;
+            // SAFETY: SyncUnsafeCell::get() is non-null; descriptor sizes
+            // are verified in `region_structs_fit_regions`.
+            unsafe { walk_read(base, addr - CONFIG_BASE_ADDR, dst, CONFIG_BLOCKS) }
+        } else if range_in(addr, end, TELEMETRY_BASE_ADDR, TELEMETRY_REGION_SIZE) {
+            let base = self.telemetry.get() as *const u8;
+            unsafe { walk_read(base, addr - TELEMETRY_BASE_ADDR, dst, TELEMETRY_BLOCKS) }
+        } else if range_in(addr, end, CONTROL_BASE_ADDR, CONTROL_REGION_SIZE) {
+            let base = self.control.get() as *const u8;
+            unsafe { walk_read(base, addr - CONTROL_BASE_ADDR, dst, CONTROL_BLOCKS) }
+        } else if range_in(addr, end, CALIB_BASE_ADDR, CALIB_REGION_SIZE) {
+            let base = self.calib.get() as *const u8;
+            unsafe { walk_read(base, addr - CALIB_BASE_ADDR, dst, CALIB_BLOCKS) }
+        } else {
+            Err(RegmapError::OutOfRange)
+        }
+    }
+
+    /// Write `src` to `[addr, addr+src.len())`. Validates the full span
+    /// against descriptors before any byte is committed; an AccessError
+    /// leaves the table untouched.
+    ///
+    /// Caller must be the region's sole writer for the duration of the
+    /// call (services for CONFIG/CONTROL/CALIB, kernel for TELEMETRY).
+    pub fn write_bytes(&self, addr: u16, src: &[u8]) -> Result<(), RegmapError> {
+        if src.is_empty() {
+            return Ok(());
+        }
+        let end = (addr as usize)
+            .checked_add(src.len())
+            .ok_or(RegmapError::OutOfRange)?;
+
+        if range_in(addr, end, CONFIG_BASE_ADDR, CONFIG_REGION_SIZE) {
+            let base = self.config.get() as *mut u8;
+            unsafe { walk_write(base, addr - CONFIG_BASE_ADDR, src, CONFIG_BLOCKS) }
+        } else if range_in(addr, end, TELEMETRY_BASE_ADDR, TELEMETRY_REGION_SIZE) {
+            let base = self.telemetry.get() as *mut u8;
+            unsafe { walk_write(base, addr - TELEMETRY_BASE_ADDR, src, TELEMETRY_BLOCKS) }
+        } else if range_in(addr, end, CONTROL_BASE_ADDR, CONTROL_REGION_SIZE) {
+            let base = self.control.get() as *mut u8;
+            unsafe { walk_write(base, addr - CONTROL_BASE_ADDR, src, CONTROL_BLOCKS) }
+        } else if range_in(addr, end, CALIB_BASE_ADDR, CALIB_REGION_SIZE) {
+            let base = self.calib.get() as *mut u8;
+            unsafe { walk_write(base, addr - CALIB_BASE_ADDR, src, CALIB_BLOCKS) }
+        } else {
+            Err(RegmapError::OutOfRange)
+        }
+    }
+}
+
+fn range_in(addr: u16, end: usize, base: u16, size: usize) -> bool {
+    let base = base as usize;
+    (addr as usize) >= base && end <= base + size
+}
+
+/// Copy `dst.len()` bytes starting at `offset_in_region` into `dst`.
+/// Descriptors must be sorted by `addr_offset` and non-overlapping.
+unsafe fn walk_read(
+    region_base: *const u8,
+    offset_in_region: u16,
+    dst: &mut [u8],
+    blocks: &[BlockDesc],
+) -> Result<(), RegmapError> {
+    let mut req_lo = offset_in_region as usize;
+    let req_hi = req_lo + dst.len();
+    let mut dst_pos = 0usize;
+
+    for desc in blocks {
+        if req_lo >= req_hi {
+            break;
+        }
+        let blk_lo = desc.addr_offset as usize;
+        let blk_hi = blk_lo + desc.size as usize;
+        if blk_hi <= req_lo {
+            continue;
+        }
+        if blk_lo > req_lo {
+            return Err(RegmapError::AccessError);
+        }
+        let chunk_hi = req_hi.min(blk_hi);
+        let chunk_len = chunk_hi - req_lo;
+        let struct_off = desc.struct_offset as usize + (req_lo - blk_lo);
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                region_base.add(struct_off),
+                dst.as_mut_ptr().add(dst_pos),
+                chunk_len,
+            );
+        }
+        dst_pos += chunk_len;
+        req_lo = chunk_hi;
+    }
+
+    if req_lo < req_hi {
+        Err(RegmapError::AccessError)
+    } else {
+        Ok(())
+    }
+}
+
+unsafe fn walk_write(
+    region_base: *mut u8,
+    offset_in_region: u16,
+    src: &[u8],
+    blocks: &[BlockDesc],
+) -> Result<(), RegmapError> {
+    // Validate before mutating: any uncovered byte or RO byte aborts the
+    // whole write.
+    let req_lo0 = offset_in_region as usize;
+    let req_hi = req_lo0 + src.len();
+    let mut req_lo = req_lo0;
+    for desc in blocks {
+        if req_lo >= req_hi {
+            break;
+        }
+        let blk_lo = desc.addr_offset as usize;
+        let blk_hi = blk_lo + desc.size as usize;
+        if blk_hi <= req_lo {
+            continue;
+        }
+        if blk_lo > req_lo || desc.access != Access::Rw {
+            return Err(RegmapError::AccessError);
+        }
+        req_lo = req_hi.min(blk_hi);
+    }
+    if req_lo < req_hi {
+        return Err(RegmapError::AccessError);
+    }
+
+    let mut req_lo = req_lo0;
+    let mut src_pos = 0usize;
+    for desc in blocks {
+        if req_lo >= req_hi {
+            break;
+        }
+        let blk_lo = desc.addr_offset as usize;
+        let blk_hi = blk_lo + desc.size as usize;
+        if blk_hi <= req_lo {
+            continue;
+        }
+        let chunk_hi = req_hi.min(blk_hi);
+        let chunk_len = chunk_hi - req_lo;
+        let struct_off = desc.struct_offset as usize + (req_lo - blk_lo);
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                src.as_ptr().add(src_pos),
+                region_base.add(struct_off),
+                chunk_len,
+            );
+        }
+        src_pos += chunk_len;
+        req_lo = chunk_hi;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ControlTable;
+    use crate::regions::{CALIB_BASE_ADDR, CONFIG_BASE_ADDR, CONTROL_BASE_ADDR, TELEMETRY_BASE_ADDR};
+
+    fn fresh() -> ControlTable {
+        ControlTable::const_new()
+    }
+
+    #[test]
+    fn read_identity_initially_zero() {
+        let t = fresh();
+        let mut buf = [0xAAu8; 12];
+        t.read_bytes(CONFIG_BASE_ADDR, &mut buf).unwrap();
+        assert_eq!(buf, [0u8; 12]);
+    }
+
+    #[test]
+    fn write_then_read_comms() {
+        let t = fresh();
+        // CONFIG block 1 = comms, 4 bytes.
+        let comms_addr = CONFIG_BASE_ADDR + 32;
+        let payload = [0x07u8, 0x03, 0x96, 0x00];
+        t.write_bytes(comms_addr, &payload).unwrap();
+        let mut buf = [0u8; 4];
+        t.read_bytes(comms_addr, &mut buf).unwrap();
+        assert_eq!(buf, payload);
+        let comms = unsafe { &*t.config.get() }.comms;
+        assert_eq!(comms.id, 0x07);
+        assert_eq!(comms.baud_rate_idx, 0x03);
+        assert_eq!(comms.return_delay_us, 0x0096);
+    }
+
+    #[test]
+    fn write_to_ro_identity_fails_and_does_not_mutate() {
+        let t = fresh();
+        let payload = [0xFFu8; 4];
+        let err = t.write_bytes(CONFIG_BASE_ADDR, &payload).unwrap_err();
+        assert_eq!(err, RegmapError::AccessError);
+        let identity = unsafe { &*t.config.get() }.identity;
+        assert_eq!(identity.model_number, 0);
+    }
+
+    #[test]
+    fn read_into_reserved_tail_fails() {
+        // identity is 12 bytes; bytes 12..32 within block 0 are reserved.
+        let t = fresh();
+        let mut buf = [0u8; 1];
+        let err = t.read_bytes(CONFIG_BASE_ADDR + 12, &mut buf).unwrap_err();
+        assert_eq!(err, RegmapError::AccessError);
+    }
+
+    #[test]
+    fn read_spanning_into_reserved_block_fails() {
+        // CONFIG block 6 (offset 0xC0) is reserved.
+        let t = fresh();
+        let mut buf = [0u8; 8];
+        // Start in block 5 (control/position, last 4 bytes), spill into reserved.
+        let addr = CONFIG_BASE_ADDR + (5 * 32) + 20;
+        let err = t.read_bytes(addr, &mut buf).unwrap_err();
+        assert_eq!(err, RegmapError::AccessError);
+    }
+
+    #[test]
+    fn cross_region_read_fails() {
+        let t = fresh();
+        let mut buf = [0u8; 8];
+        // Start near end of CONFIG, spill into TELEMETRY.
+        let err = t.read_bytes(0x01FE, &mut buf).unwrap_err();
+        assert_eq!(err, RegmapError::OutOfRange);
+    }
+
+    #[test]
+    fn unknown_address_fails() {
+        let t = fresh();
+        let mut buf = [0u8; 1];
+        let err = t.read_bytes(0xFFFF, &mut buf).unwrap_err();
+        assert_eq!(err, RegmapError::OutOfRange);
+    }
+
+    #[test]
+    fn write_control_lifecycle_full_block() {
+        let t = fresh();
+        // ControlLifecycle = 16 B.
+        let payload: [u8; 16] = [
+            1, 3, 0, 0, // torque_enable, mode, padding
+            0x10, 0x27, 0, 0, // goal_position = 10000
+            0xD0, 0x07, 0, 0, // goal_velocity = 2000
+            0x40, 0x01, // goal_effort = 320
+            0, 0,
+        ];
+        t.write_bytes(CONTROL_BASE_ADDR, &payload).unwrap();
+        let lc = unsafe { &*t.control.get() }.lifecycle;
+        assert_eq!(lc.torque_enable, 1);
+        assert_eq!(lc.mode, 3);
+        assert_eq!(lc.goal_position, 10000);
+        assert_eq!(lc.goal_velocity, 2000);
+        assert_eq!(lc.goal_effort, 320);
+    }
+
+    #[test]
+    fn telemetry_writes_fail() {
+        let t = fresh();
+        let payload = [0u8; 4];
+        let err = t.write_bytes(TELEMETRY_BASE_ADDR, &payload).unwrap_err();
+        assert_eq!(err, RegmapError::AccessError);
+    }
+
+    #[test]
+    fn telemetry_reads_succeed_for_active_blocks() {
+        let t = fresh();
+        let mut buf = [0xAAu8; 16];
+        t.read_bytes(TELEMETRY_BASE_ADDR, &mut buf).unwrap();
+        assert_eq!(buf, [0u8; 16]);
+    }
+
+    #[test]
+    fn calib_block_round_trip() {
+        let t = fresh();
+        // CALIB block 1 = bemf, 40 B.
+        let bemf_addr = CALIB_BASE_ADDR + 256;
+        let mut payload = [0u8; 8];
+        payload[0..2].copy_from_slice(&1234u16.to_le_bytes());
+        payload[2..4].copy_from_slice(&500u16.to_le_bytes());
+        payload[4..6].copy_from_slice(&12000u16.to_le_bytes());
+        payload[6..8].copy_from_slice(&100u16.to_le_bytes());
+        t.write_bytes(bemf_addr, &payload).unwrap();
+        let mut readback = [0u8; 8];
+        t.read_bytes(bemf_addr, &mut readback).unwrap();
+        assert_eq!(readback, payload);
+    }
+
+    #[test]
+    fn calib_reserved_block_fails() {
+        let t = fresh();
+        // CALIB block 2 (offset 512) is reserved.
+        let mut buf = [0u8; 1];
+        let err = t.read_bytes(CALIB_BASE_ADDR + 512, &mut buf).unwrap_err();
+        assert_eq!(err, RegmapError::AccessError);
+    }
+}

--- a/firmware/lib/core/src/sample_frame.rs
+++ b/firmware/lib/core/src/sample_frame.rs
@@ -1,0 +1,24 @@
+use osc_units::{CentiCelsius, Microrads, Milliamps, Millivolts};
+
+#[derive(Copy, Clone, Debug)]
+pub struct SampleFrame {
+    pub tick: u32,
+    pub pos: Microrads,
+    pub current: Milliamps,
+    pub temp: CentiCelsius,
+    pub vbus: Millivolts,
+    /// |V_A − V_B| during the ON window of the PWM period.
+    pub vmotor: Millivolts,
+    pub raw: RawSamples,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct RawSamples {
+    pub pos: u16,
+    /// Averaged shunt count.
+    pub current: u16,
+    pub temp: u16,
+    pub vbus: u16,
+    pub vmotor_a: u16,
+    pub vmotor_b: u16,
+}

--- a/firmware/lib/core/src/services.rs
+++ b/firmware/lib/core/src/services.rs
@@ -1,0 +1,17 @@
+use crate::Shared;
+
+/// Cooperative background services. Runs on the main thread; non-real-time
+/// work like DXL parsing, flash commits, status indicators.
+pub struct Services;
+
+impl Services {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    pub fn run(&mut self, _shared: &Shared) -> ! {
+        loop {
+            core::hint::spin_loop();
+        }
+    }
+}

--- a/firmware/lib/core/src/shared.rs
+++ b/firmware/lib/core/src/shared.rs
@@ -1,0 +1,18 @@
+//! Singleton state shared between kernel (ISR) and services (main loop).
+
+use crate::{ControlTable, StreamCoord};
+
+#[repr(C)]
+pub struct Shared {
+    pub table: ControlTable,
+    pub stream: StreamCoord,
+}
+
+impl Shared {
+    pub const fn const_new() -> Self {
+        Self {
+            table: ControlTable::const_new(),
+            stream: StreamCoord::const_new(),
+        }
+    }
+}

--- a/firmware/lib/core/src/stream_coord.rs
+++ b/firmware/lib/core/src/stream_coord.rs
@@ -1,0 +1,23 @@
+//! Cross-domain RMW counters used by the kernel ↔ services handoff. Not part
+//! of the control table; lives as a separate field on `Shared`.
+
+use portable_atomic::{AtomicU16, AtomicU32};
+
+pub struct StreamCoord {
+    /// ISR `fetch_add`s on each decimated tick; main reads + clears.
+    pub pending: AtomicU32,
+    /// Main writes after draining; ISR reads (diag only).
+    pub consumed: AtomicU32,
+    /// USART1 IDLE handler stores the DMA write index.
+    pub dxl_rx_write_pos: AtomicU16,
+}
+
+impl StreamCoord {
+    pub const fn const_new() -> Self {
+        Self {
+            pending: AtomicU32::new(0),
+            consumed: AtomicU32::new(0),
+            dxl_rx_write_pos: AtomicU16::new(0),
+        }
+    }
+}

--- a/firmware/lib/dxl-protocol/Cargo.toml
+++ b/firmware/lib/dxl-protocol/Cargo.toml
@@ -3,3 +3,7 @@ name    = "dxl-protocol"
 version = "0.0.0"
 edition.workspace = true
 license.workspace = true
+
+[dependencies]
+heapless.workspace = true
+crc.workspace      = true

--- a/firmware/lib/dxl-protocol/src/bytes.rs
+++ b/firmware/lib/dxl-protocol/src/bytes.rs
@@ -1,0 +1,110 @@
+/// Byte payload borrowed from a parsed frame (`Stuffed`, may contain
+/// inserted `0xFD` bytes) or supplied by the caller (`Raw`).
+///
+/// `Stuffed::prefix` carries the three logical bytes preceding `slice` so
+/// that an iterator handed a tail-slice can detect a trigger that spanned
+/// the cut. Top-level params from `parse_one` use `[0; 3]` because no valid
+/// Protocol 2.0 prefix byte completes a trigger (instruction `0xFD` is
+/// undefined).
+#[derive(Copy, Clone, Debug)]
+pub enum Bytes<'a> {
+    Stuffed { slice: &'a [u8], prefix: [u8; 3] },
+    Raw(&'a [u8]),
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Overflow;
+
+impl<'a> Bytes<'a> {
+    pub const fn stuffed(slice: &'a [u8]) -> Self {
+        Bytes::Stuffed {
+            slice,
+            prefix: [0; 3],
+        }
+    }
+
+    pub fn iter(&self) -> ByteIter<'a> {
+        match *self {
+            Bytes::Stuffed { slice, prefix } => ByteIter::with_prefix(slice, prefix),
+            Bytes::Raw(s) => ByteIter::raw(s),
+        }
+    }
+
+    pub fn unstuffed_len(&self) -> usize {
+        match *self {
+            Bytes::Raw(s) => s.len(),
+            Bytes::Stuffed { .. } => self.iter().count(),
+        }
+    }
+
+    pub fn copy_into(&self, dst: &mut [u8]) -> Result<usize, Overflow> {
+        let mut n = 0;
+        for b in self.iter() {
+            if n >= dst.len() {
+                return Err(Overflow);
+            }
+            dst[n] = b;
+            n += 1;
+        }
+        Ok(n)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct ByteIter<'a> {
+    src: &'a [u8],
+    i: usize,
+    last3: [u8; 3],
+    stuffed: bool,
+}
+
+impl<'a> ByteIter<'a> {
+    pub(crate) fn raw(src: &'a [u8]) -> Self {
+        Self {
+            src,
+            i: 0,
+            last3: [0; 3],
+            stuffed: false,
+        }
+    }
+
+    pub(crate) fn stuffed(src: &'a [u8]) -> Self {
+        Self::with_prefix(src, [0; 3])
+    }
+
+    pub(crate) fn with_prefix(src: &'a [u8], prefix: [u8; 3]) -> Self {
+        Self {
+            src,
+            i: 0,
+            last3: prefix,
+            stuffed: true,
+        }
+    }
+
+    pub(crate) fn rest_bytes(&self) -> Bytes<'a> {
+        Bytes::Stuffed {
+            slice: &self.src[self.i..],
+            prefix: self.last3,
+        }
+    }
+}
+
+impl<'a> Iterator for ByteIter<'a> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<u8> {
+        if self.i >= self.src.len() {
+            return None;
+        }
+        let b = self.src[self.i];
+        self.i += 1;
+        if self.stuffed && b == 0xFD && self.last3 == [0xFF, 0xFF, 0xFD] {
+            // Advance past the trigger window so a logical FD immediately
+            // following does not get re-suppressed.
+            self.last3 = [self.last3[1], self.last3[2], 0xFD];
+            return self.next();
+        }
+        self.last3 = [self.last3[1], self.last3[2], b];
+        Some(b)
+    }
+}

--- a/firmware/lib/dxl-protocol/src/crc.rs
+++ b/firmware/lib/dxl-protocol/src/crc.rs
@@ -1,0 +1,18 @@
+use crc::{Algorithm, Crc};
+
+const DXL_CRC: Algorithm<u16> = Algorithm {
+    width: 16,
+    poly: 0x8005,
+    init: 0x0000,
+    refin: false,
+    refout: false,
+    xorout: 0x0000,
+    check: 0xFEE8,
+    residue: 0x0000,
+};
+
+const DXL: Crc<u16> = Crc::<u16>::new(&DXL_CRC);
+
+pub fn crc16(bytes: &[u8]) -> u16 {
+    DXL.checksum(bytes)
+}

--- a/firmware/lib/dxl-protocol/src/instruction.rs
+++ b/firmware/lib/dxl-protocol/src/instruction.rs
@@ -1,0 +1,48 @@
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Instruction {
+    Ping = 0x01,
+    Read = 0x02,
+    Write = 0x03,
+    RegWrite = 0x04,
+    Action = 0x05,
+    FactoryReset = 0x06,
+    Reboot = 0x08,
+    Clear = 0x10,
+    ControlTableBackup = 0x20,
+    Status = 0x55,
+    SyncRead = 0x82,
+    SyncWrite = 0x83,
+    FastSyncRead = 0x8A,
+    BulkRead = 0x92,
+    BulkWrite = 0x93,
+    FastBulkRead = 0x9A,
+}
+
+impl Instruction {
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn from_u8(b: u8) -> Option<Self> {
+        Some(match b {
+            0x01 => Self::Ping,
+            0x02 => Self::Read,
+            0x03 => Self::Write,
+            0x04 => Self::RegWrite,
+            0x05 => Self::Action,
+            0x06 => Self::FactoryReset,
+            0x08 => Self::Reboot,
+            0x10 => Self::Clear,
+            0x20 => Self::ControlTableBackup,
+            0x55 => Self::Status,
+            0x82 => Self::SyncRead,
+            0x83 => Self::SyncWrite,
+            0x8A => Self::FastSyncRead,
+            0x92 => Self::BulkRead,
+            0x93 => Self::BulkWrite,
+            0x9A => Self::FastBulkRead,
+            _ => return None,
+        })
+    }
+}

--- a/firmware/lib/dxl-protocol/src/lib.rs
+++ b/firmware/lib/dxl-protocol/src/lib.rs
@@ -1,1 +1,13 @@
 #![no_std]
+
+mod bytes;
+mod crc;
+mod instruction;
+mod parser;
+mod writer;
+
+pub use bytes::{ByteIter, Bytes, Overflow};
+pub use crc::crc16;
+pub use instruction::Instruction;
+pub use parser::{parse_one, Packet, ParseError, BROADCAST_ID, HEADER, MAX_LENGTH};
+pub use writer::{write, WriteError};

--- a/firmware/lib/dxl-protocol/src/parser.rs
+++ b/firmware/lib/dxl-protocol/src/parser.rs
@@ -1,0 +1,301 @@
+use crate::bytes::{ByteIter, Bytes};
+use crate::crc::crc16;
+use crate::Instruction;
+
+pub const HEADER: [u8; 4] = [0xFF, 0xFF, 0xFD, 0x00];
+pub const BROADCAST_ID: u8 = 0xFE;
+
+/// Cap on the wire `Length` field. The field is u16 (up to 65535) but real
+/// DXL frames stay well under this. The cap bounds how long the parser will
+/// wait on a phantom header in random byte traffic.
+pub const MAX_LENGTH: usize = 1024;
+
+#[derive(Copy, Clone, Debug)]
+pub enum Packet<'a> {
+    Ping {
+        id: u8,
+    },
+    Read {
+        id: u8,
+        address: u16,
+        length: u16,
+    },
+    Write {
+        id: u8,
+        address: u16,
+        data: Bytes<'a>,
+    },
+    RegWrite {
+        id: u8,
+        address: u16,
+        data: Bytes<'a>,
+    },
+    Action {
+        id: u8,
+    },
+    FactoryReset {
+        id: u8,
+        mode: u8,
+    },
+    Reboot {
+        id: u8,
+    },
+    Clear {
+        id: u8,
+        body: Bytes<'a>,
+    },
+    ControlTableBackup {
+        id: u8,
+        body: Bytes<'a>,
+    },
+    Status {
+        id: u8,
+        error: u8,
+        params: Bytes<'a>,
+    },
+    SyncRead {
+        address: u16,
+        length: u16,
+        ids: Bytes<'a>,
+    },
+    SyncWrite {
+        address: u16,
+        length: u16,
+        body: Bytes<'a>,
+    },
+    BulkRead {
+        body: Bytes<'a>,
+    },
+    BulkWrite {
+        body: Bytes<'a>,
+    },
+    FastSyncRead {
+        address: u16,
+        length: u16,
+        ids: Bytes<'a>,
+    },
+    FastBulkRead {
+        body: Bytes<'a>,
+    },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ParseError {
+    Incomplete,
+    Resync { skip: usize },
+    BadCrc { skip: usize },
+    BadInstruction { skip: usize },
+    BadLength { skip: usize },
+}
+
+/// Parse a single Protocol 2.0 frame from `input`.
+///
+/// On success returns the decoded `Packet` and the number of input bytes
+/// consumed. On error variants other than `Incomplete`, `skip` is the
+/// number of bytes the caller should drop before retrying.
+pub fn parse_one(input: &[u8]) -> Result<(Packet<'_>, usize), ParseError> {
+    let header_off = match find_header(input) {
+        Some(0) => 0,
+        Some(n) => return Err(ParseError::Resync { skip: n }),
+        None => {
+            // Keep only the longest suffix of `input` that is a proper
+            // prefix of HEADER — those are the only bytes that could yet
+            // form the start of a valid frame. HEADER has no internal
+            // repetition, so the candidate prefixes are 3, 2, 1, 0 bytes.
+            let keep = if input.ends_with(&HEADER[..3]) {
+                3
+            } else if input.ends_with(&HEADER[..2]) {
+                2
+            } else if input.ends_with(&HEADER[..1]) {
+                1
+            } else {
+                0
+            };
+            let skip = input.len() - keep;
+            if skip == 0 {
+                return Err(ParseError::Incomplete);
+            }
+            return Err(ParseError::Resync { skip });
+        }
+    };
+
+    let frame = &input[header_off..];
+
+    if frame.len() < 7 {
+        return Err(ParseError::Incomplete);
+    }
+
+    let id = frame[4];
+    let length = u16::from_le_bytes([frame[5], frame[6]]) as usize;
+
+    // A bad length means we don't trust this header — step past it (4 bytes)
+    // rather than honoring its claimed frame size, so a spurious header in
+    // random traffic can't mask a real frame that follows.
+    if !(3..=MAX_LENGTH).contains(&length) {
+        return Err(ParseError::BadLength { skip: HEADER.len() });
+    }
+
+    let frame_len = 7 + length;
+    if frame.len() < frame_len {
+        return Err(ParseError::Incomplete);
+    }
+
+    let crc_pos = frame_len - 2;
+    let computed = crc16(&frame[..crc_pos]);
+    let received = u16::from_le_bytes([frame[crc_pos], frame[crc_pos + 1]]);
+    if computed != received {
+        // Same reasoning: CRC failure could mean a corrupted real frame *or*
+        // a phantom header — drop just past the header and let the resync
+        // path find the next one.
+        return Err(ParseError::BadCrc { skip: HEADER.len() });
+    }
+
+    let instruction = match Instruction::from_u8(frame[7]) {
+        Some(i) => i,
+        None => return Err(ParseError::BadInstruction { skip: frame_len }),
+    };
+    let params_stuffed = &frame[8..crc_pos];
+
+    let packet = decode(instruction, id, params_stuffed)
+        .map_err(|_| ParseError::BadLength { skip: frame_len })?;
+
+    Ok((packet, frame_len))
+}
+
+fn find_header(input: &[u8]) -> Option<usize> {
+    if input.len() < 4 {
+        return None;
+    }
+    let mut i = 0;
+    while i + 4 <= input.len() {
+        if input[i..i + 4] == HEADER {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+#[derive(Copy, Clone, Debug)]
+struct DecodeError;
+
+fn decode<'a>(
+    instruction: Instruction,
+    id: u8,
+    params: &'a [u8],
+) -> Result<Packet<'a>, DecodeError> {
+    use Instruction::*;
+    match instruction {
+        Ping => need_empty(params).map(|_| Packet::Ping { id }),
+        Read => {
+            let mut it = ByteIter::stuffed(params);
+            let address = take_u16_le(&mut it)?;
+            let length = take_u16_le(&mut it)?;
+            if it.next().is_some() {
+                return Err(DecodeError);
+            }
+            Ok(Packet::Read {
+                id,
+                address,
+                length,
+            })
+        }
+        Write => {
+            let mut it = ByteIter::stuffed(params);
+            let address = take_u16_le(&mut it)?;
+            Ok(Packet::Write {
+                id,
+                address,
+                data: it.rest_bytes(),
+            })
+        }
+        RegWrite => {
+            let mut it = ByteIter::stuffed(params);
+            let address = take_u16_le(&mut it)?;
+            Ok(Packet::RegWrite {
+                id,
+                address,
+                data: it.rest_bytes(),
+            })
+        }
+        Action => need_empty(params).map(|_| Packet::Action { id }),
+        FactoryReset => {
+            let mut it = ByteIter::stuffed(params);
+            let mode = it.next().ok_or(DecodeError)?;
+            if it.next().is_some() {
+                return Err(DecodeError);
+            }
+            Ok(Packet::FactoryReset { id, mode })
+        }
+        Reboot => need_empty(params).map(|_| Packet::Reboot { id }),
+        Clear => Ok(Packet::Clear {
+            id,
+            body: Bytes::stuffed(params),
+        }),
+        ControlTableBackup => Ok(Packet::ControlTableBackup {
+            id,
+            body: Bytes::stuffed(params),
+        }),
+        Status => {
+            let mut it = ByteIter::stuffed(params);
+            let error = it.next().ok_or(DecodeError)?;
+            Ok(Packet::Status {
+                id,
+                error,
+                params: it.rest_bytes(),
+            })
+        }
+        SyncRead => {
+            let mut it = ByteIter::stuffed(params);
+            let address = take_u16_le(&mut it)?;
+            let length = take_u16_le(&mut it)?;
+            Ok(Packet::SyncRead {
+                address,
+                length,
+                ids: it.rest_bytes(),
+            })
+        }
+        SyncWrite => {
+            let mut it = ByteIter::stuffed(params);
+            let address = take_u16_le(&mut it)?;
+            let length = take_u16_le(&mut it)?;
+            Ok(Packet::SyncWrite {
+                address,
+                length,
+                body: it.rest_bytes(),
+            })
+        }
+        FastSyncRead => {
+            let mut it = ByteIter::stuffed(params);
+            let address = take_u16_le(&mut it)?;
+            let length = take_u16_le(&mut it)?;
+            Ok(Packet::FastSyncRead {
+                address,
+                length,
+                ids: it.rest_bytes(),
+            })
+        }
+        BulkRead => Ok(Packet::BulkRead {
+            body: Bytes::stuffed(params),
+        }),
+        BulkWrite => Ok(Packet::BulkWrite {
+            body: Bytes::stuffed(params),
+        }),
+        FastBulkRead => Ok(Packet::FastBulkRead {
+            body: Bytes::stuffed(params),
+        }),
+    }
+}
+
+fn need_empty(s: &[u8]) -> Result<(), DecodeError> {
+    if !s.is_empty() {
+        return Err(DecodeError);
+    }
+    Ok(())
+}
+
+fn take_u16_le<I: Iterator<Item = u8>>(it: &mut I) -> Result<u16, DecodeError> {
+    let lo = it.next().ok_or(DecodeError)?;
+    let hi = it.next().ok_or(DecodeError)?;
+    Ok(u16::from_le_bytes([lo, hi]))
+}

--- a/firmware/lib/dxl-protocol/src/writer.rs
+++ b/firmware/lib/dxl-protocol/src/writer.rs
@@ -1,0 +1,242 @@
+use crate::crc::crc16;
+use crate::parser::{Packet, HEADER};
+use crate::Instruction;
+use heapless::Vec;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum WriteError {
+    Overflow,
+    Invalid,
+}
+
+pub fn write<const N: usize>(out: &mut Vec<u8, N>, packet: &Packet<'_>) -> Result<(), WriteError> {
+    match packet {
+        Packet::Ping { id } => write_packet(out, *id, Instruction::Ping, &mut core::iter::empty()),
+        Packet::Read {
+            id,
+            address,
+            length,
+        } => {
+            let mut params = U16Pair::new(*address, *length).into_iter();
+            write_packet(out, *id, Instruction::Read, &mut params)
+        }
+        Packet::Write { id, address, data } => {
+            let mut params = U16One::new(*address).into_iter().chain(data.iter());
+            write_packet(out, *id, Instruction::Write, &mut params)
+        }
+        Packet::RegWrite { id, address, data } => {
+            let mut params = U16One::new(*address).into_iter().chain(data.iter());
+            write_packet(out, *id, Instruction::RegWrite, &mut params)
+        }
+        Packet::Action { id } => {
+            write_packet(out, *id, Instruction::Action, &mut core::iter::empty())
+        }
+        Packet::FactoryReset { id, mode } => write_packet(
+            out,
+            *id,
+            Instruction::FactoryReset,
+            &mut core::iter::once(*mode),
+        ),
+        Packet::Reboot { id } => {
+            write_packet(out, *id, Instruction::Reboot, &mut core::iter::empty())
+        }
+        Packet::Clear { id, body } => write_packet(out, *id, Instruction::Clear, &mut body.iter()),
+        Packet::ControlTableBackup { id, body } => {
+            write_packet(out, *id, Instruction::ControlTableBackup, &mut body.iter())
+        }
+        Packet::Status { id, error, params } => {
+            let mut p = core::iter::once(*error).chain(params.iter());
+            write_packet(out, *id, Instruction::Status, &mut p)
+        }
+        Packet::SyncRead {
+            address,
+            length,
+            ids,
+        } => {
+            let mut p = U16Pair::new(*address, *length)
+                .into_iter()
+                .chain(ids.iter());
+            write_packet(out, BROADCAST, Instruction::SyncRead, &mut p)
+        }
+        Packet::SyncWrite {
+            address,
+            length,
+            body,
+        } => {
+            let mut p = U16Pair::new(*address, *length)
+                .into_iter()
+                .chain(body.iter());
+            write_packet(out, BROADCAST, Instruction::SyncWrite, &mut p)
+        }
+        Packet::FastSyncRead {
+            address,
+            length,
+            ids,
+        } => {
+            let mut p = U16Pair::new(*address, *length)
+                .into_iter()
+                .chain(ids.iter());
+            write_packet(out, BROADCAST, Instruction::FastSyncRead, &mut p)
+        }
+        Packet::BulkRead { body } => {
+            write_packet(out, BROADCAST, Instruction::BulkRead, &mut body.iter())
+        }
+        Packet::BulkWrite { body } => {
+            write_packet(out, BROADCAST, Instruction::BulkWrite, &mut body.iter())
+        }
+        Packet::FastBulkRead { body } => {
+            write_packet(out, BROADCAST, Instruction::FastBulkRead, &mut body.iter())
+        }
+    }
+}
+
+const BROADCAST: u8 = crate::parser::BROADCAST_ID;
+
+/// id != 0xFF and instruction byte != 0xFD are required so the unstuffed
+/// prefix (header..instruction) cannot itself complete a stuffing trigger.
+///
+/// On any failure (including `Overflow` partway through), `out` is truncated
+/// back to its length on entry — callers using `out` as a DMA TX buffer can
+/// assume that a failed write leaves prior frames untouched.
+fn write_packet<const N: usize, I: Iterator<Item = u8>>(
+    out: &mut Vec<u8, N>,
+    id: u8,
+    instruction: Instruction,
+    params: &mut I,
+) -> Result<(), WriteError> {
+    if id == 0xFF {
+        return Err(WriteError::Invalid);
+    }
+    let start = out.len();
+    match write_packet_body(out, start, id, instruction, params) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            out.truncate(start);
+            Err(e)
+        }
+    }
+}
+
+fn write_packet_body<const N: usize, I: Iterator<Item = u8>>(
+    out: &mut Vec<u8, N>,
+    start: usize,
+    id: u8,
+    instruction: Instruction,
+    params: &mut I,
+) -> Result<(), WriteError> {
+    push(out, HEADER[0])?;
+    push(out, HEADER[1])?;
+    push(out, HEADER[2])?;
+    push(out, HEADER[3])?;
+    push(out, id)?;
+    let len_pos = out.len();
+    push(out, 0)?;
+    push(out, 0)?;
+    push(out, instruction.as_u8())?;
+
+    let mut last2: [u8; 2] = [0, instruction.as_u8()];
+    for b in params.by_ref() {
+        push(out, b)?;
+        if last2[0] == 0xFF && last2[1] == 0xFF && b == 0xFD {
+            push(out, 0xFD)?;
+            last2 = [0xFD, 0xFD];
+        } else {
+            last2 = [last2[1], b];
+        }
+    }
+
+    let stuffed_params_len = out.len() - (len_pos + 2 + 1);
+    let length_value = (1 + stuffed_params_len + 2) as u16;
+    let len_bytes = length_value.to_le_bytes();
+    out[len_pos] = len_bytes[0];
+    out[len_pos + 1] = len_bytes[1];
+
+    let crc = crc16(&out[start..]);
+    let crc_bytes = crc.to_le_bytes();
+    push(out, crc_bytes[0])?;
+    push(out, crc_bytes[1])?;
+
+    Ok(())
+}
+
+fn push<const N: usize>(out: &mut Vec<u8, N>, b: u8) -> Result<(), WriteError> {
+    out.push(b).map_err(|_| WriteError::Overflow)
+}
+
+#[derive(Copy, Clone)]
+struct U16One {
+    bytes: [u8; 2],
+    i: u8,
+}
+
+impl U16One {
+    fn new(v: u16) -> Self {
+        Self {
+            bytes: v.to_le_bytes(),
+            i: 0,
+        }
+    }
+}
+
+impl IntoIterator for U16One {
+    type Item = u8;
+    type IntoIter = U16OneIter;
+    fn into_iter(self) -> U16OneIter {
+        U16OneIter(self)
+    }
+}
+
+struct U16OneIter(U16One);
+
+impl Iterator for U16OneIter {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        if self.0.i < 2 {
+            let b = self.0.bytes[self.0.i as usize];
+            self.0.i += 1;
+            Some(b)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct U16Pair {
+    bytes: [u8; 4],
+    i: u8,
+}
+
+impl U16Pair {
+    fn new(a: u16, b: u16) -> Self {
+        let aa = a.to_le_bytes();
+        let bb = b.to_le_bytes();
+        Self {
+            bytes: [aa[0], aa[1], bb[0], bb[1]],
+            i: 0,
+        }
+    }
+}
+
+impl IntoIterator for U16Pair {
+    type Item = u8;
+    type IntoIter = U16PairIter;
+    fn into_iter(self) -> U16PairIter {
+        U16PairIter(self)
+    }
+}
+
+struct U16PairIter(U16Pair);
+
+impl Iterator for U16PairIter {
+    type Item = u8;
+    fn next(&mut self) -> Option<u8> {
+        if self.0.i < 4 {
+            let b = self.0.bytes[self.0.i as usize];
+            self.0.i += 1;
+            Some(b)
+        } else {
+            None
+        }
+    }
+}

--- a/firmware/lib/dxl-protocol/tests/adversarial.rs
+++ b/firmware/lib/dxl-protocol/tests/adversarial.rs
@@ -1,0 +1,579 @@
+//! Stress tests for parser robustness:
+//! - never panics on arbitrary byte streams
+//! - never wedges (always makes forward progress)
+//! - rejects foreign protocols without false-accepting frames
+//! - real frames embedded in noise are recovered
+//!
+//! Tests run with `std` (in `tests/`), but parser/writer are `no_std`.
+
+use dxl_protocol::{parse_one, write, Bytes, Packet, ParseError, HEADER, MAX_LENGTH};
+use heapless::Vec as HVec;
+
+/// Deterministic PRNG (xorshift64*).
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed.max(1))
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+    fn next_byte(&mut self) -> u8 {
+        self.next_u64() as u8
+    }
+    fn fill(&mut self, dst: &mut [u8]) {
+        for b in dst.iter_mut() {
+            *b = self.next_byte();
+        }
+    }
+}
+
+/// Drives `parse_one` over `bytes` in chunks of `chunk_size`. Asserts the
+/// progress invariant (every error variant other than Incomplete must report
+/// `skip >= 1`) and that the loop terminates. Returns the number of accepted
+/// frames.
+fn drain_stream(bytes: &[u8], chunk_size: usize) -> usize {
+    assert!(chunk_size >= 1);
+    let mut buf: Vec<u8> = Vec::new();
+    let mut feed_idx = 0usize;
+    let mut accepts = 0usize;
+    let mut iter = 0usize;
+    let max_iter = (bytes.len() + 64).saturating_mul(8).max(1024);
+
+    loop {
+        iter += 1;
+        assert!(
+            iter <= max_iter,
+            "non-terminating loop after {iter} iterations on {} input bytes",
+            bytes.len()
+        );
+
+        match parse_one(&buf) {
+            Ok((_pkt, n)) => {
+                accepts += 1;
+                assert!(n >= 10, "min DXL frame is 10 bytes, got {n}");
+                assert!(n <= buf.len());
+                buf.drain(..n);
+            }
+            Err(ParseError::Incomplete) => {
+                if feed_idx >= bytes.len() {
+                    break;
+                }
+                let to_pull = (bytes.len() - feed_idx).min(chunk_size);
+                buf.extend_from_slice(&bytes[feed_idx..feed_idx + to_pull]);
+                feed_idx += to_pull;
+            }
+            Err(e) => {
+                let skip = match e {
+                    ParseError::Resync { skip }
+                    | ParseError::BadCrc { skip }
+                    | ParseError::BadLength { skip }
+                    | ParseError::BadInstruction { skip } => skip,
+                    ParseError::Incomplete => unreachable!(),
+                };
+                assert!(skip >= 1, "skip invariant violated: {e:?}");
+                let skip = skip.min(buf.len());
+                buf.drain(..skip);
+            }
+        }
+    }
+    accepts
+}
+
+#[test]
+fn random_byte_stream_does_not_panic_or_wedge() {
+    let mut rng = Rng::new(0xDEADBEEFu64);
+    let mut bytes = vec![0u8; 1_000_000];
+    rng.fill(&mut bytes);
+
+    let accepts = drain_stream(&bytes, 64);
+    // CRC-16 false-accept probability is ~2^-16 conditioned on header+length+
+    // instruction also matching. Across 1MB, expectation is far below 1.
+    // Allow some slack but flag a regression if accepts spike.
+    assert!(
+        accepts < 5,
+        "unexpected false accepts in random data: {accepts}"
+    );
+}
+
+#[test]
+fn random_byte_stream_byte_at_a_time() {
+    let mut rng = Rng::new(7);
+    let mut bytes = vec![0u8; 100_000];
+    rng.fill(&mut bytes);
+    let accepts = drain_stream(&bytes, 1);
+    assert!(accepts < 5, "byte-at-a-time false accepts: {accepts}");
+}
+
+#[test]
+fn all_zero_stream_no_accepts() {
+    let bytes = vec![0u8; 100_000];
+    assert_eq!(drain_stream(&bytes, 64), 0);
+}
+
+#[test]
+fn all_ff_stream_no_accepts() {
+    let bytes = vec![0xFFu8; 100_000];
+    assert_eq!(drain_stream(&bytes, 64), 0);
+}
+
+#[test]
+fn repeated_header_pattern_no_accepts() {
+    let mut bytes: Vec<u8> = Vec::new();
+    for _ in 0..10_000 {
+        bytes.extend_from_slice(&HEADER);
+    }
+    assert_eq!(drain_stream(&bytes, 64), 0);
+}
+
+#[test]
+fn header_then_random_payload_does_not_wedge() {
+    let mut rng = Rng::new(1);
+    let mut stream: Vec<u8> = Vec::new();
+    for _ in 0..1000 {
+        stream.extend_from_slice(&HEADER);
+        for _ in 0..64 {
+            stream.push(rng.next_byte());
+        }
+    }
+    let accepts = drain_stream(&stream, 64);
+    assert!(accepts < 5, "phantom-header accepts: {accepts}");
+}
+
+#[test]
+fn modbus_rtu_like_traffic_no_false_accept() {
+    // Synthetic Modbus-RTU-ish frames: [addr, func, payload..., crc_lo, crc_hi].
+    // Loop a wide range of addresses/functions/payloads — none should ever
+    // contain the DXL header pattern by accident.
+    let mut rng = Rng::new(0xB0BA);
+    let mut stream: Vec<u8> = Vec::new();
+    for addr in 1..=247u8 {
+        for func in [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x10, 0x17] {
+            stream.push(addr);
+            stream.push(func);
+            for _ in 0..rng.next_u64() % 16 + 4 {
+                // Avoid producing the DXL header pattern accidentally —
+                // mask the high bit out so we never emit 0xFF.
+                stream.push(rng.next_byte() & 0x7F);
+            }
+            stream.push(rng.next_byte() & 0x7F);
+            stream.push(rng.next_byte() & 0x7F);
+        }
+    }
+    assert_eq!(drain_stream(&stream, 64), 0);
+}
+
+#[test]
+fn ascii_text_traffic_no_false_accept() {
+    // Pure ASCII can never form the DXL header (0xFF, 0xFD bytes are 8-bit).
+    let chunk = b"GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n";
+    let mut stream: Vec<u8> = Vec::new();
+    for _ in 0..1000 {
+        stream.extend_from_slice(chunk);
+    }
+    assert_eq!(drain_stream(&stream, 64), 0);
+}
+
+#[test]
+fn real_frames_with_random_garbage_between_recover_all() {
+    let mut rng = Rng::new(42);
+    let mut stream: Vec<u8> = Vec::new();
+    let real_count = 200;
+    for i in 0..real_count {
+        let garbage_len = (rng.next_u64() % 96) as usize;
+        for _ in 0..garbage_len {
+            // Mask high bit so we don't accidentally synthesize valid frames
+            // in the "garbage" section.
+            stream.push(rng.next_byte() & 0x7F);
+        }
+        let mut frame: HVec<u8, 32> = HVec::new();
+        write(
+            &mut frame,
+            &Packet::Ping {
+                id: ((i % 253) + 1) as u8,
+            },
+        )
+        .unwrap();
+        stream.extend_from_slice(&frame);
+    }
+    let accepts = drain_stream(&stream, 64);
+    assert_eq!(
+        accepts, real_count,
+        "expected to recover all {real_count} real frames, got {accepts}"
+    );
+}
+
+#[test]
+fn real_frames_byte_at_a_time_recover_all() {
+    let mut rng = Rng::new(0xCAFEBABE);
+    let mut stream: Vec<u8> = Vec::new();
+    let real_count = 50;
+    for i in 0..real_count {
+        let garbage_len = (rng.next_u64() % 32) as usize;
+        for _ in 0..garbage_len {
+            stream.push(rng.next_byte() & 0x7F);
+        }
+        let mut frame: HVec<u8, 32> = HVec::new();
+        write(
+            &mut frame,
+            &Packet::Ping {
+                id: ((i % 253) + 1) as u8,
+            },
+        )
+        .unwrap();
+        stream.extend_from_slice(&frame);
+    }
+    let accepts = drain_stream(&stream, 1);
+    assert_eq!(accepts, real_count);
+}
+
+#[test]
+fn real_frames_with_partial_corrupt_frames_recover_clean_ones() {
+    // Mix valid frames with frames whose CRC has been bit-flipped. The
+    // parser should accept every valid frame and reject every corrupt one.
+    let mut rng = Rng::new(0x12345678);
+    let mut stream: Vec<u8> = Vec::new();
+    let valid = 100;
+    let corrupt = 100;
+
+    for i in 0..valid {
+        let mut frame: HVec<u8, 32> = HVec::new();
+        write(
+            &mut frame,
+            &Packet::Ping {
+                id: ((i % 253) + 1) as u8,
+            },
+        )
+        .unwrap();
+        stream.extend_from_slice(&frame);
+    }
+    for i in 0..corrupt {
+        let mut frame: HVec<u8, 32> = HVec::new();
+        write(
+            &mut frame,
+            &Packet::Ping {
+                id: ((i % 253) + 1) as u8,
+            },
+        )
+        .unwrap();
+        // Corrupt the CRC.
+        let last = frame.len() - 1;
+        frame[last] ^= rng.next_byte() | 1;
+        stream.extend_from_slice(&frame);
+    }
+
+    let accepts = drain_stream(&stream, 64);
+    // Each corrupt frame's body bytes can re-resync to the next real header
+    // (or to themselves), so we may accept slightly more than `valid` if the
+    // body bytes overlap — but for plain PINGs they don't form headers.
+    assert_eq!(accepts, valid);
+}
+
+#[test]
+fn parse_one_progress_invariant_random_short_inputs() {
+    // For ANY input, parse_one either:
+    //  - returns Ok with n >= 10
+    //  - returns Incomplete
+    //  - returns an error with skip >= 1
+    // and never panics.
+    let mut rng = Rng::new(0xC0FFEE);
+    for _ in 0..50_000 {
+        let len = (rng.next_u64() % 64) as usize;
+        let mut buf = vec![0u8; len];
+        rng.fill(&mut buf);
+        match parse_one(&buf) {
+            Ok((_, n)) => assert!(n >= 10),
+            Err(ParseError::Incomplete) => {}
+            Err(ParseError::Resync { skip })
+            | Err(ParseError::BadCrc { skip })
+            | Err(ParseError::BadLength { skip })
+            | Err(ParseError::BadInstruction { skip }) => {
+                assert!(skip >= 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_one_progress_invariant_long_random_inputs() {
+    let mut rng = Rng::new(0xC0FFEE2);
+    for _ in 0..2000 {
+        let len = (rng.next_u64() % (MAX_LENGTH as u64 * 2 + 64)) as usize;
+        let mut buf = vec![0u8; len];
+        rng.fill(&mut buf);
+        match parse_one(&buf) {
+            Ok((_, n)) => assert!(n >= 10 && n <= buf.len()),
+            Err(ParseError::Incomplete) => {}
+            Err(ParseError::Resync { skip })
+            | Err(ParseError::BadCrc { skip })
+            | Err(ParseError::BadLength { skip })
+            | Err(ParseError::BadInstruction { skip }) => {
+                assert!(skip >= 1);
+            }
+        }
+    }
+}
+
+#[test]
+fn truncated_real_frame_returns_incomplete_at_each_step() {
+    const PING: &[u8] = &[
+        0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x03, 0x00, 0x01, 0x19, 0x4E,
+    ];
+    for n in 0..PING.len() {
+        let r = parse_one(&PING[..n]);
+        assert!(
+            matches!(r, Err(ParseError::Incomplete)),
+            "truncation to {n} bytes: got {r:?}"
+        );
+    }
+    let (pkt, n) = parse_one(PING).unwrap();
+    assert_eq!(n, PING.len());
+    assert!(matches!(pkt, Packet::Ping { id: 1 }));
+}
+
+#[test]
+fn random_header_id_length_does_not_lock_parser() {
+    // Construct buffers that look "headerly" but with random id+length, and
+    // verify the parser always returns a definite error or completes within
+    // a bounded number of steps.
+    let mut rng = Rng::new(13);
+    for _ in 0..500 {
+        let len = (rng.next_u64() % 2048) as usize;
+        let mut buf = vec![0u8; 7 + len + 2];
+        rng.fill(&mut buf);
+        buf[0..4].copy_from_slice(&HEADER);
+        // Random id and length field.
+        let _ = drain_stream(&buf, 64);
+    }
+}
+
+#[test]
+fn maxlen_phantom_header_returns_definite_error() {
+    // A buffer of exactly (7 + MAX_LENGTH) bytes with a header at start and
+    // length = MAX_LENGTH should not return Incomplete — it has enough data
+    // to verify CRC and reject.
+    let mut rng = Rng::new(1234);
+    for _ in 0..200 {
+        let mut buf = vec![0u8; 7 + MAX_LENGTH];
+        rng.fill(&mut buf);
+        buf[0..4].copy_from_slice(&HEADER);
+        buf[5] = (MAX_LENGTH & 0xFF) as u8;
+        buf[6] = ((MAX_LENGTH >> 8) & 0xFF) as u8;
+        if let Err(ParseError::Incomplete) = parse_one(&buf) {
+            panic!("should not be Incomplete with full frame");
+        }
+    }
+}
+
+#[test]
+fn over_maxlen_header_short_circuits() {
+    // Length above MAX_LENGTH must trigger BadLength immediately, not wait
+    // for ~64KB of phantom data.
+    let bad = [0xFFu8, 0xFF, 0xFD, 0x00, 0x01, 0xFF, 0xFF, 0x01];
+    match parse_one(&bad) {
+        Err(ParseError::BadLength { skip }) => assert_eq!(skip, 4),
+        other => panic!("expected BadLength, got {other:?}"),
+    }
+}
+
+#[test]
+fn writer_id_0xff_rejected() {
+    let mut out: HVec<u8, 32> = HVec::new();
+    let err = write(&mut out, &Packet::Ping { id: 0xFF }).unwrap_err();
+    assert_eq!(err, dxl_protocol::WriteError::Invalid);
+}
+
+#[test]
+fn writer_overflow_reported_and_rolled_back() {
+    let mut tiny: HVec<u8, 5> = HVec::new();
+    let err = write(&mut tiny, &Packet::Ping { id: 1 }).unwrap_err();
+    assert_eq!(err, dxl_protocol::WriteError::Overflow);
+    assert!(
+        tiny.is_empty(),
+        "buffer should be rolled back on overflow, has {} bytes",
+        tiny.len()
+    );
+}
+
+#[test]
+fn writer_overflow_preserves_prior_frames() {
+    // Simulate a DMA TX buffer holding a complete frame, then a second
+    // write that overflows. The first frame must remain intact.
+    let mut buf: HVec<u8, 16> = HVec::new();
+    write(&mut buf, &Packet::Ping { id: 1 }).unwrap();
+    let snapshot: HVec<u8, 16> = buf.clone();
+    let pre_len = buf.len();
+
+    // Try to write a Status whose body cannot fit in the remaining capacity.
+    let big = [0u8; 32];
+    let err = write(
+        &mut buf,
+        &Packet::Status {
+            id: 1,
+            error: 0,
+            params: Bytes::Raw(&big),
+        },
+    )
+    .unwrap_err();
+    assert_eq!(err, dxl_protocol::WriteError::Overflow);
+    assert_eq!(buf.len(), pre_len, "buffer length changed on overflow");
+    assert_eq!(&buf[..], &snapshot[..], "prior frame corrupted on overflow");
+
+    // The preserved frame still parses.
+    let (pkt, n) = parse_one(&buf).unwrap();
+    assert_eq!(n, buf.len());
+    assert!(matches!(pkt, Packet::Ping { id: 1 }));
+}
+
+#[test]
+fn writer_invalid_id_does_not_touch_buffer() {
+    let mut buf: HVec<u8, 32> = HVec::new();
+    write(&mut buf, &Packet::Ping { id: 1 }).unwrap();
+    let snapshot: HVec<u8, 32> = buf.clone();
+
+    let err = write(&mut buf, &Packet::Ping { id: 0xFF }).unwrap_err();
+    assert_eq!(err, dxl_protocol::WriteError::Invalid);
+    assert_eq!(&buf[..], &snapshot[..]);
+}
+
+#[test]
+fn no_header_skips_all_when_no_partial_prefix() {
+    // No 0xFF anywhere — every byte can be discarded.
+    let buf = [0xAA, 0xBB, 0xCC, 0xDD];
+    match parse_one(&buf) {
+        Err(ParseError::Resync { skip }) => assert_eq!(skip, 4),
+        other => panic!("expected Resync(4), got {other:?}"),
+    }
+}
+
+#[test]
+fn no_header_keeps_trailing_single_ff() {
+    let buf = [0xAA, 0xBB, 0xCC, 0xFF];
+    match parse_one(&buf) {
+        Err(ParseError::Resync { skip }) => assert_eq!(skip, 3),
+        other => panic!("expected Resync(3), got {other:?}"),
+    }
+}
+
+#[test]
+fn no_header_keeps_trailing_ff_ff() {
+    let buf = [0xAA, 0xBB, 0xFF, 0xFF];
+    match parse_one(&buf) {
+        Err(ParseError::Resync { skip }) => assert_eq!(skip, 2),
+        other => panic!("expected Resync(2), got {other:?}"),
+    }
+}
+
+#[test]
+fn no_header_keeps_trailing_ff_ff_fd() {
+    let buf = [0xAA, 0xFF, 0xFF, 0xFD];
+    match parse_one(&buf) {
+        Err(ParseError::Resync { skip }) => assert_eq!(skip, 1),
+        other => panic!("expected Resync(1), got {other:?}"),
+    }
+}
+
+#[test]
+fn short_input_with_no_partial_prefix_skips_immediately() {
+    // Length-3 input that can't possibly start a header → Resync(3),
+    // not Incomplete (which would force the caller to wait for bytes that
+    // can never extend these into a valid header).
+    let buf = [0xAA, 0xBB, 0xCC];
+    match parse_one(&buf) {
+        Err(ParseError::Resync { skip }) => assert_eq!(skip, 3),
+        other => panic!("expected Resync(3), got {other:?}"),
+    }
+}
+
+#[test]
+fn short_input_with_partial_prefix_returns_incomplete() {
+    // Trailing prefix of HEADER — must wait for more bytes.
+    for partial in [
+        &[0xFFu8][..],
+        &[0xFF, 0xFF][..],
+        &[0xFF, 0xFF, 0xFD][..],
+    ] {
+        assert!(
+            matches!(parse_one(partial), Err(ParseError::Incomplete)),
+            "partial = {partial:02X?}"
+        );
+    }
+}
+
+#[test]
+fn round_trip_every_instruction() {
+    // Sanity: every Packet variant survives write -> parse -> write.
+    let cases: &[Packet<'static>] = &[
+        Packet::Ping { id: 1 },
+        Packet::Read {
+            id: 1,
+            address: 132,
+            length: 4,
+        },
+        Packet::Write {
+            id: 1,
+            address: 116,
+            data: Bytes::Raw(&[0, 2, 0, 0]),
+        },
+        Packet::RegWrite {
+            id: 1,
+            address: 100,
+            data: Bytes::Raw(&[0xAA]),
+        },
+        Packet::Action { id: 1 },
+        Packet::FactoryReset { id: 1, mode: 0xFF },
+        Packet::Reboot { id: 1 },
+        Packet::Clear {
+            id: 1,
+            body: Bytes::Raw(&[0x01, 0x02, 0x03]),
+        },
+        Packet::ControlTableBackup {
+            id: 1,
+            body: Bytes::Raw(&[0xAA, 0xBB]),
+        },
+        Packet::Status {
+            id: 1,
+            error: 0,
+            params: Bytes::Raw(&[0xDE, 0xAD]),
+        },
+        Packet::SyncRead {
+            address: 132,
+            length: 4,
+            ids: Bytes::Raw(&[1, 2, 3]),
+        },
+        Packet::SyncWrite {
+            address: 116,
+            length: 4,
+            body: Bytes::Raw(&[1, 0, 1, 0, 0]),
+        },
+        Packet::FastSyncRead {
+            address: 132,
+            length: 4,
+            ids: Bytes::Raw(&[1, 2]),
+        },
+        Packet::BulkRead {
+            body: Bytes::Raw(&[1, 2]),
+        },
+        Packet::BulkWrite {
+            body: Bytes::Raw(&[1, 2, 3]),
+        },
+        Packet::FastBulkRead {
+            body: Bytes::Raw(&[1, 2]),
+        },
+    ];
+
+    for case in cases {
+        let mut wire1: HVec<u8, 128> = HVec::new();
+        write(&mut wire1, case).unwrap();
+        let (pkt, n) = parse_one(&wire1).expect("parse failed");
+        assert_eq!(n, wire1.len());
+        let mut wire2: HVec<u8, 128> = HVec::new();
+        write(&mut wire2, &pkt).unwrap();
+        assert_eq!(&wire1[..], &wire2[..], "wire mismatch on {case:?}");
+    }
+}

--- a/firmware/lib/dxl-protocol/tests/vectors.rs
+++ b/firmware/lib/dxl-protocol/tests/vectors.rs
@@ -1,0 +1,589 @@
+use dxl_protocol::{crc16, parse_one, write, Bytes, Instruction, Packet, ParseError, MAX_LENGTH};
+use heapless::Vec;
+
+const PING_ID1: &[u8] = &[0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x03, 0x00, 0x01, 0x19, 0x4E];
+
+const READ_ID1_ADDR132_LEN4: &[u8] = &[
+    0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x07, 0x00, 0x02, 0x84, 0x00, 0x04, 0x00, 0x1D, 0x15,
+];
+
+// Write 512 (0x00000200) to Goal Position (address 116, 4 bytes) on ID 1.
+const WRITE_ID1_GOAL512: &[u8] = &[
+    0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x09, 0x00, 0x03, 0x74, 0x00, 0x00, 0x02, 0x00, 0x00, 0xCA, 0x89,
+];
+
+const REBOOT_ID1: &[u8] = &[0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x03, 0x00, 0x08, 0x2F, 0x4E];
+
+#[test]
+fn crc_matches_known_frames() {
+    for frame in [
+        PING_ID1,
+        READ_ID1_ADDR132_LEN4,
+        WRITE_ID1_GOAL512,
+        REBOOT_ID1,
+    ] {
+        let body = &frame[..frame.len() - 2];
+        let expected = u16::from_le_bytes([frame[frame.len() - 2], frame[frame.len() - 1]]);
+        assert_eq!(
+            crc16(body),
+            expected,
+            "CRC mismatch on frame: {:02X?}",
+            frame
+        );
+    }
+}
+
+#[test]
+fn parse_ping() {
+    let (pkt, n) = parse_one(PING_ID1).unwrap();
+    assert_eq!(n, PING_ID1.len());
+    match pkt {
+        Packet::Ping { id } => assert_eq!(id, 1),
+        other => panic!("not Ping: {:?}", other),
+    }
+}
+
+#[test]
+fn parse_read() {
+    let (pkt, n) = parse_one(READ_ID1_ADDR132_LEN4).unwrap();
+    assert_eq!(n, READ_ID1_ADDR132_LEN4.len());
+    match pkt {
+        Packet::Read {
+            id,
+            address,
+            length,
+        } => {
+            assert_eq!(id, 1);
+            assert_eq!(address, 132);
+            assert_eq!(length, 4);
+        }
+        other => panic!("not Read: {:?}", other),
+    }
+}
+
+#[test]
+fn parse_write() {
+    let (pkt, n) = parse_one(WRITE_ID1_GOAL512).unwrap();
+    assert_eq!(n, WRITE_ID1_GOAL512.len());
+    match pkt {
+        Packet::Write { id, address, data } => {
+            assert_eq!(id, 1);
+            assert_eq!(address, 116);
+            let mut buf = [0u8; 16];
+            let n = data.copy_into(&mut buf).unwrap();
+            assert_eq!(&buf[..n], &[0x00, 0x02, 0x00, 0x00]);
+        }
+        other => panic!("not Write: {:?}", other),
+    }
+}
+
+#[test]
+fn parse_reboot() {
+    let (pkt, _) = parse_one(REBOOT_ID1).unwrap();
+    assert!(matches!(pkt, Packet::Reboot { id: 1 }));
+}
+
+#[test]
+fn write_ping_matches_reference() {
+    let mut out: Vec<u8, 32> = Vec::new();
+    write(&mut out, &Packet::Ping { id: 1 }).unwrap();
+    assert_eq!(&out[..], PING_ID1);
+}
+
+#[test]
+fn write_read_matches_reference() {
+    let mut out: Vec<u8, 32> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Read {
+            id: 1,
+            address: 132,
+            length: 4,
+        },
+    )
+    .unwrap();
+    assert_eq!(&out[..], READ_ID1_ADDR132_LEN4);
+}
+
+#[test]
+fn write_write_matches_reference() {
+    let data = [0x00u8, 0x02, 0x00, 0x00];
+    let mut out: Vec<u8, 32> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 116,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+    assert_eq!(&out[..], WRITE_ID1_GOAL512);
+}
+
+#[test]
+fn write_reboot_matches_reference() {
+    let mut out: Vec<u8, 32> = Vec::new();
+    write(&mut out, &Packet::Reboot { id: 1 }).unwrap();
+    assert_eq!(&out[..], REBOOT_ID1);
+}
+
+#[test]
+fn write_status_round_trip() {
+    let params = [0x06u8, 0x04, 0x26];
+    let mut out: Vec<u8, 64> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Status {
+            id: 1,
+            error: 0,
+            params: Bytes::Raw(&params),
+        },
+    )
+    .unwrap();
+
+    let (pkt, n) = parse_one(&out).unwrap();
+    assert_eq!(n, out.len());
+    match pkt {
+        Packet::Status {
+            id,
+            error,
+            params: p,
+        } => {
+            assert_eq!(id, 1);
+            assert_eq!(error, 0);
+            let mut buf = [0u8; 16];
+            let n = p.copy_into(&mut buf).unwrap();
+            assert_eq!(&buf[..n], &params);
+        }
+        other => panic!("not Status: {:?}", other),
+    }
+}
+
+#[test]
+fn stuffing_round_trip() {
+    let data = [0xFFu8, 0xFF, 0xFD, 0x42, 0xFF, 0xFF, 0xFD, 0xFD, 0x55];
+    let mut out: Vec<u8, 64> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0x0040,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+
+    let raw_count = out.iter().filter(|&&b| b == 0xFD).count();
+    assert!(raw_count >= 4, "expected stuffed bytes: {:02X?}", out);
+
+    let (pkt, n) = parse_one(&out).unwrap();
+    assert_eq!(n, out.len());
+    match pkt {
+        Packet::Write {
+            id,
+            address,
+            data: d,
+        } => {
+            assert_eq!(id, 1);
+            assert_eq!(address, 0x0040);
+            assert_eq!(d.unstuffed_len(), data.len());
+            let mut buf = [0u8; 32];
+            let n = d.copy_into(&mut buf).unwrap();
+            assert_eq!(&buf[..n], &data);
+        }
+        other => panic!("not Write: {:?}", other),
+    }
+}
+
+#[test]
+fn stuffing_at_field_boundary() {
+    let data = [0xFDu8, 0x11, 0x22];
+    let mut out: Vec<u8, 64> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0xFFFF,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+
+    let (pkt, _) = parse_one(&out).unwrap();
+    match pkt {
+        Packet::Write {
+            address, data: d, ..
+        } => {
+            assert_eq!(address, 0xFFFF);
+            let mut buf = [0u8; 16];
+            let n = d.copy_into(&mut buf).unwrap();
+            assert_eq!(&buf[..n], &data);
+        }
+        _ => panic!("not Write"),
+    }
+}
+
+#[test]
+fn resync_skips_leading_garbage() {
+    let mut buf: Vec<u8, 64> = Vec::new();
+    buf.extend_from_slice(&[0x00, 0x11, 0x22]).unwrap();
+    buf.extend_from_slice(PING_ID1).unwrap();
+
+    match parse_one(&buf) {
+        Err(ParseError::Resync { skip: 3 }) => {}
+        other => panic!("expected Resync(3), got {:?}", other),
+    }
+
+    let (pkt, n) = parse_one(&buf[3..]).unwrap();
+    assert_eq!(n, PING_ID1.len());
+    assert!(matches!(pkt, Packet::Ping { id: 1 }));
+}
+
+#[test]
+fn incomplete_returns_err() {
+    let partial = &PING_ID1[..6];
+    assert!(matches!(parse_one(partial), Err(ParseError::Incomplete)));
+    let partial = &PING_ID1[..7];
+    assert!(matches!(parse_one(partial), Err(ParseError::Incomplete)));
+}
+
+#[test]
+fn bad_crc_is_reported() {
+    let mut bad: Vec<u8, 32> = Vec::new();
+    bad.extend_from_slice(PING_ID1).unwrap();
+    let last = bad.len() - 1;
+    bad[last] ^= 0xFF;
+    match parse_one(&bad) {
+        Err(ParseError::BadCrc { skip }) => assert_eq!(skip, 4),
+        other => panic!("expected BadCrc, got {:?}", other),
+    }
+}
+
+#[test]
+fn oversized_length_is_rejected() {
+    // Crafted "header" with length = 0xFFFF, well above MAX_LENGTH.
+    let bad = [0xFFu8, 0xFF, 0xFD, 0x00, 0x01, 0xFF, 0xFF, 0x01];
+    assert!((MAX_LENGTH as u32) < 0xFFFF);
+    match parse_one(&bad) {
+        Err(ParseError::BadLength { skip }) => assert_eq!(skip, 4),
+        other => panic!("expected BadLength, got {:?}", other),
+    }
+}
+
+#[test]
+fn undersized_length_is_rejected() {
+    // length = 2 is below the 3-byte minimum (instruction + crc).
+    let bad = [0xFFu8, 0xFF, 0xFD, 0x00, 0x01, 0x02, 0x00, 0x01];
+    match parse_one(&bad) {
+        Err(ParseError::BadLength { skip }) => assert_eq!(skip, 4),
+        other => panic!("expected BadLength, got {:?}", other),
+    }
+}
+
+#[test]
+fn false_header_with_huge_length_does_not_wedge() {
+    // A spurious header with length = 0xFFFF would, before the cap, cause
+    // the parser to wait on ~64 KB of phantom data. With the cap it returns
+    // BadLength immediately, the caller drops 4 bytes, and the real PING
+    // sitting after the noise is recoverable.
+    let mut buf: Vec<u8, 64> = Vec::new();
+    buf.extend_from_slice(&[0xFF, 0xFF, 0xFD, 0x00, 0x42, 0xFF, 0xFF, 0x99])
+        .unwrap();
+    buf.extend_from_slice(PING_ID1).unwrap();
+
+    let skip = match parse_one(&buf) {
+        Err(ParseError::BadLength { skip }) => skip,
+        other => panic!("expected BadLength, got {:?}", other),
+    };
+    assert_eq!(skip, 4);
+
+    // After dropping the false header, the next call resyncs onto the real
+    // PING frame instead of skipping past it.
+    let rest = &buf[skip..];
+    let resync = match parse_one(rest) {
+        Err(ParseError::Resync { skip }) => skip,
+        other => panic!("expected Resync, got {:?}", other),
+    };
+    let (pkt, n) = parse_one(&rest[resync..]).unwrap();
+    assert_eq!(n, PING_ID1.len());
+    assert!(matches!(pkt, Packet::Ping { id: 1 }));
+}
+
+#[test]
+fn bad_instruction_is_reported() {
+    let mut frame: Vec<u8, 32> = Vec::new();
+    frame
+        .extend_from_slice(&[0xFF, 0xFF, 0xFD, 0x00, 0x01, 0x03, 0x00, 0x77])
+        .unwrap();
+    let crc = crc16(&frame);
+    frame.extend_from_slice(&crc.to_le_bytes()).unwrap();
+    match parse_one(&frame) {
+        Err(ParseError::BadInstruction { skip }) => assert_eq!(skip, frame.len()),
+        other => panic!("expected BadInstruction, got {:?}", other),
+    }
+}
+
+#[test]
+fn instruction_byte_constants() {
+    assert_eq!(Instruction::Ping.as_u8(), 0x01);
+    assert_eq!(Instruction::Status.as_u8(), 0x55);
+    assert_eq!(Instruction::SyncWrite.as_u8(), 0x83);
+    assert_eq!(Instruction::FastBulkRead.as_u8(), 0x9A);
+}
+
+fn round_trip_data(data: &[u8]) -> heapless::Vec<u8, 256> {
+    let mut out: Vec<u8, 256> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0x0010,
+            data: Bytes::Raw(data),
+        },
+    )
+    .unwrap();
+    let (pkt, n) = parse_one(&out).unwrap();
+    assert_eq!(n, out.len());
+    match pkt {
+        Packet::Write {
+            data: d, address, ..
+        } => {
+            assert_eq!(address, 0x0010);
+            let mut buf = [0u8; 256];
+            let n = d.copy_into(&mut buf).unwrap();
+            let mut got: heapless::Vec<u8, 256> = Vec::new();
+            got.extend_from_slice(&buf[..n]).unwrap();
+            assert_eq!(d.unstuffed_len(), data.len());
+            assert_eq!(&got[..], data);
+            out
+        }
+        _ => panic!("not Write"),
+    }
+}
+
+fn fds_in_payload_region(frame: &[u8]) -> usize {
+    let payload = &frame[8..frame.len() - 2];
+    payload.iter().filter(|&&b| b == 0xFD).count()
+}
+
+#[test]
+fn stuff_no_trigger() {
+    let data = [0x01u8, 0x02, 0x03, 0x04];
+    let frame = round_trip_data(&data);
+    assert_eq!(fds_in_payload_region(&frame), 0);
+}
+
+#[test]
+fn stuff_single_trigger_inserts_one_byte() {
+    let data = [0xFFu8, 0xFF, 0xFD, 0x00];
+    let frame = round_trip_data(&data);
+    assert_eq!(fds_in_payload_region(&frame), 2);
+}
+
+#[test]
+fn stuff_multiple_triggers() {
+    let data = [
+        0xFFu8, 0xFF, 0xFD, 0x01, 0x02, 0xFF, 0xFF, 0xFD, 0x03, 0xAA, 0xFF, 0xFF, 0xFD,
+    ];
+    let frame = round_trip_data(&data);
+    let logical_fds = data.iter().filter(|&&b| b == 0xFD).count();
+    assert_eq!(fds_in_payload_region(&frame), logical_fds + 3);
+}
+
+#[test]
+fn stuff_trigger_at_payload_start() {
+    let data = [0xFFu8, 0xFF, 0xFD, 0xAA, 0xBB];
+    let _ = round_trip_data(&data);
+}
+
+#[test]
+fn stuff_trigger_at_payload_end() {
+    let data = [0xAAu8, 0xBB, 0xFF, 0xFF, 0xFD];
+    let frame = round_trip_data(&data);
+    assert_eq!(fds_in_payload_region(&frame), 2);
+}
+
+#[test]
+fn stuff_logical_fd_after_trigger() {
+    let data = [0xFFu8, 0xFF, 0xFD, 0xFD, 0x55];
+    let _ = round_trip_data(&data);
+}
+
+#[test]
+fn stuff_two_adjacent_triggers() {
+    let data = [0xFFu8, 0xFF, 0xFD, 0xFF, 0xFF, 0xFD, 0xAA];
+    let _ = round_trip_data(&data);
+}
+
+#[test]
+fn stuff_trigger_spanning_address_boundary() {
+    let mut out: Vec<u8, 64> = Vec::new();
+    let data = [0xFDu8, 0x11, 0x22];
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0xFFFF,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+    let (pkt, _) = parse_one(&out).unwrap();
+    let Packet::Write {
+        address, data: d, ..
+    } = pkt
+    else {
+        panic!("not Write");
+    };
+    assert_eq!(address, 0xFFFF);
+    assert_eq!(d.unstuffed_len(), data.len());
+    let mut buf = [0u8; 8];
+    let n = d.copy_into(&mut buf).unwrap();
+    assert_eq!(&buf[..n], &data);
+}
+
+#[test]
+fn stuff_trigger_spanning_address_then_more_in_data() {
+    let data = [0xFDu8, 0x42, 0xFF, 0xFF, 0xFD, 0x55, 0x66];
+    let mut out: Vec<u8, 64> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0xFFFF,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+    let (pkt, _) = parse_one(&out).unwrap();
+    let Packet::Write { data: d, .. } = pkt else {
+        panic!();
+    };
+    let mut buf = [0u8; 16];
+    let n = d.copy_into(&mut buf).unwrap();
+    assert_eq!(&buf[..n], &data);
+}
+
+#[test]
+fn stuff_unstuffed_len_matches_iter_count() {
+    let data = [0xFFu8, 0xFF, 0xFD, 0x00, 0xFF, 0xFF, 0xFD, 0xFD];
+    let mut out: Vec<u8, 64> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0x0010,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+    let (pkt, _) = parse_one(&out).unwrap();
+    let Packet::Write { data: d, .. } = pkt else {
+        panic!();
+    };
+    assert_eq!(d.unstuffed_len(), data.len());
+    assert_eq!(d.iter().count(), data.len());
+}
+
+#[test]
+fn stuff_raw_passthrough_does_not_unstuff() {
+    let raw = [0xFFu8, 0xFF, 0xFD, 0xFD, 0xAA];
+    let bytes = Bytes::Raw(&raw);
+    let collected: heapless::Vec<u8, 16> = bytes.iter().collect();
+    assert_eq!(&collected[..], &raw);
+    assert_eq!(bytes.unstuffed_len(), raw.len());
+}
+
+#[test]
+fn stuff_empty_payload() {
+    let mut out: Vec<u8, 32> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0x0010,
+            data: Bytes::Raw(&[]),
+        },
+    )
+    .unwrap();
+    let (pkt, _) = parse_one(&out).unwrap();
+    let Packet::Write { data: d, .. } = pkt else {
+        panic!();
+    };
+    assert_eq!(d.unstuffed_len(), 0);
+    assert_eq!(d.iter().next(), None);
+}
+
+#[test]
+fn stuff_status_with_trigger_in_params() {
+    let params = [0xFFu8, 0xFF, 0xFD, 0x00, 0x42];
+    let mut out: Vec<u8, 64> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Status {
+            id: 1,
+            error: 0,
+            params: Bytes::Raw(&params),
+        },
+    )
+    .unwrap();
+    let (pkt, _) = parse_one(&out).unwrap();
+    let Packet::Status {
+        error, params: p, ..
+    } = pkt
+    else {
+        panic!();
+    };
+    assert_eq!(error, 0);
+    let mut buf = [0u8; 16];
+    let n = p.copy_into(&mut buf).unwrap();
+    assert_eq!(&buf[..n], &params);
+}
+
+#[test]
+fn stuff_forwarding_round_trip() {
+    let original_data = [0xFFu8, 0xFF, 0xFD, 0x42, 0xAA];
+    let mut wire1: Vec<u8, 64> = Vec::new();
+    write(
+        &mut wire1,
+        &Packet::Write {
+            id: 1,
+            address: 0x0010,
+            data: Bytes::Raw(&original_data),
+        },
+    )
+    .unwrap();
+
+    let (pkt, _) = parse_one(&wire1).unwrap();
+    let mut wire2: Vec<u8, 64> = Vec::new();
+    write(&mut wire2, &pkt).unwrap();
+    assert_eq!(&wire1[..], &wire2[..]);
+}
+
+#[test]
+fn stuff_long_payload_with_many_triggers() {
+    let mut data: heapless::Vec<u8, 64> = Vec::new();
+    for _ in 0..6 {
+        data.extend_from_slice(&[0xFF, 0xFF, 0xFD, 0x42, 0x55])
+            .unwrap();
+    }
+    let mut out: Vec<u8, 128> = Vec::new();
+    write(
+        &mut out,
+        &Packet::Write {
+            id: 1,
+            address: 0x0010,
+            data: Bytes::Raw(&data),
+        },
+    )
+    .unwrap();
+    let (pkt, _) = parse_one(&out).unwrap();
+    let Packet::Write { data: d, .. } = pkt else {
+        panic!();
+    };
+    assert_eq!(d.unstuffed_len(), data.len());
+    let mut buf = [0u8; 64];
+    let n = d.copy_into(&mut buf).unwrap();
+    assert_eq!(&buf[..n], &data[..]);
+}

--- a/firmware/lib/rust-toolchain.toml
+++ b/firmware/lib/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel    = "nightly"
+components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]

--- a/firmware/lib/units/src/lib.rs
+++ b/firmware/lib/units/src/lib.rs
@@ -1,1 +1,35 @@
+//! OSC native engineering units.
+
 #![no_std]
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Microrads(pub i32);
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct MilliradsPerSec(pub i32);
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Milliamps(pub i16);
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Millivolts(pub i16);
+
+/// 0.1 °C; e.g. 250 = 25.0 °C.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct CentiCelsius(pub i16);
+
+/// Dimensionless normalized actuator command. Negative = reverse, positive = forward.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Effort(pub i16);
+
+impl Effort {
+    pub const ZERO: Self = Self(0);
+    pub const FULL: Self = Self(i16::MAX);
+    pub const MIN: Self = Self(-i16::MAX);
+}


### PR DESCRIPTION
- implemented dxl-protocol
- added types needed for osc-ch32
- added control table definition
- added a RegMap for byte addressable access for the control table
- use nightly