### PR TITLE
docs: v2 design docs + readme refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > An open platform for turning cheap servos into smart actuators.
 
-OpenServoCore (OSC) is open hardware and firmware that drops a CH32V006 control board into a $2-3 cloned hobby servo (SG90 and friends) and turns it into a DXL-style smart actuator — position feedback, current sensing, bus-addressable, programmable.
+OpenServoCore (OSC) is open hardware and firmware that drops a CH32V006 control board into a $2-3 cloned hobby servo (SG90 and friends) and turns it into a Dynamixel-class smart actuator — position feedback, current sensing, bus-addressable, programmable. The bus speaks the **osc-native protocol**: our own break-framed wire protocol, inspired by Dynamixel Protocol 2.0 but redesigned to run whole on sub-$0.20 MCUs ([spec](docs/osc-native-protocol.md)).
 
 The thesis is the price point: at mass-production volume, an OSC swap board should add **no more than ~$1 to the BOM** of a cloned servo. Cheap enough that "upgrade every servo in a robot to smart" stops being a premium decision and starts being a default.
 
@@ -20,7 +20,7 @@ The thesis is the price point: at mass-production volume, an OSC swap board shou
 - **OSC Dev CH32** (`osc-dev-v006`) — Rev B validated. Firmware integration ongoing.
 - **OSC SG90 CH32** (`sg90-prod-ch32v006`) — designed, not spun. Waiting on firmware v2 to be testable against.
 - **Firmware v1** (`firmware-old/`) — legacy. First pass was vibe-coded and got poor Reddit feedback. Kept as historical reference; **not a target for new work**.
-- **Firmware v2** (rewrite) — in progress.
+- **Firmware v2** (rewrite) — in progress. The osc-native protocol and the servo bus transport are implemented and bench-proven on silicon (0.5-3 Mbaud, multi-servo chains); control loops are next.
 - **tinyboot** (OSC bootloader) — v0.4.0 shipped. Lives at [`OpenServoCore/tinyboot`](https://github.com/OpenServoCore/tinyboot).
 
 ## Repo map
@@ -36,7 +36,9 @@ open-servo-core/
 │   │   └── motor-mount/              # 3D-printable test fixtures
 │   ├── shared.kicad_sym / shared.pretty / shared.3dshapes  # Shared KiCad libraries
 │   └── templates/                    # KiCad project templates
-├── firmware/                         # Firmware v2 lives here once the rewrite starts
+├── docs/                             # Design docs — protocol spec, transport, driver pattern, history
+├── firmware/                         # Firmware v2 (Rust) — chip-agnostic libs, CH32 chip crate, board binaries
+├── tools/                            # Bench + bus-forensics tooling (host-side test suite, uart-pirate)
 └── firmware-old/                     # Legacy firmware (do not use)
 ```
 
@@ -62,9 +64,21 @@ Each board has its own README with full schematics, pinouts, jumper behaviour, a
 
 ## Firmware
 
-The Rust firmware is mid-rewrite. The legacy `firmware-old/` tree contains the original architecture (multi-crate workspace targeting STM32F301 and partly CH32V003) and is kept for reference, but the v2 rewrite starts from a cleaner architecture targeting CH32V006 first. Plan: DXL-compatible register table, persistence, control loops, safety features.
+The Rust firmware v2 lives in `firmware/`: chip-agnostic library crates (protocol, drivers, control table, discrete-event integration tests), a CH32 chip crate, and board binaries. It speaks the osc-native protocol — our own break-framed bus protocol, inspired by Dynamixel Protocol 2.0. DXL 2.0 itself was implemented and tuned first, then replaced: its wire format (header hunting, byte stuffing, reply-grid timing) costs more than a $0.15 MCU should pay, and controlling both ends of the wire let us delete those subsystems outright — the story is in [design history](docs/design-history.md). The register-table conventions (flat control table, staged writes, alert semantics) keep the DXL flavor.
 
-Build instructions will appear here as the rewrite matures.
+The bus transport is bench-proven on silicon: 0.5-3 Mbaud, ~30 us ping turnaround at 1 M, multi-servo status chains, hardware CRC both directions. Control loops, persistence, and safety features are in progress; build instructions will appear as the rewrite matures.
+
+The legacy `firmware-old/` tree contains the original architecture (multi-crate workspace targeting STM32F301 and partly CH32V003) and is kept for reference only.
+
+## Documentation
+
+Design docs live in [`docs/`](docs/):
+
+- **[osc-native protocol](docs/osc-native-protocol.md)** — the wire protocol spec: break framing, instruction set, management plane.
+- **[Servo transport](docs/osc-servo-transport.md)** — the servo-side transport design: DMA ring, deadline pipeline, hardware CRC.
+- **[Driver pattern](docs/driver-pattern.md)** — the firmware architecture: services / drivers / providers / HAL.
+- **[Design history](docs/design-history.md)** — what we tried and abandoned, and what it taught us.
+- **[Testing](docs/testing.md)** — the test strategy.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > An open platform for turning cheap servos into smart actuators.
 
-OpenServoCore (OSC) is open hardware and firmware that drops a CH32V006 control board into a $2-3 cloned hobby servo (SG90 and friends) and turns it into a Dynamixel-class smart actuator — position feedback, current sensing, bus-addressable, programmable. The bus speaks the **osc-native protocol**: our own break-framed wire protocol, inspired by Dynamixel Protocol 2.0 but redesigned to run whole on sub-$0.20 MCUs ([spec](docs/osc-native-protocol.md)).
+OpenServoCore (OSC) is open hardware and firmware that drops a CH32V006 control board into a $2-3 cloned hobby servo (SG90 and friends) and turns it into a Dynamixel-class smart actuator — position feedback, current sensing, bus-addressable, programmable. The bus speaks the **osc-native protocol**: OSC's own break-framed wire protocol, inspired by Dynamixel Protocol 2.0 but redesigned to run whole on sub-$0.20 MCUs ([spec](docs/osc-native-protocol.md)).
 
 The thesis is the price point: at mass-production volume, an OSC swap board should add **no more than ~$1 to the BOM** of a cloned servo. Cheap enough that "upgrade every servo in a robot to smart" stops being a premium decision and starts being a default.
 
@@ -64,7 +64,7 @@ Each board has its own README with full schematics, pinouts, jumper behaviour, a
 
 ## Firmware
 
-The Rust firmware v2 lives in `firmware/`: chip-agnostic library crates (protocol, drivers, control table, discrete-event integration tests), a CH32 chip crate, and board binaries. It speaks the osc-native protocol — our own break-framed bus protocol, inspired by Dynamixel Protocol 2.0. DXL 2.0 itself was implemented and tuned first, then replaced: its wire format (header hunting, byte stuffing, reply-grid timing) costs more than a $0.15 MCU should pay, and controlling both ends of the wire let us delete those subsystems outright — the story is in [design history](docs/design-history.md). The register-table conventions (flat control table, staged writes, alert semantics) keep the DXL flavor.
+The Rust firmware v2 lives in `firmware/`: chip-agnostic library crates (protocol, drivers, control table, discrete-event integration tests), a CH32 chip crate, and board binaries. It speaks the osc-native protocol — OSC's own break-framed bus protocol, inspired by Dynamixel Protocol 2.0. DXL 2.0 itself was implemented and tuned first, then replaced: its wire format (header hunting, byte stuffing, reply-grid timing) costs more than a $0.15 MCU should pay, and controlling both ends of the wire made those subsystems deletable outright — the story is in [design history](docs/design-history.md). The register-table conventions (flat control table, staged writes, alert semantics) keep the DXL flavor.
 
 The bus transport is bench-proven on silicon: 0.5-3 Mbaud, ~30 us ping turnaround at 1 M, multi-servo status chains, hardware CRC both directions. Control loops, persistence, and safety features are in progress; build instructions will appear as the rewrite matures.
 
@@ -77,7 +77,7 @@ Design docs live in [`docs/`](docs/):
 - **[osc-native protocol](docs/osc-native-protocol.md)** — the wire protocol spec: break framing, instruction set, management plane.
 - **[Servo transport](docs/osc-servo-transport.md)** — the servo-side transport design: DMA ring, deadline pipeline, hardware CRC.
 - **[Driver pattern](docs/driver-pattern.md)** — the firmware architecture: services / drivers / providers / HAL.
-- **[Design history](docs/design-history.md)** — what we tried and abandoned, and what it taught us.
+- **[Design history](docs/design-history.md)** — what I tried and abandoned, and what it taught.
 - **[Testing](docs/testing.md)** — the test strategy.
 
 ## Contributing

--- a/docs/design-history.md
+++ b/docs/design-history.md
@@ -1,0 +1,210 @@
+# Design history — what I tried, and what it taught
+
+The transport did not arrive at its shape by foresight. It got there by
+building the obvious thing, measuring it, and deleting it — repeatedly. This
+file is the itemized record of the abandoned paths and the lessons they
+distilled, so a reader gets the war stories without the git archaeology. The
+arc in one line: the firmware first spoke Dynamixel Protocol 2.0, made it
+work, and then replaced the protocol itself on the strength of one fact: I
+control both ends of the wire.
+
+Companion pillars: `osc-native-protocol.md` (the wire),
+`osc-servo-transport.md` (the receiver), `driver-pattern.md` (the layering).
+
+## The protocol pivot
+
+### Dynamixel Protocol 2.0 as the wire protocol
+
+I implemented and tuned a complete DXL 2.0 stack — parser, hardware reply
+timing, Fast chain CRC, clock calibration — and it worked: 62.8 µs measured
+ping turnaround at the end of its tuning arc. I replaced it anyway. Every
+hard problem in that stack traced to one wire-format fact: DXL has no
+out-of-band delimiter, so it needs `FF FF FD` header hunting, byte stuffing
+to keep the header out of payloads, and a stuffed length that isn't known
+until the whole payload is walked — which forbids streaming TX outright. Add
+10–12 bytes of overhead per frame, the RDT reply-grid tuning surface, and
+byte-granular indirect registers that force replies through a per-byte
+pointer chase (defeating both the hardware CRC engine and copy-once TX), and
+the stack's complexity was the protocol's, not ours. A UART break is an
+out-of-band delimiter: framing became 5 bytes + a break, the receiver became
+a two-state framer, and the stuffing, hunting, and reply-grid subsystems
+stopped existing. Lesson: when you control both ends of the wire, fix the
+wire — a delimiter the data cannot forge deletes entire subsystems.
+
+## Receive machinery built, measured, deleted
+
+### Per-byte streaming RX parser
+
+The first receiver walked the wire byte by byte: an event-per-protocol-field
+iterator pumped into a stateful dispatcher that tracked each in-flight
+instruction across the event sequence. The per-byte pipeline measured ~55%
+of the CPU during sustained 3 Mbaud reception — spent producing a
+granularity no consumer used. Reply timing needs one number per frame, chain
+sequencing needs frame boundaries, drift estimation needs a rate over a
+burst. Deleted for whole-frame classification: probe the header, copy once,
+decode once, one verdict per frame. Lesson: precision nobody downstream
+spends is pure cost — find what consumers actually need before building the
+producer.
+
+### Hardware input-capture RX timing
+
+Early bringup timestamped every falling edge on the RX pin through timer
+input capture: a DMA-drained edge-stamp ring and a classifier walker turned
+edge times into per-byte wire ticks. It worked, and it was the single
+largest CPU consumer in the transport. All ~3000 lines were deleted and RX
+timing became fully software once measurement showed every timing consumer
+met its tolerance from plain clock reads. Lesson: RX jitter does not
+propagate to the wire — only TX jitter does. Spend hardware where error
+reaches the wire; software is fine everywhere else.
+
+## Transmit timing the break made obsolete
+
+### Hardware-timed TX kickoff + RDT
+
+To hit DXL's reply grid, a timer-compare match fired a DMA write that
+enabled the TX stream — zero CPU in the deadline path — backed by
+per-fire-path lead-calibration constants and a wrap-guard arming dance. All
+of it existed because DXL schedules replies on a clock grid. Break framing
+made reply timing event-driven: send the break when ready, and the break
+itself tells every listener a frame is starting. The kickoff hardware, the
+RDT register, and the whole lead-tuning surface were deleted. Lesson: the
+best exit from a precision-timing problem is a protocol that doesn't pose
+it.
+
+## Clock discipline: the long road to CAL
+
+### Fire-intercept calibration (DXL era)
+
+The chip has no crystal, and its RC oscillator drifts enough to break
+chain timing at 3 Mbaud. The first calibration was a three-knob
+decomposition — HSITRIM for the drift slope, a per-family structural-latency
+intercept, a per-chip sub-trim residual — derived host-side from a
+crystal-clocked timer stamping a stimulus reply. It was correct and it was
+heavy: biased rounding rules, Q8.8 unit plumbing, per-family
+characterization sweeps. The break-framed protocol deleted its main
+consumer (the reply grid), and the replacement ruler is one broadcast
+instruction: the host emits breaks spaced exactly T µs apart and the servo
+stamps its own wake entries — same ISR path both ends of every gap, so
+entry latency cancels in the difference. The lesson survives unchanged: a
+chip cannot time itself. SysTick, the UART, and ISR latency all derive from
+the oscillator under test; every self-measurement is structurally biased.
+You need a reference on a clock domain that isn't the one being measured.
+
+### Passive drift estimator
+
+Between calibrations, thermal drift still needs tracking. The first tracker
+eavesdropped: it sampled the host's byte cadence at mid-frame resolver
+wakes. It starved — the frames long enough to qualify barely exist in real
+traffic — and its software-phased stamps needed a dither/floor/gate pipeline
+just to launder their quantization. Replaced by the differential chain-pair
+tracker: break-wake stamps bracketing one CRC-verified silent instruction,
+with a post-trim baseline subtraction that kills every constant (host
+queuing seam, detector latch offset, ISR flavor residue) so only drift
+survives. Lesson: when only the host has the truth — it owns the crystal —
+ask the host to cooperate instead of eavesdropping on it.
+
+## Position and time from wake evidence: three dead ends
+
+### Capture FIFO / deferred dispatch
+
+Zero-gap bursts lost frames, and the diagnosis pointed at ISR latency: a
+long dispatch body delays break service, breaks coalesce, the late handler
+misreads the ring. So I queued — a capture FIFO that snapshotted the ring
+cursor at each event for later processing. Reverted: probes proved the
+snapshots were already stale *at capture time*; fixing latency attacked the
+wrong term. The design rule since: position is derived from the stream,
+never sampled at ISR entry. Latency merely amplifies staleness — remove the
+staleness and latency stops meaning loss.
+
+### Per-event timestamps → ring-cadence time
+
+The break wake once carried one timestamp — its own delivery tick — as the
+frame's clock anchor. Everything timed from it inherited ISR delivery lag
+wholesale: a wake serviced 60 µs late made the reply 60 µs late. Replaced by
+projecting `now + missing byte-times` from live ring state at every resolve.
+`now` and the ring cursor advance together, so delivery lag cancels out of
+the projection; the residual error is bounded under a byte-time and always
+on the late side, never early. The wake carries nothing now — not position,
+not time. It is only a wake.
+
+### Error-flag wake + fault fence + storm mute
+
+The receive wake originally lived on the UART's framing-error flag, and I
+twice shipped machinery that extracted more than a wake from it: a
+positional fault fence (record where the error was seen, kill frames behind
+it) and a service-time storm mute (throttle a flag that re-fires). Both
+passed every quiet-wire test. Both killed live frames under fleet load —
+service-time cursors lie under ISR lag and latch re-fires — and the mute's
+restore chain wedged servos deaf to rescue. The resolution inverted the
+premise: wake on the length-qualified break detector, and leave the error
+flags with no interrupt enabled at all. Errors never interrupt; their
+consequences surface where data-driven handling already looks (a corrupt
+byte fails its frame's CRC). Lesson: latched, positionless, coalescing
+signals cannot be event sources — don't build event machinery on one.
+
+## Dispatch placement
+
+### Class-routing carve-out (heavy dispatch at low priority)
+
+To keep long dispatch bodies from preempting the motor kernel, heavy
+instruction classes were routed across a priority boundary: staged through a
+one-slot handoff to a low-priority consumer. It bought kernel isolation and
+cost ack-bearing writes a cross-priority hop and an adoption round-trip —
+and the handoff machinery (slot FSM, two wake lanes, adoption guard) became
+the single largest complexity center in the transport. Deleted, ~800 lines,
+once silicon measurement settled the question the structure was built to
+avoid asking: kernel tick coalescing under realistic bus duty is negligible.
+Lesson: measure the cost before building structure to avoid it.
+
+## Smaller calls that shaped the design
+
+### Torque-gated EEPROM writes
+
+DXL gates every config-region write behind torque-off — a category error
+that conflates the storage medium with the data's mutability. The actual
+mid-motion hazard is the flash program operation, which stalls instruction
+fetch for milliseconds under a live control loop. So only SAVE is gated;
+config writes always land in the RAM table, volatile until saved. Flash wear
+drops to program-per-session and the write stall happens exactly once, at a
+moment the user chose. Lesson: gate the hazard, not the category.
+
+### Async/await on the servo side
+
+Rust async was considered for the bus driver and rejected. Executor
+wake→poll overhead per frame is real money against a ~41 µs turnaround
+budget on a 48 MHz RV32EC, and async costs control of code placement — hot
+paths must land in RAM sections deliberately, which the executor's generated
+state machines defeat. The driver is instead a composed set of explicitly
+scheduled state machines driven by two interrupt vectors: the scheduling is
+the design, not plumbing to be abstracted away.
+
+### Framing alternatives that lost to the break
+
+Recorded so they are not re-derived. Closing double-break (a break at both
+ends of every frame): deletes every receiver clock, but costs wire time per
+frame and gives up dispatching under the instruction's own wire time.
+Covered-position break (delimiter at the payload/CRC boundary): a
+wire-native dispatch trigger, but it resurrects the commit/revert machinery
+it was meant to delete. Sync bytes, header checksums, parity: each adds wire
+cost to buy detection the break + CRC + host-retry contract already
+provides, and none deletes receiver machinery. Break framing is the strong
+form of sync — DXL's `FF FF FD` + stuffing is the workaround for not having
+an out-of-band delimiter at all.
+
+## Recurring lessons
+
+- **Measure before structuring.** Twice I built structure to avoid a cost
+  nobody had measured; both times the measurement, once taken, deleted the
+  structure.
+- **Delete machinery rather than tuning it.** Every major win here was a
+  subtraction; a fix that adds a knob is usually aimed at the wrong term.
+- **Data over wake evidence.** Positions come from the stream, times from
+  cadence projections; nothing derived at ISR entry survives load.
+- **A clock needs an external reference.** Every self-measurement path
+  shares the oscillator under test.
+- **Gate hazards, not categories.** Find the actual dangerous operation and
+  gate exactly that.
+- **Precision nobody spends is pure cost.** Identify what consumers need
+  before building the producer.
+- **When you control both ends, fix the wire.** Complexity moved into the
+  wire format's construction is deleted from every implementation, forever.

--- a/docs/driver-pattern.md
+++ b/docs/driver-pattern.md
@@ -1,0 +1,1012 @@
+# Hierarchical Driver Pattern
+
+A design convention for organizing firmware that has more than two or three peripherals interacting with a protocol stack. This doc captures the convention in generic terms so it can be applied to any project — examples are illustrative rather than tied to a specific codebase. For a full worked example in this tree, see the bus driver under `firmware/lib/drivers/src/bus/` (the composite `ServoBus` composing the `Framer`/`Chain`/`TxEngine`/`ClockTracker` sub-drivers) with its providers in `firmware/ch32/src/providers/`.
+
+---
+
+## 1. The problem it solves
+
+Most embedded firmware starts the same way: each peripheral gets a struct or a handful of globals, ISRs read and write those globals directly, and inter-peripheral coordination happens through shared atomics or ad-hoc flags. This works for a few peripherals. It collapses around the time the firmware has:
+
+- Multiple ISRs reading and writing the same state.
+- State machines whose transitions are scattered across ISRs and main-loop code.
+- Cross-peripheral coordination (timer X drives DMA Y based on UART Z's state).
+- A protocol layer above the peripherals that needs to issue commands and read status.
+- A testing ceiling: integration tests cover what fits on the bench, but the FSM and policy logic inside drivers can't be exercised in isolation because every method touches registers directly.
+
+The symptoms look like:
+
+- A module of "statics" with dozens of `AtomicU32` / `SyncUnsafeCell` items at the top level. Each is referenced from three or four places. Ownership is implicit. Adding a new feature requires reading every file that touches the related atomics to understand the invariants.
+- Hand-rolled seqlocks built out of multiple atomics that are conceptually one struct.
+- ISRs that take several screens to read, alternating between hardware register polls, state machine transitions, and statics manipulation.
+- Multiple implicit state machines encoded as the *combination* of several boolean flags and counter values, with no single place that names the states or transitions.
+- A protocol-level adapter ("this peripheral is a USB CDC", "this UART implements a custom protocol") that ends up holding peripheral state instead of just adapting it.
+- Driver logic that can only be exercised by running the firmware end-to-end. A subtle FSM bug requires a hardware repro, a logic analyzer, and an afternoon — not a one-line unit test.
+
+The pattern below is one way to keep the structure under control as the firmware grows past the "couple of peripherals" complexity ceiling.
+
+---
+
+## 2. The four-layer chip lib
+
+The chip-specific firmware crate splits into four layers. Each layer has one reason to change, and dependencies run strictly downward.
+
+| Layer | Lives in | Responsibility | Varies with |
+| --- | --- | --- | --- |
+| **Service** | `services/<name>.rs` | Adapt a protocol-side trait (defined in a chip-agnostic core) to driver method calls | The protocol stack above |
+| **Driver** | `drivers/<name>/` | Own hardware state; expose a pure-method API; generic over its interface dependencies | Features and FSM logic |
+| **Provider** | `provider/<role>.rs` (or `<role>/v<variant>.rs`) | Implement driver-defined interfaces over HAL primitives (production) or record calls (tests); own per-peripheral init including clock-gate enable | Role-to-peripheral allocation; chip variant (cfg-gated per project) |
+| **HAL** | `hal/<peripheral>.rs` (or `<peripheral>/v<ip>.rs`) | Register access; peripheral primitives; chip-specific resource identifiers (pin enums, peripheral handles, configuration structs) | Peripheral IP version (multiple chips may share; cfg-gated when they diverge) |
+
+The dependency direction is strictly downward: services depend on drivers, drivers depend on interfaces they themselves define, providers implement those interfaces and consume HAL, HAL talks to the silicon. **Nothing skips a layer.** A driver never imports HAL types or calls HAL functions directly; a service never reaches past its bound driver.
+
+Three small facades sit *outside* the stack:
+- The **driver registry** — owns static storage for installed driver *instances* and exposes typed accessors. Driver types themselves carry no statics. §9.1 covers it.
+- The **provider facade** — orchestrates hardware setup and deferred IRQ enable. Bringup goes through this single entry point. §9.2 covers it.
+- The **IRQ vector binding** — a thin dispatcher that reads an interrupt-source flag, classifies into a logical event, and calls a driver method through the registry. §8 covers it.
+
+None are layers of their own — they're orchestration surfaces over the four-layer stack.
+
+### 2.1 Why the layers exist
+
+Each layer corresponds to a thing that varies independently:
+
+- **Chip variant** changes ripple into the provider's variant-specific files (peripheral choice differs per chip) and may ripple into HAL when peripheral IP version differs. Driver interfaces and driver logic stay pinned across chip variants — that's the point of the provider seam (§5.6).
+- **Protocol changes** ripple into services. Everything below stays pinned.
+- **Feature and FSM work** ripples into drivers. Providers and HAL stay pinned.
+- **Test substitution** ripples into providers only. Drivers are generic over their interfaces, so a test substitutes a fake provider without touching production code.
+
+If a single change requires editing two layers at once, the layering is leaking. The typical culprit is a chip-specific type appearing in a driver method signature — the fix is to define a domain type at the driver layer (or hoist a shared primitive to a sibling location) so the interface carries no HAL types.
+
+### 2.2 Reading order
+
+To understand a system built this way, read top-down for orchestration or bottom-up for hardware:
+
+- **Top-down**: service → top-level driver → composite routing → sub-drivers → interfaces → providers. This tells the story of "what the protocol asked for and how it became register writes."
+- **Bottom-up**: HAL → providers → interfaces → driver methods → composite routing → service. This tells the story of "this register exists; what consumes it?"
+
+Each file is independently legible. The IRQ vector binding file is read after the driver — it tells you which hardware sources route to which driver methods.
+
+### 2.3 Chip-agnostic drivers by construction
+
+The four-layer split has a stronger consequence than "driver code stays pinned across chip variants" — **drivers are by construction unaware of any specific chip.** Their imports name only their own trait surface (e.g., `drivers/traits.rs`) and Rust core; chip-specific types never appear in a driver method signature, field, or body. A second chip is a second provider set; the entire `drivers/` tree compiles unchanged.
+
+The unit-test seam (§6) is the in-tree proof: `Driver<Fake>` and `Driver<Real>` are the same driver code with different providers — same as `Driver<ChipA>` and `Driver<ChipB>` would be. The property generalizes from "swap a fake for a real provider" to "swap chip A's provider set for chip B's."
+
+In hexagonal-architecture terms (§11), drivers are the **domain core** and providers are the bottom adapter ring. The convention makes drivers portable across chips for the same reason hexagonal makes the domain core portable across infrastructure — it's the same property applied to the chip-portability axis. In practice this means a mature multi-chip codebase can lift the entire `drivers/` tree into a chip-agnostic core crate alongside the protocol stack, leaving only `provider/`, `hal/`, and bringup in each chip-specific firmware crate. §2.4 describes that crate-level packaging.
+
+### 2.4 Packaging across crates
+
+The four-layer split is a module convention inside a single firmware crate, and that's enough for small projects. For projects with multi-chip support, long-term-support guarantees, or quality goals that benefit from machine-enforced layering, the same four layers map cleanly across crates — and the chip-family crate takes on a sharpened role: it becomes an **orchestration crate**.
+
+```
+<project>-core            ← domain types, protocol stack, control loops — chip-agnostic
+<project>-drivers         ← driver state machines + driver-trait surface — chip-agnostic
+                            depends on <project>-core for domain types
+<chip-family>             ← ORCHESTRATION CRATE
+                            composes hal + providers + services + drivers (instantiated)
+                            + ISRs + bringup into a running system
+                            depends on <project>-core, <project>-drivers, <chip-family>-metapac
+                            chip-variant feature flags forward to <chip-family>-metapac
+firmware/<board>          ← binary entry point
+                            holds the BoardWiring const + main()
+                            depends on <chip-family>, pins one chip-variant feature flag
+```
+
+Two crate-level properties fall out:
+
+- **The driver crate is a pure library.** `<project>-drivers` defines driver types and their trait surfaces — nothing else. No registry, no concrete instances, no bringup. Drivers stay generic over their trait bounds; the crate has no HAL dependency to import. Chip-agnosticity becomes a `cargo build` invariant.
+- **The chip-family crate is the orchestration crate.** It holds *everything* that composes the system: HAL primitives, trait impls (providers), trait impls for core (services), the driver registry (`Drivers` struct holding concrete instances like `DxlRx<DmaRing07>`), the bringup sequence, and the ISR vector binding. §2.5 covers its internal layout.
+
+The consumer-owned-interface rule (§5.1) carries across crate boundaries: **driver traits live in `<project>-drivers`, not in `<chip-family>`.** Providers in `<chip-family>` import the trait from `<project>-drivers` and implement it over local HAL primitives. This is cross-crate dependency-inversion — the lower-level crate depends on the higher-level crate's interface.
+
+The driver registry stays chip-side rather than in `<project>-drivers`. Its fields are concrete chip-side instantiations (`dxl_rx: DxlRx<DmaRing07>`, `dxl_clock: DxlClock<Tim2Mono>`); putting the registry in the driver crate would either force a circular dependency (driver crate names chip-side types) or force generic-parameter explosion (every accessor signature carries the full provider set). Letting the orchestration crate own its registry is honest: each chip family has its own bag of concrete driver instances, and that bag belongs with the chip.
+
+A second chip family is a new sibling orchestration crate with the same shape — its own HAL, its own providers, its own registry, its own bringup. `<project>-drivers` and `<project>-core` are unchanged. Board binaries select chip family by depending on the corresponding orchestration crate.
+
+The trade-off:
+
+- **Single-crate firmware** — all four layers as modules in one crate. Less ceremony. Chip-agnosticity is a code-review convention.
+- **Multi-crate firmware** — chip-agnosticity is a build-time invariant; the driver crate physically cannot import HAL. Multi-chip support, layered review automation, and long-term-support boundaries all become structural. Recommended when project longevity or quality discipline matters.
+
+The split is mechanical once the role-shaped provider convention is in place. The cost is paid in extra crate scaffolding (Cargo.toml, lib.rs entries); the value is the build-time enforcement of the architectural property the convention is designed to provide.
+
+### 2.5 Internal layout of the orchestration crate
+
+Within the chip-family orchestration crate, files organize into five top-level modules. The split mirrors the conceptual layer model but adds explicit homes for things the layer model leaves implicit (declarative config, orchestration glue):
+
+| Module | Shape | Contents | Reads from |
+| --- | --- | --- | --- |
+| `hal/` | Foundation | Peripheral IP primitives (register dance); chip-family type enums (`Pin`, `UsartRemap`, `TimerChannel`, `DmaChannel`) — values may be chip-variant-routed | — |
+| `cfg/` | Declarative | Board-wiring schema struct (`BoardWiring { dxl_uart_rx_pin: Pin, ... }`) — types only, no concrete values | `hal/` types |
+| `providers/` | Impl (driver-facing) | Role-shaped impls of `<project>-drivers` traits | `hal/`, `cfg/` |
+| `services/` | Impl (core-facing) | Impls of `<project>-core` traits | `runtime::registry` |
+| `runtime/` | Orchestration | `registry.rs` (Drivers struct + facade), `init.rs` (bringup sequence), `isr.rs` (handler bodies + `install_isrs!` macro) | All of the above |
+
+Dependency flow (within the crate):
+
+```
+hal ──┐
+cfg ──┴── providers ──┐
+                       ├── runtime::registry ── runtime::init
+                       │                         runtime::isr
+                       │
+                       └── services
+```
+
+The split rests on three observations:
+
+- **Two shapes, cleanly separated.** Providers and services are *impls* — consumer-owned-interface fulfillment, just for different consumer crates (drivers and core respectively). Registry / init / isr are *orchestrators* — they hold, sequence, or dispatch concrete instances. The shapes don't mix in one file: a provider file impls a trait for any consumer; an ISR file names a specific driver to dispatch to.
+- **Wiring schema is chip-family-shaped; wiring values are board-shaped.** The `BoardWiring` struct definition lives in `cfg/` because its fields are typed with chip-family enums (`Pin`, `UsartRemap`, …) — the schema varies by chip variant. The concrete values (which physical pin? which UART? which timer channel?) live in the board binary as a `pub const WIRING: BoardWiring`. The runtime entry point takes `&'static BoardWiring` as a parameter; nothing in the chip-family crate hardcodes pin choices.
+- **ISRs are peripheral-driver bindings, not role-shaped.** A handler names a specific peripheral *and* a specific dispatch target — that pairing is a one-off binding, not a reusable role. So ISRs live in `runtime/isr.rs` (alongside `install_isrs!`) rather than in provider files. A provider file impls `RxDma` for any consumer; the ISR file names "DMA1_CH5 dispatches to `DxlUart` specifically." The target can also be a provider module when no driver logic is involved — "DMA1_CH7's TC dispatches to `tx_kickoff::on_kickoff_complete`" is pure chip-side channel restoration the driver only observes later through its trait surface.
+
+**Chip-variant routing** uses the same cfg-routing pattern at three layers:
+
+```
+hal/types.rs              -- cfg-routed enum bodies per package (V006P8U6, V006E8U6, V307VCT6 …)
+cfg/board_wiring.rs       -- cfg-routed schema (different chips support different fields)
+providers/<role>.rs       -- cfg-routed impl (different chips need different register writes)
+```
+
+A single-variant project uses flat files (`hal/types.rs`, `cfg/board_wiring.rs`, `providers/monotonic.rs`). When a second variant lands, each splits into a sub-directory (`hal/types/{mod,v006p8u6,v307vct6}.rs`, etc.) with cfg-routed re-exports. The pattern is the same at all three layers — one mental model handles every chip-variant axis.
+
+---
+
+## 3. The driver convention
+
+A driver is a Rust type that owns hardware state. Its public surface is pure methods — no `handle(Command)` indirection, no per-driver `Event`/`Effect` enums. Operations are named for what they do; signatures carry only the inputs and outputs they actually need.
+
+The convention is in *naming and role separation*, not in shape:
+
+- **Hardware events**: methods prefixed `on_*` (e.g. `on_idle`, `on_deadline`). They mutate state and may return an outcome value when something downstream needs to act on the transition. They never return `Result` — a hardware event already happened and can't be refused.
+- **Software commands**: methods named for the operation (`arm`, `stage_baud`, `set`). They mutate state. They return `Result<T, E>` *when the operation has a runtime failure mode* a caller might reasonably encounter and handle. Programmer-error invariants (call-order violations, double-install) become `debug_assert!`s, not `Error` variants.
+- **Accessors**: methods named for what they expose (`window`, `last_tick`, `is_armed`). `&self` (or `&mut self` when truly necessary), returning primitives or small typed values. No transition coupling.
+
+The driver is always fully valid after `new(...)`. The driver type itself carries no static storage and exposes no `install` / `get` methods — singleton lifecycle is delegated to a separate registry (§9.1). Tests construct drivers directly with fake providers; the registry exists only to give production code a place to park installed instances.
+
+Three categories, three reasons to call into a driver. Keep them distinct.
+
+### 3.1 Events vs commands
+
+The distinction is *direction*, not shape:
+
+- **Event** — something the hardware made happen. ISR-originated. Already true by the time the method runs. The method records the new state and may return an outcome for the composite/ISR to route elsewhere. Methods are named `on_*`.
+
+  The `on_*` name describes the *logical event*, not the *peripheral that delivered it*. `on_tx_complete` is a logical event ("the transmission finished"); `on_uart_tc` names the peripheral flag that signaled it. The same logical event may be delivered by a different mechanism on another chip variant — e.g. a timer compare-match instead of a USART status bit — and the driver's method should not change name when that happens. Naming events by the peripheral leaks chip variation into the driver's API.
+
+- **Command** — something software wants. Main-loop or service-originated. May be rejected if it conflicts with current state; in that case the method returns `Result::Err`. Methods are named descriptively.
+
+The same conceptual transition may originate from either direction. "Start transmitting" from a hardware compare-match is an event; "start transmitting" from main-loop intent is a command. The driver's response often differs (the event has *already started* the transmission and the driver records that; the command needs to verify state permits it before committing). Naming them differently keeps the distinction visible at every call site.
+
+### 3.2 Accessors
+
+Accessors are restricted to **stable observations** — values that don't depend on a pending transition. Examples that qualify:
+
+- A configuration scalar published by an earlier command.
+- A monotonic counter incremented by an event.
+- A bool capturing a long-lived state ("is the bus armed?").
+
+Examples that *don't* qualify (return them from the relevant event method instead):
+
+- "The most recent decoded packet" — that's a transition output.
+- "What happened during the last IRQ" — also a transition output.
+- "Internal byte buffer" — that's leaking implementation; prefer a command-style enqueue method or a named operation.
+
+If the urge to add an accessor comes up, ask whether the value is being *polled* (stable observation, fine) or *consumed* (transition output, return it from the event method).
+
+### 3.3 Return values across drivers
+
+When a method's return value flows into another driver — particularly within a composite — it carries **primitives**, not driver-internal types. If two drivers need to exchange a value that's conceptually a struct, the struct gets flattened into primitive fields at the source and reconstructed (or consumed field-by-field) at the receiver. This is the encapsulation rule that keeps drivers independent: a downstream driver should never need to import an upstream driver's types.
+
+---
+
+## 4. Composite drivers
+
+Drivers compose recursively. A top-level driver may contain sub-drivers as fields; its method bodies route events to those sub-drivers and compose their return values:
+
+```rust
+pub struct Top {
+    sub_a: SubA,
+    sub_b: SubB,
+    sub_c: SubC,
+}
+
+impl Top {
+    pub fn on_external_trigger(&mut self) {
+        // Decompose into the sub-driver event(s) this trigger affects.
+        if let Some(value) = self.sub_a.on_triggered() {
+            // Route a's outcome into b as an event.
+            self.sub_b.on_data(value);
+        }
+    }
+
+    pub fn do_work(&mut self, payload: Payload) -> Result<(), TopError> {
+        self.sub_b.work(payload).map_err(TopError::SubB)
+    }
+}
+```
+
+The composite follows the same convention as its sub-drivers — `on_*` for hardware events, descriptive names for commands, accessors for observations — but its bodies route between children rather than mutating leaf state.
+
+### 4.1 The composition rule
+
+> **Sub-drivers are only reachable through their parent.** Sibling sub-drivers do not call each other directly. The parent owns the routing.
+
+This is the rule that keeps the soup out. Without it, two sub-drivers acquire a hidden coupling that doesn't show up in either of their public surfaces; with it, all coupling is visible in the parent's method bodies.
+
+### 4.2 The no-peer-to-peer rule for top-level drivers
+
+> **Top-level drivers do not communicate with each other.**
+
+If two top-level drivers would need to coordinate — for example, a motor driver consulting a sensor driver for thermal protection — they are not actually top-level. They become sub-drivers of a higher composite driver that coordinates them:
+
+```
+drivers/
+  control/         ← new top-level
+    mod.rs          composite: routes between motor and sensors
+    motor.rs        was top-level, now sub-driver
+    sensors.rs      was top-level, now sub-driver
+```
+
+The composite's method bodies are where the coordination lives. From the outside, `Control` exposes the same pure-method surface as any other driver.
+
+This rule has teeth: if you find yourself wanting driver-to-driver calls, the architecture is telling you that two concerns belong together. Either compose them, or move the orchestration up to the protocol layer (see §7).
+
+### 4.3 Sub-composites for disjoint borrows
+
+§7.4's data-centric trait surface relies on the driver caching the request that drives the reply. When the cached request borrows one part of the driver's state and the reply path mutates another, the naive single-struct form runs into Rust's borrow checker: returning `Item<'a>` from a method holds `&mut self` for as long as the item is held, and the reply call can't reborrow.
+
+A **sub-composite** resolves this. Its structural job is to expose disjoint mutable halves:
+
+```rust
+pub struct Inner {
+    a: HalfA,
+    b: HalfB,
+}
+
+impl Inner {
+    /// Disjoint borrow — both halves usable at once.
+    pub fn split_mut(&mut self) -> (&mut HalfA, &mut HalfB) {
+        (&mut self.a, &mut self.b)
+    }
+
+    // Forwarders for sequential single-half call sites.
+    pub fn observe(&mut self) -> Option<Token> { self.a.observe() }
+    pub fn act(&mut self, payload: Payload) -> Result<(), Error> { self.b.act(payload) }
+}
+```
+
+The parent's hot path is closure-based — `split_mut` at the seam hands both halves to the dispatcher at once:
+
+```rust
+impl Top {
+    pub fn poll<F>(&mut self, f: F)
+    where
+        F: for<'a> FnOnce(Item<'a>, &mut Handle<'_, /* ... */>),
+    {
+        let (a, b) = self.inner.split_mut();
+        // ...derive context from a-side state...
+        let item = a.materialize();
+        f(item, &mut Handle::new(b, /* ... */));
+    }
+}
+```
+
+This is a different pattern from the coordinating composite the rest of §4 describes. A coordinating composite owns routing between sub-drivers in its method bodies (the §4 opening's `Top::on_external_trigger → sub_a.on_triggered → sub_b.on_data`). A borrow-splitting sub-composite owns no routing — the dispatcher closure does. `split_mut` is the reason the type exists; forwarder methods are there so non-hot call sites stay compact.
+
+Reach for it when §7.4's cached context and reply path naturally split into two halves of state. Don't reach for it when the borrow conflict can be reshaped away — returning owned data instead of a borrow, or restructuring the trait method, often eliminates the need. Over-applying gives sub-composites that don't earn their weight.
+
+---
+
+## 5. Interfaces and providers
+
+A driver doesn't talk to hardware directly. It talks to one or more **interfaces** — Rust traits that describe what the driver needs done — and is generic over the concrete type that implements each interface. The interfaces are defined alongside the drivers; the implementations (called **providers**) live one layer below.
+
+### 5.1 Drivers own their interfaces
+
+The interface is a contract *written by the consumer*. It expresses what the driver wants done — set this output low, give me the current tick count, apply this trim step to the clock — not what the peripheral exposes. This direction matters:
+
+- **Driver-shaped methods, not peripheral-shaped.** An interface to "set a digital output" reads `fn set(&mut self, level: Level)`. The implementor is already bound to one specific output; the driver issues a command. Compare to a peripheral-shaped equivalent `fn set_level(pin: Pin, level: Level)` where the driver has to thread a pin identifier on every call and import a chip-specific `Pin` type just to compile. The driver-shaped form lets the driver stay free of chip types entirely.
+- **Narrow per-driver granularity.** Each interface declares only what one driver actually calls. A clock driver's "apply trim" interface doesn't expose the rest of the clock-controller registers. Reading the trait bounds on a driver tells you exactly what hardware operations it depends on.
+- **Domain types at the interface boundary.** A `Level` enum (high/low) is a domain concept — it has meaning at the driver layer and above. It lives with the interface that uses it, not with the HAL. The HAL itself can take primitives (a `bool`) and the provider does the one-line translation.
+
+The reverse direction — HAL exposes traits, drivers consume them — is the conventional layered-HAL design. It works, but the trait surface ends up shaped by what the HAL chose to offer rather than by what the driver needs, which tends to produce wider traits than the consumer actually uses.
+
+### 5.2 Providers implement interfaces over HAL or fakes
+
+The provider is the layer where the choice of *which peripheral plays this role* lives, plus the bridge from the driver's trait surface to HAL primitives. Each interface has at least two implementations:
+
+- **Production provider.** A small struct that holds whatever per-instance state is needed (often zero-sized for singleton peripherals) and dispatches each interface method into HAL functions. Lives in `provider/`. Its thinness is the point, not redundancy — the production driver pays no size or speed cost (monomorphization plus `#[inline]` collapses the dispatch to a direct HAL call), and the file is the unambiguous home for the "this peripheral plays this role" decision.
+- **Fake provider.** A test-only implementation that records calls into a log instead of touching hardware. Used by host-side unit tests. Lives alongside the production provider, gated `cfg(test)`.
+
+Both satisfy the same interface, so they're interchangeable from the driver's perspective. Production code constructs the driver with the real provider; tests construct it with the fake.
+
+### 5.3 Naming
+
+The provider layer is **role-shaped**: file names and type names both reflect the trait role, not the peripheral. This is the convention's single most useful tell — a directory listing of `provider/` reads as the catalog of driver-trait roles the firmware fulfills.
+
+- **Interface (trait)** — a capability-flavored name (`Monotonic`, `DigitalOut`, `DmaRing`, `UsartBaud`, `ClockTrim`). Reads as something the driver wants done. Defined in the drivers tree (e.g., `drivers/traits.rs`).
+- **Provider module file** — `snake_case` of the trait name: `provider/monotonic.rs`, `provider/dma_ring.rs`. One file per role.
+- **Provider type** — `PascalCase` of the trait name, same word: `pub struct Monotonic;` inside `provider/monotonic.rs`. The fully-qualified path reads as a sentence: `provider::monotonic::Monotonic` says *"the Monotonic provider."* The peripheral choice (SysTick, TIM6, …) is the file's *content*, not its name.
+- **Fake** — `pub struct Fake;` in the same file under `#[cfg(test)]`. Resolved by path: `provider::monotonic::Fake` parses as *"the test fake for the Monotonic role."*
+
+The trait and the provider type share a name, so the provider file imports the trait by fully-qualified path in the `impl` line rather than via `use`:
+
+```rust
+// provider/monotonic.rs
+pub struct Monotonic;
+
+impl Monotonic {
+    pub fn init() { /* claim and configure the peripheral */ }
+}
+
+impl crate::drivers::traits::Monotonic for Monotonic {
+    const TICKS_PER_US: u32 = /* ... */;
+    fn ticks(&self) -> u32 { /* HAL call */ }
+}
+
+#[cfg(test)]
+pub struct Fake { /* recorded calls */ }
+#[cfg(test)]
+impl crate::drivers::traits::Monotonic for Fake { /* ... */ }
+```
+
+The verbosity stays in this one line per provider file; every other call site reads `provider::monotonic::Monotonic` or imports the trait normally.
+
+HAL is the orthogonal axis: HAL files are peripheral-IP-shaped (`hal/systick.rs`, `hal/timer/v3.rs`, `hal/usart/v1.rs`). A provider file imports HAL primitives by peripheral and calls them — the role-to-peripheral mapping lives in the provider, the peripheral primitives live in HAL.
+
+### 5.4 Composition under interfaces
+
+When a composite driver owns multiple sub-drivers, each sub-driver is generic over its own interfaces. The composite is generic over the union:
+
+```rust
+pub struct Top<I1, I2, I3>
+where I1: InterfaceA, I2: InterfaceB, I3: InterfaceC,
+{
+    sub_a: SubA<I1>,
+    sub_b: SubB<I2, I3>,
+}
+
+pub type ProdTop = Top<ProdA, ProdB, ProdC>;
+```
+
+The `pub type` alias keeps production call sites short — they say `ProdTop`, not the generic form. Tests instantiate `Top<FakeA, FakeB, FakeC>` directly.
+
+When the generic-parameter list grows past about four, a **super-interface** collapses them. The composite takes a single type parameter and reaches each leaf through an associated type:
+
+```rust
+pub trait Providers {
+    type RoleA: InterfaceA;
+    type RoleB: InterfaceB;
+    type RoleC: InterfaceC;
+}
+
+pub struct Top<P: Providers> {
+    sub_a: SubA<P::RoleA>,
+    sub_b: SubB<P::RoleB, P::RoleC>,
+}
+```
+
+Chip-side wiring is a single `impl Providers for ChipProviders { type RoleA = …; … }` block; the chip family keeps one ZST per role (§2.5 — one `providers/<role>.rs` file per leaf interface) and the super-interface impl just names them. Tests follow the same shape: one `TestProviders` ZST whose impl maps each associated type to its recording fake.
+
+The role-shaped name (`Providers`, `Deps`, `Backend` — whatever fits the project's vocabulary) is preferred over hardware-shaped names like `Chip`. The trait describes what the chip side provides to the driver, not the chip itself; tests substitute it without any chip in sight.
+
+Leaves stay narrowly typed (so reading the leaf still shows exactly what hardware it depends on); the composite trades documentation-via-bounds for ergonomic call sites. Introduce the super-interface only when the parameter list actually hurts — it's an optimization, not the default shape.
+
+Blanket-impl shape (`trait Chip: InterfaceA + InterfaceB {} + impl<T> Chip for T where T: InterfaceA + InterfaceB`) is an alternative but conflicts with §2.5's per-role provider files: it forces every leaf impl onto a single shared ZST. Prefer associated types unless the chip family genuinely has one ZST per peripheral group.
+
+### 5.5 Provider categories and init responsibility
+
+Providers come in two flavors:
+
+- **Driver providers** implement a driver-trait and are consumed by generic drivers. Examples: `provider::monotonic::Monotonic`, `provider::dma_ring::DmaRing`. The driver holds one as a type parameter and calls trait methods.
+- **System providers** are init-only bundles called once from the orchestrator. They expose no trait and are not consumed by drivers — they configure chip-wide preconditions on which everything else depends. Examples: `provider::clocks::Clocks` (clock tree setup), `provider::pins::Pins` (pin modes per board wiring), `provider::interrupts::Interrupts` (interrupt-controller base config).
+
+Both follow the same role-shaped naming convention (file = role, type = role).
+
+**Init responsibility.** A driver provider owns *everything* required to make its claimed peripheral usable: the **peripheral clock-gate enable** (RCC ENR bit, or the chip's equivalent), peripheral mode/baud/IRQ-config writes, and any one-shot register setup. System providers own chip-wide preconditions (clock tree, pin modes, interrupt-controller base).
+
+The cohesion rule:
+
+> The provider that decides "I'm using peripheral X for this role" is the one that enables X's clock gate and configures X.
+
+This keeps the peripheral allocation decision and its setup code in the same file. Multi-chip swap (§5.6) is then one file: the replacement provider enables whichever peripheral *it* picks. Conversely, no init scattered across bringup or other files reaches into a peripheral that "belongs" to a provider.
+
+IRQ enable is the one exception — it's deferred to a separate facade phase so handlers are installed before vectors can fire. See §9.2 for the contract.
+
+### 5.6 Multi-chip variants
+
+When a codebase supports more than one chip variant, the provider layer is the chip-variant boundary. Driver code stays variant-agnostic — its trait bounds don't change — and the provider type stays role-named at the import surface (`provider::monotonic::Monotonic`). Concrete chip-specific implementations hide inside.
+
+The convention extends to a sub-module per role:
+
+```
+provider/
+  monotonic.rs            ← variant dispatcher (or monotonic/mod.rs)
+  monotonic/
+    v00x.rs               ← variant A impl
+    v30x.rs               ← variant B impl
+```
+
+The dispatcher cfg-routes the re-export:
+
+```rust
+// provider/monotonic.rs
+#[cfg(feature = "chip-v00x")] mod v00x;
+#[cfg(feature = "chip-v00x")] pub use v00x::Monotonic;
+
+#[cfg(feature = "chip-v30x")] mod v30x;
+#[cfg(feature = "chip-v30x")] pub use v30x::Monotonic;
+```
+
+Gate on whatever chip feature flags the project already uses (typically the same flags exposed by the chip-support crate). A single-chip project uses the flat form (`provider/monotonic.rs`); a multi-chip project sub-modules. **Drivers, the registry, and the `Provider` facade are unchanged either way** — the variant axis lives entirely inside each role module.
+
+Two chips with the same IP for a peripheral can share a HAL file (`hal/timer/v3.rs`) but still differ at the provider — e.g., one chip picks SysTick for `Monotonic`, the other picks a timer. The provider encodes the choice; HAL provides the IP-shaped primitives.
+
+System providers follow the same sub-module pattern when their setup is chip-specific (`provider/clocks/v00x.rs`, `provider/clocks/v30x.rs`). Clock tree, pin alternates, and interrupt-controller base config typically vary more across chips than driver-trait providers do, so multi-chip projects often see system providers sub-moduled first.
+
+The variant-routing pattern extends beyond providers: `hal/types.rs` (chip-family enum bodies) and `cfg/board_wiring.rs` (board-wiring schema fields) follow the same cfg-routing convention. §2.5 covers the pattern across all three layers.
+
+When variant counts grow large enough that the per-chip-family cfg gates become unwieldy — or when chips diverge enough that providers don't usefully share a file — the next step is to split chip families into separate crates. §2.4 describes that packaging.
+
+---
+
+## 6. Unit testing via provider swap
+
+The interface/provider split exists primarily for one reason: **driver logic is unit-testable on the host without an MCU, without a simulator, and without writing integration-style harnesses.** Tests construct a driver with fake providers, drive it through a scenario, and assert on the recorded calls and the driver's resulting state.
+
+### 6.1 What this looks like
+
+A leaf-driver test:
+
+```rust
+#[test]
+fn arming_drives_output_low_then_high() {
+    let fake = FakeDigitalOut::default();
+    let mut driver = SomeDriver::new(fake);
+    driver.arm();
+    assert_eq!(driver.provider().ops(), &[Op::Set(Level::Low), Op::Set(Level::High)]);
+}
+```
+
+The fake records every method call in order. The test asserts on the call sequence, the call arguments, or the resulting state of the driver — whichever the driver under test is responsible for.
+
+For composite drivers, a single fake-host struct hands out per-resource fake providers that share an underlying log. The composite test constructs one host, asks it for each sub-driver's fake, and inspects the combined log:
+
+```rust
+#[test]
+fn workflow_dispatches_to_both_sub_drivers() {
+    let host = FakeHost::default();
+    let mut top = Top::new(
+        host.interface_a(),
+        host.interface_b(),
+    );
+    top.do_workflow();
+    assert_eq!(host.log(), &[expected_op_1, expected_op_2, expected_op_3]);
+}
+```
+
+The host pattern keeps test ergonomics manageable even when a composite consumes several interfaces — there's still one fake to construct, one log to inspect.
+
+### 6.2 What's testable at the driver layer
+
+Most of what drivers actually do:
+
+- **State machine transitions.** Every `on_*` method moves the driver through its FSM; tests cover the transition graph and its edges.
+- **Command rejection.** Methods that return `Result::Err` when state forbids them; tests assert the rejection under each disallowed state.
+- **Integrators, filters, schedulers.** Driver-owned math (drift correction, scheduling deadlines, retry counters, hysteresis) is pure given a fake for the time source.
+- **Composition routing.** A composite's `on_*` methods dispatch to children; tests verify the routing with fakes that record receipt.
+
+### 6.3 What's not testable at the driver layer
+
+- **Actual peripheral behavior.** Register-write side effects, hardware-bounded timing, electrical signaling. These need integration tests on real hardware.
+- **Provider correctness.** The production provider's translation from interface call to HAL function. Tested at the provider layer (small surface, mostly mechanical) or by running the firmware on hardware.
+- **ISR-priority races.** Any concurrency between ISRs sharing a driver. Out of scope for host tests; needs hardware or a model checker.
+
+The split is intentional. Driver-layer host tests catch the bugs that show up in FSM and policy logic — by far the largest class of bugs in firmware of this shape. Hardware-shaped bugs are caught by hardware-shaped tests; the host-test layer isn't trying to replace them.
+
+### 6.4 Fakes are providers too
+
+Fake providers live in the same `provider/` layer as production providers, gated `cfg(test)`. They satisfy the same interfaces. From the driver's perspective there's no distinction; from the layering's perspective, **the provider layer is the testability seam by design**. The fakes aren't a separate "mock layer" bolted on — they're a second flavor of provider, parallel to the production one. That's why the interface/provider split is in the architecture rather than added as an afterthought when tests get hard to write.
+
+---
+
+## 7. Services
+
+Services are **adapters** between protocol-side traits (defined in a chip-agnostic core) and driver methods. They are thin:
+
+```rust
+// Protocol-side trait, defined in the chip-agnostic core:
+pub trait SomeBus {
+    fn send(&mut self, payload: Payload);
+    fn poll(&mut self) -> Option<Request<'_>>;
+}
+
+// Chip-specific service:
+pub struct SomeBusAdapter;
+
+impl SomeBus for SomeBusAdapter {
+    fn send(&mut self, payload: Payload) {
+        let _ = unsafe { Drivers::top() }.send(|buf| serialize(payload, buf));
+    }
+
+    fn poll(&mut self) -> Option<Request<'_>> {
+        unsafe { Drivers::top() }.poll()
+    }
+}
+```
+
+(`send` carries data, not scheduling — see §7.4. The driver derives wire timing from the request it polled. `poll` returns decoded protocol-domain values, not raw bytes — anything wire-shaped stays in the driver.)
+
+That's the whole service. Each method:
+
+1. Acquires access to the driver.
+2. Translates protocol-level arguments to driver method calls.
+3. Translates the driver result back to the protocol-level return type.
+
+(Services and providers both adapt between two type universes — that's the family resemblance with hexagonal-architecture adapters. The two roles don't conflict: §5 **providers** bridge driver interfaces to HAL; **services** here bridge protocol traits to driver methods. The struct name `SomeBusAdapter` is convention for service implementations; it's a name choice, not a layer identifier.)
+
+### 7.1 The 1:1 rule
+
+> **Each service binds to exactly one top-level driver.**
+
+If a service needs to call methods on two different top-level drivers to fulfill its trait, that's the no-peer-to-peer rule (§4.2) telling you to compose those drivers into a higher one. The 1:1 rule keeps services trivial: every method has exactly one driver to delegate to.
+
+### 7.2 Why services aren't drivers
+
+The temptation to skip the service layer and have drivers implement the protocol traits directly is real. The reason not to:
+
+- Drivers live in the chip-specific tree (knows about registers, DMA channels, IRQ priorities).
+- Protocol traits live in the chip-agnostic tree (knows about packet formats, schedule semantics).
+- Mixing them couples the driver to the protocol, defeating the chip-agnostic split.
+
+The service layer is the *anti-corruption layer* between two type universes. It's thin because the only thing it does is type translation; the work is in the driver, the policy is in the protocol stack. Both ends stay clean.
+
+### 7.3 Cross-domain orchestration
+
+> **Orchestration that spans multiple devices lives at the protocol layer (or main loop), not in any driver.**
+
+Example: a control-table Write touches a configuration field that should both be persisted to non-volatile storage *and* trigger a runtime reconfiguration. The protocol layer's Write handler does:
+
+```rust
+self.persist.stage(addr, bytes)?;
+if addr == BAUD_ADDR { self.events.send(Event::SetBaud(decode(bytes))); }
+self.bus.send(Status::Empty { /* ack */ }, schedule);
+```
+
+Three service calls. None of the underlying drivers know the other exists. The orchestration knowledge — "this address means persist and also signal" — is protocol-level, so it lives at the protocol layer.
+
+This is the same rule as §4.2 stated from the other direction: drivers don't reach across; the layer that knows about both concerns is responsible for the coordination.
+
+### 7.4 Data-centric trait surfaces
+
+Service traits should be **data-centric** — methods carry *what* to do, not *how to position it on the wire*. Scheduling, slot positioning, retry timing, framing details, and any other "where/when on the wire" concern belongs inside the driver whenever the driver has the cached request state to derive it.
+
+The driver already holds the request that drives the response (the polled token, the parsed command, the wire-end tick). Extending that cache to derive positioning is natural and keeps the service trait protocol-shape pure. The dispatcher then reads as straight protocol logic — every method call is "reply with this Status" or "reply with this slot," and nothing about timing or framing leaks into the protocol layer.
+
+A trait method *should* take a scheduling parameter when the protocol genuinely lets the consumer decide — a retry policy chosen by the caller, a deadline that originates above the driver, a deferred-send queue the protocol layer manages. When the protocol determines the schedule from the *received request* — slot positioning, response delay, chain-CRC anchor — the driver derives it from cached state and the trait stays clean.
+
+Symptom of the wrong split: a `Schedule` struct (or analogous record of "where on the wire") threaded through every send method. If the driver can compute that struct from state it already keeps for other reasons, the parameter is leaking driver knowledge into the service interface.
+
+When the cached request and reply path touch disjoint parts of driver state, §4.3 covers the implementation seam.
+
+---
+
+## 8. Hardware demultiplexing
+
+The IRQ vector binding file is structurally minimal: each ISR is a small dispatcher that reads the hardware status register, classifies into logical events, and calls into one or more drivers.
+
+```rust
+// runtime/isr.rs — vector binding
+pub fn on_some_peripheral() {
+    let status = peripheral_status();
+    let driver = unsafe { Drivers::top() };
+
+    if status.condition_a() { driver.on_condition_a(); }
+    if status.condition_b() { driver.on_condition_b(); }
+    if status.condition_c() { driver.on_condition_c(status.detail()); }
+}
+```
+
+Two things this file does:
+- Resolves the hardware vector to a driver.
+- Splits a multi-source IRQ into discrete logical events.
+
+It is **not** the place to:
+- Mutate driver state.
+- Make routing decisions between drivers.
+- Hold its own state across invocations.
+
+If an ISR is doing more than the dispatcher shape above, the work probably belongs inside the relevant `on_*` method on the driver. If routing complexity is creeping into the ISR (e.g., "if driver A's method returns X, then call driver B"), it belongs in the composite driver's `on_*` method, not in the ISR.
+
+### 8.1 Single-source IRQs
+
+When an IRQ has a single logical source (a dedicated timer compare match, a dedicated DMA channel), the ISR collapses to one line:
+
+```rust
+pub fn on_dedicated_timer() {
+    unsafe { Drivers::top() }.on_deadline();
+}
+```
+
+In hot-path cases where the dispatcher's overhead matters, the ISR can call the relevant sub-driver directly instead of going through the composite. This is a deliberate exception to the composition rule and should be commented as such — it's an optimization, not the default shape.
+
+---
+
+## 9. Registries and facades
+
+Driver types are pure (no statics) and provider types are decision-free at the import site (peripheral choice is hidden inside the file). Production firmware still needs two pieces of orchestration: a place to hold installed driver *instances* and reach them from ISRs (§9.1, the **driver registry**), and a single entry point for hardware setup + deferred IRQ enable (§9.4, the **provider facade**). §9.5 states the HAL access rule that keeps both layers honest.
+
+### 9.1 The driver registry
+
+Driver types are pure: they own state, expose methods, and know nothing about being singletons. Production firmware still needs a place to hold installed driver *instances* and a way to reach them from ISRs and main-loop code. That place is the **registry** — a single facade type that owns one static cell per instance and exposes typed accessors.
+
+```rust
+use core::cell::SyncUnsafeCell;
+
+struct Cells {
+    top: SyncUnsafeCell<Option<Top>>,
+    aux: SyncUnsafeCell<Option<Aux>>,
+}
+
+static CELLS: Cells = Cells {
+    top: SyncUnsafeCell::new(None),
+    aux: SyncUnsafeCell::new(None),
+};
+
+pub struct Drivers;
+
+impl Drivers {
+    /// SAFETY: bringup-only, pre-IRQ; sole writer. Must be called exactly once.
+    pub unsafe fn install(/* construction args */) {
+        // SAFETY: see fn doc.
+        let top = unsafe { &mut *CELLS.top.get() };
+        debug_assert!(top.is_none(), "Drivers: top already installed");
+        *top = Some(Top::new(/* args */));
+
+        // SAFETY: see fn doc.
+        let aux = unsafe { &mut *CELLS.aux.get() };
+        debug_assert!(aux.is_none(), "Drivers: aux already installed");
+        *aux = Some(Aux::new(/* args */));
+    }
+
+    /// SAFETY: bringup installs `top` before any ISR runs; access follows
+    /// the driver's IRQ-priority contract documented at the call site.
+    #[inline(always)]
+    pub unsafe fn top() -> &'static mut Top {
+        // SAFETY: see fn doc.
+        let cell = unsafe { &mut *CELLS.top.get() };
+        debug_assert!(cell.is_some(), "Drivers::top() before install");
+        // SAFETY: bringup ensures Some before any ISR fires.
+        unsafe { cell.as_mut().unwrap_unchecked() }
+    }
+
+    // ...one accessor per instance.
+}
+```
+
+The shape has three properties worth naming:
+
+- **Driver types are decoupled from singleton lifecycle.** A driver named for its *mechanism* — a generic LED controller, a generic counter — can be instantiated as many times as the firmware needs. Adding a second instance is one cell + one accessor; the driver type doesn't change. (Before this split, drivers that hosted their own static cell tended to absorb their usage into the type name — "status LED" instead of "LED" — because the type *was* the singleton.)
+- **Each instance has its own cell, not a shared `&mut Drivers`.** This preserves borrow independence: an ISR mutating one driver and the main loop mutating another don't pass through a shared mutable reference to the registry, so there's no aliasing UB even at the conceptual level. The registry struct itself is a ZST; the cells are the storage.
+- **Tests bypass the registry entirely.** Unit tests construct driver types directly with fake providers — no `install`, no `get`, no `unsafe`. The registry is a production-only artifact for singleton management; the testability seam from §5–§6 is unaffected by it.
+
+The two-layer `Option<Driver>` inside each cell keeps the driver type itself honest: `Driver::new(...)` never returns a half-constructed object. The "is it installed?" question is asked once per access, at the registry accessor, `debug_assert`-checked in dev / `unwrap_unchecked` in release (sound because bringup must run before any IRQ).
+
+### 9.2 Access discipline
+
+The discipline beyond install depends on the runtime model. For a no-RTOS firmware where ISRs share a single priority level and don't preempt each other (or use cooperative scheduling), the rules are:
+
+- **From an ISR at the shared priority**: `Drivers::foo()` is safe because no other code at the same priority can preempt.
+- **From the main loop**: `Drivers::foo()` is safe only after disabling the relevant ISRs around the access, OR if the access only touches state the ISRs never mutate (read-only accessors are usually safe without IRQ masking; mutating commands typically need a masked critical section).
+
+Every `unsafe { Drivers::foo() }` site is making a contract claim. The discipline is:
+
+1. State the contract once, in the accessor's `SAFETY:` doc comment.
+2. Site-level comments only when the call site deviates from the default discipline.
+3. Restrict all mutation to driver methods (no raw field access from outside).
+
+If the project uses RTIC, an async executor, or another framework that provides safer ownership patterns, those should be preferred. The registry + `SyncUnsafeCell<Option<Driver>>` cells is the floor — it works without runtime support but requires discipline.
+
+### 9.3 Cross-cell coordination
+
+Most coordination happens through the composite-driver routing in §4. The remaining cases are where two genuinely independent top-level drivers need to exchange a value — and per §4.2, that should be rare. When it does happen, the channel is one of:
+
+- An atomic flag/counter, when the value is a scalar.
+- A small lock-free queue or `SyncUnsafeCell<Option<T>>` with seqlock semantics, when the value is a struct.
+
+These cross-cell channels live alongside the registry's instance cells but aren't *of* it — the registry holds driver instances, not communication channels. If you find yourself adding more than one or two channels, the architecture is telling you to reconsider whether the two drivers should be composed.
+
+### 9.4 The provider facade
+
+The provider facade mirrors the driver registry, but for *hardware setup* rather than *runtime access*. Bringup goes through a single entry point that orchestrates every provider's init in a fixed order, then runs `Drivers::install` to populate cells, then enables IRQs last.
+
+```rust
+pub struct Provider;
+
+impl Provider {
+    /// SAFETY: bringup-only, called exactly once before Drivers::install.
+    /// Sets up hardware; does NOT enable IRQs.
+    pub unsafe fn init(/* wiring, defaults */) {
+        // System providers — chip-wide preconditions
+        clocks::Clocks::init();
+        pins::Pins::init(/* wiring */);
+        interrupts::Interrupts::init();
+
+        // Driver providers — peripheral clock-gate enable + mode/config writes
+        monotonic::Monotonic::init();
+        dma_ring::DmaRing::init();
+        usart_baud::UsartBaud::init(/* baud */);
+        clock_trim::ClockTrim::init();
+        // Multi-instance providers (e.g., digital_out per pin) are constructed
+        // inside Drivers::install, not here.
+    }
+
+    /// SAFETY: call AFTER Drivers::install. Cells must be populated before
+    /// any vector unmasks.
+    pub unsafe fn enable_irqs() {
+        dma_ring::DmaRing::enable_irq();
+        usart_baud::UsartBaud::enable_irq();
+        // …one call per provider that fires an IRQ
+    }
+}
+```
+
+Bringup collapses to three lines with a structural contract:
+
+```rust
+pub unsafe fn bringup(/* wiring, defaults */) {
+    Provider::init(/* … */);          // hardware powered + configured
+    Drivers::install(/* … */);        // handlers ready
+    Provider::enable_irqs();          // IRQs hot
+}
+```
+
+The contract: *hardware powered + configured → handlers ready → IRQs hot.* Hard to get the order wrong.
+
+Three intentional asymmetries vs the driver registry:
+
+- **No cells, no storage.** Provider types are zero-sized; nothing to store. `Provider` is a pure namespace + init entry point.
+- **No accessors.** `Drivers::install` reaches directly into provider types (e.g., `provider::monotonic::Monotonic`) to construct driver instances. Routing those through `Provider::monotonic()` would just rename the same unit struct.
+- **`init` vs `install` verb.** `install` implies storage (cells); `init` implies setup. Layer names stay symmetric (`Provider` ↔ `Drivers`); method verbs differ because the work differs.
+
+**Init-order discipline.** System providers run first (clock tree must exist before any peripheral is configured; pin modes must be set before any peripheral that drives those pins comes up). Driver providers follow. Each driver provider's `::init()` performs the clock-gate enable + peripheral configuration writes; IRQs stay masked. After `Drivers::install` populates cells, `Provider::enable_irqs` unmasks vectors.
+
+### 9.5 Chip-agnosticity boundary
+
+Drivers stay chip-agnostic because they have no path to chip-specific types. The enforcement model differs by packaging:
+
+**Single-crate firmware.** Chip-agnosticity is a code-review convention: `hal::*` imports are confined to the `provider/` layer; a `use crate::hal::` outside `provider/*` is a layering violation. The rule is mechanically grep-able and amenable to lint enforcement, but its weight rests on review discipline.
+
+**Multi-crate firmware (recommended for long-lived projects).** Chip-agnosticity is a `cargo build` invariant. The driver crate (`<project>-drivers`) has no dependency on the chip-family crate, so it physically cannot import HAL. Within the chip-family orchestration crate, HAL is just an internal module — providers, runtime, and ISR bodies all consume it as needed. There is no within-crate HAL access rule; the boundary that matters is the crate edge.
+
+The multi-crate form is preferred where chip-agnosticity actually matters because the invariant is structural rather than social. Review still catches local quality issues (provider ergonomics, leaky type signatures), but the foundational property — drivers cannot see HAL — holds without anyone having to check.
+
+Three downstream properties hold under either form:
+
+- **Drivers stay generic** over their trait bounds, so unit tests substitute `Fake` providers without touching driver code.
+- **Chip variants land in providers** (§5.6), in `cfg/` (board-wiring schema), and in `hal/types.rs` (chip-family enums) — not in driver bodies. §2.5 covers the variant-routing pattern across all three layers.
+- **Bringup carries no chip knowledge of its own.** Its body names which providers exist and the order they init in — not which registers they touch.
+
+**ISR vector bodies** (§8) dispatch through `Drivers::*` to driver methods. In the multi-crate form, ISR bodies live in `runtime/isr.rs` inside the orchestration crate and import HAL directly to ack hardware flags (read NDTR, clear HT/TC, sample EXTI pin) — unrestricted within the orchestration crate. In the single-crate form, ISR HAL access is typically routed through a provider method to keep the within-crate rule local. The ISR's job — dispatch to a driver — is the same either way; only the ack code's home differs.
+
+---
+
+## 10. Worked example — abstract UART bridge
+
+Hypothetical: a chip implements a serial protocol over a UART, with a half-duplex direction-control GPIO, hardware-timed transmit triggering from a timer, and clock-drift calibration based on observed receive timing.
+
+The hardware concerns:
+- UART RX and TX framing.
+- A timer that schedules TX firing.
+- A GPIO that gates the half-duplex direction.
+- A clock-rate calibration loop based on RX byte arrival timing.
+
+The protocol concerns (in a chip-agnostic core):
+- Decode incoming packets, dispatch to handlers, emit replies.
+- Decide when to persist configuration changes.
+
+### 10.1 Mapping to drivers
+
+The hardware concerns compose into one top-level driver because they share the UART's timing model:
+
+```
+drivers/
+  bus/
+    mod.rs       Bus composite — routes events between sub-drivers
+    rx.rs        BusRx — RX byte buffer, IDLE detection, drift observation
+    tx.rs        BusTx — TX buffer, fire scheduling, direction GPIO
+    clock.rs     BusClock — rate constants, pending re-tune values
+```
+
+Each sub-driver exposes pure methods. The composite (`Bus`) has them too, but its bodies route between children rather than mutating leaf state:
+
+```rust
+impl Bus {
+    pub fn on_uart_idle(&mut self) {
+        if let Some(wire_end_tick) = self.rx.on_uart_idle() {
+            // Wire-end is the input to TX's fire scheduling.
+            self.tx.on_wire_end(wire_end_tick);
+        }
+    }
+
+    pub fn on_timer_match(&mut self) {
+        self.tx.on_fire_deadline();
+    }
+
+    pub fn on_uart_tc_completed(&mut self) {
+        if self.tx.on_tc_completed().released() {
+            self.clock.apply_pending();
+        }
+    }
+
+    pub fn on_uart_rx_error(&mut self, flags: RxErrorFlags) {
+        self.rx.on_error(flags);
+    }
+
+    pub fn send_reply<F>(&mut self, writer: F) -> Result<(), BusError>
+    where
+        F: FnOnce(&mut [u8]) -> usize,
+    {
+        // The Bus already cached the request that produced this reply
+        // (`self.rx.last_request()`), so it derives wire-end tick + slot
+        // offset + chain-CRC anchor internally. The caller hands data; the
+        // bus places it. See §7.4 for the underlying principle.
+        self.tx.arm(writer).map_err(BusError::Tx)
+    }
+
+    pub fn stage_baud(&mut self, rate: BaudRate) -> Result<(), BusError> {
+        self.clock.stage_baud(rate).map_err(BusError::Clock)
+    }
+
+    pub fn rx_window(&self) -> Option<&[u8]> {
+        self.rx.window()
+    }
+}
+```
+
+The wire diagram is one file's worth of method bodies. Reading the `Bus` impl tells you every cross-component interaction in the system. Sub-drivers stay independent and unaware of each other.
+
+### 10.2 Mapping to providers
+
+Each driver-trait the `Bus` sub-drivers consume has a provider file under `provider/`:
+
+```
+provider/
+  monotonic.rs      Monotonic    — tick source for fire scheduling
+  usart_baud.rs     UsartBaud    — claims the UART and sets baud
+  dma_ring.rs       DmaRing      — claims a DMA channel for the RX byte ring
+  digital_out.rs    DigitalOut   — drives the TX-direction GPIO (multi-instance)
+  clock_trim.rs     ClockTrim    — applies clock-rate trim steps
+  clocks.rs         Clocks       — (system) clock tree
+  pins.rs           Pins         — (system) pin modes per board wiring
+  interrupts.rs     Interrupts   — (system) IRQ controller base
+```
+
+The orchestrator collapses bringup to three lines:
+
+```rust
+pub unsafe fn bringup(wiring: &Wiring, defaults: &Defaults) {
+    Provider::init(wiring, defaults);   // hardware powered + configured
+    Drivers::install(wiring, defaults); // handlers ready
+    Provider::enable_irqs();            // IRQs hot
+}
+```
+
+If the example were ported to a second chip variant where the UART is on a different peripheral block, only `provider/usart_baud.rs` (and possibly its `vNNx.rs` sub-files per §5.6) changes. `drivers/bus/*` is untouched.
+
+### 10.3 Mapping to ISRs
+
+```rust
+// runtime/isr.rs
+pub fn on_uart() {
+    let status = uart_status();
+    // SAFETY: see Drivers::bus.
+    let bus = unsafe { Drivers::bus() };
+    if status.has_rx_error() { bus.on_uart_rx_error(status.rx_flags()); }
+    if status.idle()         { bus.on_uart_idle(); }
+    if status.tc()           { bus.on_uart_tc_completed(); }
+}
+
+pub fn on_timer_compare() {
+    unsafe { Drivers::bus() }.on_timer_match();
+}
+```
+
+Two ISRs. Combined: about a dozen lines. Each does one thing and reads as one thing.
+
+### 10.4 Mapping to a service
+
+```rust
+// services/bus.rs
+pub struct BusAdapter;
+
+impl ProtocolBus for BusAdapter {
+    fn rx_window(&mut self) -> Option<&[u8]> {
+        unsafe { Drivers::bus() }.rx_window()
+    }
+
+    fn send(&mut self, packet: Packet<'_>, schedule: Schedule) {
+        let _ = unsafe { Drivers::bus() }.arm_reply(
+            |buf| serialize(packet, buf),
+            schedule,
+        );
+    }
+}
+```
+
+The protocol layer's dispatcher consumes `ProtocolBus`, knowing nothing about UARTs, timers, or GPIOs. The service is purely type translation. If the same protocol runs on a different chip with different peripherals, only the providers (and possibly the driver, if the hardware concerns diverge enough) change — the protocol stack is identical.
+
+---
+
+## 11. Related patterns and origins
+
+This convention is a synthesis of established patterns rather than a novel design. The components map roughly as:
+
+- **Command Query Responsibility Segregation (CQRS).** The mutating-command / read-only-query split. Commands here are pure methods rather than reified message objects, but the read/write separation is the same. Long established in distributed systems and DDD.
+- **Domain events.** `on_*` methods are the *intake* of domain events; their return values are the *output*. Mealy-machine outputs from event-sourced systems map directly.
+- **Hexagonal architecture / Ports and Adapters.** Drivers are the domain core; the interface/provider split in §5 is a direct application of Cockburn's ports-and-adapters at the module level. The "interface" in this doc corresponds to a "port" in hexagonal vocabulary; what hexagonal calls an "adapter" this doc calls a **provider** — the rename emphasizes the role-shaped naming convention (the file lives at the role's name, the type lives at the role's name) and avoids the term collision with services. Services play the analogous role one layer up, adapting protocol traits to driver methods.
+- **DDD aggregates.** A composite driver is an aggregate root; sub-drivers are entities reachable only through the aggregate. The "no sibling access" rule is the aggregate-boundary rule.
+- **Active Object** (Samek, *Practical Statecharts in C/C++*). The most embedded-specific analog: each active object is a state machine with an event queue, composed hierarchically, with no direct peer access. Used heavily in safety-critical embedded.
+- **Four-layer chip stack.** The services / drivers / providers / HAL split is more structured than the typical drivers-on-top-of-HAL embedded layering. The provider layer is the explicit dependency-inversion seam: drivers depend on interfaces they themselves define, not on HAL, which is what makes driver logic testable without hardware *and* what makes drivers chip-agnostic by construction (chip choice lives in providers, not drivers).
+
+In actor-based frameworks (Erlang/OTP, Akka, Drogue Device), the same shape appears with asynchronous message passing instead of synchronous method calls. The shape is the same; the runtime is different. This pattern is the *synchronous* application of actor-style discipline, which fits firmware where the cost of queues and an executor outweighs their decoupling benefit.
+
+If a single reference best captures the embedded version of this pattern: Miro Samek's *Practical UML Statecharts in C/C++*. The active-object + hierarchical-state-machine + no-peer-access combination is articulated there, in C, with deep treatment of the embedded constraints (memory, latency, determinism).
+
+---
+
+## 12. When this pattern fits, and when it doesn't
+
+### 12.1 Use it when
+
+- The firmware has three or more peripherals that interact non-trivially.
+- A protocol stack lives above the peripherals and needs to remain chip-agnostic.
+- Multiple ISRs share state and the coordination is already painful or about to become so.
+- The codebase has a multi-year lifetime — discipline upfront amortizes well.
+- You want driver logic covered by host-side unit tests rather than relying solely on hardware integration tests.
+- The team will grow, or onboarding new contributors is a concern. The pattern is unusually self-documenting because reading any one file gives a complete picture of one concern.
+
+### 12.2 Don't use it when
+
+- The firmware is small enough that a single struct with methods would do. A blinker, a thermostat, a one-peripheral data logger — the ceremony costs more than it saves.
+- The project uses a framework (RTIC, Embassy with async, Zephyr) that provides better ownership and scheduling primitives. Use those instead. The pattern is the floor for "no framework available"; frameworks raise the floor.
+- The hot path is so tight that even the dispatch overhead of `Top::on_event_x()` matters. (For most ISR work this isn't true — the dispatch is a tail call. But cycle-budget-bound ISRs may need to inline directly into sub-drivers, breaking the composite-routing rule as a deliberate optimization.)
+- The protocol layer is trivial or absent. The service-as-adapter benefit only pays off when there's a chip-agnostic protocol on the other side. Without one, services are bureaucracy.
+
+### 12.3 Trade-offs to accept
+
+- **Translation boilerplate.** Return values flow as primitives between drivers, which means flattening structs at one boundary and rebuilding (or consuming field-by-field) at the next. Most of this is a few lines per transition.
+- **Discipline-by-convention, not by compiler.** The contract is a naming convention. Rust can't enforce "no sibling sub-driver access," "services are 1:1 with top-level drivers," or "use `on_*` for hardware events." A doc-comment per module stating the convention plus code review is the enforcement mechanism. A team that doesn't read the convention will erode it; one that does will find the pattern self-reinforcing.
+- **Generic-parameter propagation.** Drivers carry one type parameter per interface they consume; composites carry the union. A `pub type` alias hides the verbosity at production call sites, but compile errors and IDE hovers show the long form. The cost is paid in compile-time verbosity, not runtime: production providers are typically zero-sized, so monomorphization plus `#[inline]` makes the provider dispatch identical to a direct HAL call.
+- **One more layer of files.** The provider layer adds one file per driver-trait role (plus the fake alongside, cfg(test) in the same file). The cost is fixed — providers don't grow per driver — and it buys the testability seam, but it's a real addition to the file tree.
+
+---
+
+## 13. Summary
+
+Six rules:
+
+1. **Drivers own hardware state.** Expose pure methods: `on_*` for hardware events (named for the logical event, not the peripheral that delivered it), descriptive names for commands, accessors for stable observations. Programmer-error invariants are `debug_assert!`s; runtime failures return `Result`.
+2. **Composite drivers route between sub-drivers.** Sub-drivers are reachable only through the parent.
+3. **Top-level drivers do not communicate with each other.** If two would need to, compose them into a higher driver.
+4. **Services adapt protocol traits to drivers.** Each service binds to exactly one top-level driver. Services are thin, and their trait surfaces stay **data-centric** (§7.4) — driver-derivable scheduling and wire-positioning info stays inside the driver.
+5. **Cross-domain orchestration lives at the protocol layer**, never in drivers.
+6. **Drivers are generic over driver-defined interfaces; providers implement them.** Production providers wrap HAL calls; fake providers record calls for tests. Driver logic is unit-testable on the host without hardware, and drivers are chip-agnostic by construction (chip choice lives in providers).
+
+Four layers, top to bottom:
+
+- **Services** — adapt protocol traits to driver method calls.
+- **Drivers** — hierarchical pure types with pure-method APIs, generic over their interfaces. No statics, no `install` / `get` on the type. Chip-agnostic.
+- **Providers** — implement driver interfaces over HAL primitives (production) or recording stubs (test); role-shaped file and type names; own per-peripheral init including clock-gate enable.
+- **HAL** — peripheral-IP-shaped register access and resource identifiers, cfg-gated when IP version differs across chips.
+
+Plus three orthogonal facades:
+
+- **Driver registry** (§9.1) — owns one static cell per driver *instance* and exposes typed accessors. The only place that knows which type plays which singleton role.
+- **Provider facade** (§9.4) — single entry point for hardware setup (`Provider::init`) and deferred IRQ enable (`Provider::enable_irqs`). Bringup is three lines: `Provider::init → Drivers::install → Provider::enable_irqs`.
+- **IRQ vector binding** — hardware demux that routes interrupt sources to driver methods via the registry.
+
+The result is firmware where reading any one file gives you a complete picture of one concern, the wire diagram between concerns lives in composite-driver method bodies, the protocol layer stays unaware of any specific peripheral, drivers are unaware of any specific chip, and driver logic is exercisable by host-side unit tests.
+
+For projects with multi-chip support or quality goals that benefit from build-time enforcement of layering, the chip-family crate becomes an **orchestration crate** (§2.4) that composes HAL, providers, services, the driver registry, ISRs, and bringup into a running system. Driver state machines and their trait surface live in a pure library crate; chip-agnosticity becomes a `cargo build` invariant rather than a code-review convention. §2.5 covers the orchestration crate's internal module layout.

--- a/docs/osc-native-protocol.md
+++ b/docs/osc-native-protocol.md
@@ -1,0 +1,777 @@
+# OSC-Native Protocol
+
+The normative specification of the osc-native servo-bus protocol:
+break-framed, 5 overhead bytes per frame, hardware-CRC-friendly, designed
+to run whole on sub-$0.20 MCUs. Every physical-layer behavior the design
+leans on was measured on real silicon (V006 servo, V203 HSE host); the
+measured facts are collected in §11 and cited inline as [F1]..[F15].
+
+## 1. Goals and non-goals
+
+The philosophy in one line: **an efficient wire and a quick turnaround —
+low latency as the product of both.** Spend the fewest bytes per exchange,
+and never make the wire wait on the CPU. Simplicity is the mechanism, not
+a trade-off: every byte and every microsecond this protocol saves over
+DXL comes from deleting machinery, not adding it.
+
+Goals, in priority order:
+
+1. **Simplicity** — the servo-side transport should be a two-state framer, a
+   counted DMA ring, and a dispatcher. No per-byte parsing, no byte stuffing,
+   no unstuffing pass, no hardware-timed reply grid, no RDT tuning surface.
+2. **Wire efficiency and turnaround** — 5 overhead bytes + a break per
+   frame (DXL: 10–12 plus stuffing), and length is known two bytes in, so
+   dispatch and reply staging overlap the instruction's own wire time; the
+   reply's first byte waits on nothing — not a completed encode (streaming
+   TX), not a folded CRC (hardware CRC engine), not a reply grid
+   (enable-when-ready).
+3. **Cheap-MCU fit** — everything must run on the V006 tier: one UART, one
+   DMA ring, the SPI block as a CRC engine, no input capture, no crystal.
+4. **Recoverability in the field** — a servo must be reachable regardless of
+   its configured baud or ID (rescue break, UID enumeration).
+
+Non-goals: DXL wire compatibility; multi-host arbitration (a single host
+schedules the bus); encryption/auth.
+
+## 2. Physical layer
+
+Single-wire half-duplex TTL bus, 3.3 V, host-scheduled (exactly one talker
+at any time by protocol construction).
+
+- **Servo pin**: the USART TX pin with `HDSEL` (single-wire mode). RX is
+  internally tied to the pin; the direct wire needs no dedicated RX pin and
+  no direction buffer [F7] — rev C omits both. Bus side: series R +
+  pull-up (+ optional TVS); the buffer's roles collapse into the drive
+  discipline below.
+- **Buffered boards (rev B)**: the default board config (`half-duplex`
+  selects the direct wire — tinyboot's flag, same convention).
+  The USART runs plain full duplex behind the 74LVC2G241: TX drives only
+  the buffer input (push-pull, never released), and TX_EN gates the wire —
+  high drives TX onto the data line and hardware-mutes the receive path
+  (inverted enable, same signal), low releases it to the board pull-up.
+  Same observables as HDSEL: no own-TX echo, RX held at mark through the
+  TX window. The drive discipline below applies to the wire side of the
+  buffer — TX_EN assert is the claim, TX_EN release the handback.
+- **Drive discipline (all nodes, host included)**: idle/listening = AF
+  open-drain (wire released, pull-up holds mark); transmitting = AF
+  push-pull for the duration of the frame, then release. One GPIO CNF write
+  each way. A node that idles push-pull clamps every other talker [F8] —
+  this rule is the buffer replacement, not an optimization.
+- **Own-TX echo**: none on V006 — HDSEL gates RX during TX [F9]. Firmware
+  never needs echo masking. (Chips that do echo would mask in the framer;
+  the protocol itself is agnostic.)
+- **Baud**: operational baud is a config register selecting from
+  **{0.5 M, 1 M, 2 M, 3 M}**, default **1 M**. DXL's legacy low rates are
+  pointless on this bus — recovery is the rescue break's job (§9.1), not a
+  crawl-speed fallback. Servos run HSI; the host must be crystal-clocked.
+  Measured margin: the V006 cannot be detuned far enough (±3.4 % full
+  HSITRIM throw) to break 3 M framing or data in either direction [F10] —
+  ≥3× the trimmed-HSI ±1 % budget, and lower rates only widen it.
+- **Rescue baud**: 0.5 M — the floor of the option set, not a fifth rate.
+  Rescue must work anywhere the protocol can work at all: a bus that can't
+  carry the lowest operational rate can't run any configuration either, so
+  the floor is by construction sufficient. Entered only via rescue break
+  (§9.1).
+
+## 3. Framing
+
+A frame is delimited by a **UART break**. **Protocol law: a transmitted
+break is exactly 10 bit-times dominant — one character time.** The shape
+is one 9-bit `0x00` character (M=1, bit 8 = 0): start + 9 data lows =
+10 low bit-times, then a clean stop bit. Unforgeable by data (every UART
+byte contains a high stop bit within 10 bit-times); no sync header, no
+byte stuffing, no content restrictions.
+
+Why a law and not a floor: break ≡ one character time keeps every
+timing model exact — the framer's footprint algebra and the §9.3
+chain-pair gates count the break as one byte slot, so an over-long
+break is a constant error tax on every span — and the law shape is
+precisely the LIN break definition (LBDL=0), so any LIN-capable
+receiver gets hardware break detection with a deterministic 10-bit
+anchor. Every node on the bus uses it: the pirate, bridge-class hosts,
+and the servo itself (LBD-sans-LINEN break wake, §3.4 — the detector
+runs with the LIN engine off on the target silicon [F15]). Hardware
+`SBK` is off-law (~14 bit-times measured, F5).
+
+**Receivers stay length-tolerant**: any ≥10-bit dominant span is one
+break (rescue pulses, garble, and F3 all require this). Both ends
+transmit the law shape: the host sends it directly, and the V006 reply
+path sends the bracketed-M `0x00` character rather than hardware `SBK`
+(same blocking shifter contract, 3 bits shorter).
+
+Measured break behavior that the framer relies on:
+
+- The break detector (LBD, LINEN off) fires 1:1 per law break and the
+  break rings as exactly one `0x00` byte via DMA [F15][F1][F2].
+- A break of _any_ length is exactly one event — the detector re-arms only
+  on a fresh falling edge, so long breaks cannot spam [F3][F15].
+- A mid-frame framing error does not halt reception: the garbled byte
+  rings and the stream continues [F4] — and it raises nothing at all
+  (sub-10-bit lows are invisible to the detector, and no interrupt is
+  enabled on the error flags, §3.4 [F15]). Ring + NDTR are the only
+  ground truth.
+- Hardware `SBK` sends ~14-bit breaks (4.7 µs at 3 M, zero variance,
+  both chip families) [F5] — which is why the law shape is a 9-bit
+  `0x00` character, not `SBK`; receivers accept both (≥10 = break).
+
+### 3.1 Frame anatomy
+
+Both directions use one shape (symmetric framing keeps the framer identical
+for hosts, servos, and chain-snooping peers):
+
+```
+BREAK | ID | LEN | INST | payload[0..p] | CRC_lo | CRC_hi
+```
+
+- `ID` — 1 byte. `0x01..0xF9` unicast, `0xFE` broadcast, `0x00`/`0xFF`
+  invalid (never valid on the wire: `0x00` is the break's ring byte, `0xFF`
+  is idle-line noise), `0xFA..0xFD` reserved. In status frames, `ID` is the
+  responder's ID.
+- `LEN` — u8: count of bytes following it (`INST` + payload + CRC =
+  `3 + p`, any value ≥ 3). Frame end is knowable at byte 2:
+  `end = len_pos + 1 + LEN`. Max payload is 252 bytes — deliberately
+  sized so the largest legal frame (258 ring bytes) fits whole in the RX
+  ring, which deletes chunked consumption from the framer (§4.1) and all
+  per-transfer capability limits (§5.1). Fleet-scale group ops fit
+  comfortably (§5.1); bigger transfers split into frames. A corrupted
+  `LEN` cannot wedge the framer: the frame fails CRC at deadline B, and
+  any subsequent break re-anchors (the break wake fires in LOCKED too).
+- `INST` — bit 7: `0` = instruction, `1` = status (snoopers classify frames
+  without state; there is no status opcode). Instructions: bits [6:4]
+  opcode, bits [3:0] flags (§5). Status: bits [6:2] result code, bit 1
+  reserved (0), bit 0 = ALERT (§5.3).
+- `CRC` — little-endian osc-CRC-16 (§3.2) over the frame bytes
+  `ID .. payload`.
+
+### 3.2 osc-CRC-16
+
+The covered bytes are **the frame bytes `ID, LEN, INST, payload`** —
+`3 + p` bytes, any parity, in natural wire order. Over that span:
+
+**CRC-16/ARC**: poly `0x8005` reflected (table form `0xA001`), init
+`0x0000`, reflected input and output, no output XOR. Check value:
+`crc("123456789") = 0xBB3D`. This is the textbook CRC-16 — any catalog
+implementation works verbatim; no prefix, no byte swapping, no framing
+quirks.
+
+Hardware rationale: the V006 SPI CRC unit in **16-bit LSB-first mode**
+(poly register `0x8005`) shifts each little-endian halfword low byte
+first, low bit first — the exact bit order the UART itself puts on the
+wire — so DMA feeds the byte buffer unmodified and the engine computes
+the reflected CRC natively, accumulating across split DMA arms (ring
+wrap), at ~0.36 µs/B wall and ~zero CPU [F6][F11]. The engine's register
+holds the **bit-reversed** checksum (its shifter mirrors the reflected
+algorithm); the chip bit-reverses the 16-bit result once per frame
+(~40 cycles via the multiply trick — no table) when patching TX bytes or
+comparing an RX verdict. Verified on silicon [F6]:
+`TCRCR("12345678") = 0xB93C = bitrev16(ARC = 0x3C9D)`.
+
+The engine's halfword DMA appetite (even start address, whole halfwords
+[F12]) is satisfied **by construction, at any frame parity**, because a
+leading `0x00` is a mathematical no-op under this flavor (`init = 0`:
+zero state shifting zero bits stays zero):
+
+- **Feed start** — the covered span begins at `ID = anchor + 1`, and one
+  of `anchor` / `anchor + 1` is always even. Even anchor: feed from the
+  anchor, the break's ring byte leads as a no-op. Odd anchor: feed from
+  `ID` directly. The break byte is a free alignment shim, included or
+  excluded as parity demands.
+- **Feed end** — a span with a trailing odd byte feeds its even bulk by
+  DMA; the last byte is folded into the read-back CRC state in software
+  (8 reflected shift steps, ~30 cycles — the only software CRC that
+  exists on the servo).
+
+On TX the frame buffer keeps a literal `0x00` at offset 0 for the same
+alignment (CRC DMA reads from offset 0, UART TX DMA from offset 1: one
+buffer, two channel MARs, no copies); an odd payload feeds `p − 1` bytes
+by DMA and folds the last at CRC-patch time. These are silicon
+conveniences, **not protocol**: the wire checksum is defined purely over
+`ID .. payload`, and nothing at the wire level constrains length or
+position parity.
+
+Consequences worth naming: frame anchors may land at any ring parity
+(there is no even-anchor invariant); the RX ring is armed once at boot
+and **never reloaded**; a bare break on the bus is harmless (its lone
+ring byte shifts parity, which does not matter); and a mid-frame FE
+costs at most the one garbled frame [F4].
+
+Test vectors (covered bytes → CRC):
+
+```
+01 03 10                 → 0xFC50  (PING id 1)
+05 07 30 80 01 2C 01     → 0xB3B1  (WRITE id 5, addr 0x0180, data 2C 01)
+03 07 20 00 02 08 00     → 0x7015  (READ id 3, addr 0x0200, count 8)
+02 06 30 00 01 AA        → 0x0D07  (WRITE id 2, addr 0x0100, data AA; p=3, LEN even-legal)
+```
+
+### 3.3 Resync
+
+Any CRC failure, LEN overrun, or framing anomaly drops the frame and
+returns the framer to HUNT; the next break is a hardware resync point.
+There is no FF-FF-FD-style hunting cold path — the break _is_ the hunt.
+A mid-frame FE costs one frame (CRC rejects it), never the stream [F4].
+What a framing anomaly may and may not tell the implementation is
+normative — see §3.4.
+
+### 3.4 Fault contract (normative)
+
+The target silicon exposes two distinct receive-side signals, and the
+protocol binds them to two distinct roles [F15]:
+
+- **The break detector (LBD) is the wake.** It is length-qualified —
+  only a genuine ≥10-dominant-bit span sets it, the exact §3 law shape —
+  it runs with the LIN engine off, it clears by a safe flag-selective
+  write (no data-register access), and any-length span raises exactly
+  one event, **latched at the span's END** (the rising edge; for the
+  10-bit law break that IS bit 10) [F15]. It is the ONLY receive
+  interrupt an implementation enables.
+- **The per-character error flags (FE/ORE/NE) are not events at all.**
+  They are latched, positionless, coalescing, and unsafe to retire
+  mid-stream — so no interrupt is ever enabled on them. They latch
+  silently, self-clear incidentally under DMA drain traffic, and MAY be
+  polled from a cold path as line-noise telemetry; nothing else may read
+  them, and no decision may derive from them.
+
+A real error therefore never interrupts anything. Its consequences
+surface exactly where data-driven handling already looks: a corrupted
+byte fails its frame's CRC verdict (drop + count, no reply, host
+timeout+retry); a noise byte between frames rings into junk the next
+break's resolution scans off; a corrupted LEN mis-strides and dies at
+the next geometry check or CRC. Reception itself never halts on an
+error character [F4].
+
+The contract, binding on every implementation of this protocol:
+
+- **Positions come from ring data only** (§4.1). A break event MUST NOT
+  be assigned a position; no frame may be dropped, killed, or rejected
+  on wake evidence. Data is the only death authority: CRC verdicts,
+  geometry checks, and the starve horizon.
+- **Times come from data-cadence projections only** (`now + missing
+  byte-times`). A wake's arrival time MUST NOT enter any timing grid.
+  (The one exception is the §9.3 trim machinery, whose entire subject is
+  the break-service stamp itself — gated, paired, and baseline-anchored
+  there.)
+- **Breaks are not countable events.** Service can lag the wire, and N
+  breaks can coalesce into one service; all break handling MUST be
+  idempotent, and freshness (did bytes ring since the last service?)
+  MUST be derived from the ring, never assumed.
+
+**The accepted limitation** (the price of break-framed delimiting):
+garble that forms a plausible frame header parks the resolver until data
+kills it — footprint-fill CRC (≤ 258 bytes) or the starve horizon (64
+byte-times of ring silence), whichever comes first, per plausible junk
+anchor. The length qualification shrinks that surface: only garble
+containing a genuine ≥10-bit dominant span (slower-baud traffic heard at
+a faster-configured servo) can wake the resolver into junk at all —
+noise and faster-baud garble ring silently and cost nothing until the
+next real break [F15]. **Host pacing rule:** after traffic a servo may
+have received as garble (wrong-baud probing, bus glitches), allow one
+starve horizon of bus silence before expecting crisp turnarounds; under
+continuous zero-gap retries, replies can lag by up to the parked span
+until a gap appears.
+
+## 4. Servo RX/TX paths
+
+### 4.1 RX framer
+
+One circular RX DMA channel, armed once at boot; NDTR is read as a
+cursor, never reloaded (reloading a circular DMA channel drops or
+latches in-flight requests; and since anchors may sit at any parity,
+§3.2, nothing ever needs a reload). Two states:
+
+- **HUNT** — on the break wake (LBD): record the anchor = current ring
+  position (the `0x00` just ringed). Enter LOCKED.
+- **LOCKED** — deadline A at anchor + 3 byte-times + a half-byte-time of
+  wake slack: the full header (ID, LEN, INST) is in the ring — read it,
+  compute frame end, prime the dispatcher from INST, set deadline B at
+  end + margin. At B: confirm NDTR reached the end, CRC-check, dispatch.
+  Short/failed → HUNT.
+
+Deadlines come from SysTick compare; both are computed, not discovered —
+"frame end is predictable at header time." Dispatch and reply staging run
+under the instruction's own remaining wire time.
+
+Every frame fits whole in the ring by construction: the largest legal
+frame is 258 ring bytes (§3.1) against a 512 B ring. LOCKED is therefore
+the entire framer — two deadlines, no per-chunk work, no HT/TC draining,
+no staging buffers. The dispatch budget is generous: after deadline B the
+frame's bytes stay valid until the host sends another ~254 bytes (~850 µs
+at 3 M, more at lower bauds) — and a scheduling host is awaiting the
+reply anyway.
+
+### 4.2 TX path
+
+Reply buffer: `[0x00][ID][LEN][INST|0x80][payload][crc][crc]`
+in a halfword-aligned static — the `0x00` at offset 0 is an alignment
+byte and CRC no-op; an odd payload's last byte folds into the CRC in
+software at patch time (§3.2). Sequence: flip pin to
+push-pull → law break (§3, a bracketed-M `0x00` character) → enable
+UART TX DMA from offset 1 → simultaneously
+enable SPI-CRC DMA from offset 0 → the CRC engine outruns the wire 8:1,
+so `TCRCR` is patched into the trailing CRC bytes long before the shifter
+needs them (fire-first, append-later, no deadline race) [F6]. On TC:
+release pin to open-drain.
+
+No hardware-timed kickoff: TX start is "enable the channel when ready" —
+the break makes reply timing non-critical, which deletes the TIM-compare
+kickoff machinery, the RDT register, and its whole tuning surface.
+
+Payloads at or below a small threshold copy into the reply buffer
+directly — cheaper than arming a DMA channel for a couple of bytes. Larger
+payloads (the READ/GREAD case) are **copy-once**: staging the reply kicks
+off a fire-and-forget copy DMA that streams the table span into a
+dedicated 256 B engine-owned snapshot buffer; the CRC feed and the wire TX
+arm, armed separately when the reply triggers, both read from that
+snapshot instead of the table. Copy, CRC feed, and wire shift-out are
+three independent DMA/hardware engines running concurrently, not a
+blocking chain — nothing polls or waits on the copy. Correctness comes
+from relative speed and scheduling order instead: the copy is kicked off
+earliest (at stage time, ahead of the trigger) and is also the fastest of
+the three (plain M2M DMA outruns the CRC engine, which itself runs ~8×
+wire speed, F6), and its channel (CH6) sits above the CRC-feed channel on
+the bus-arbitration ladder (the RX ring alone owns the top — see
+`osc-servo-transport.md`, DMA priority ladder) — so the copy is
+guaranteed done before either downstream consumer reaches the bytes it
+needs, by construction, not by synchronization. None of this costs CPU:
+all three engines run in hardware, freeing the core to run the motor
+kernel tick underneath. The one copy still buys two things a
+direct-from-table stream couldn't: the table address's parity becomes
+irrelevant to the wire/CRC engines (the snapshot is always
+halfword-based regardless of where the source span sits), and every
+large reply carries a consistent point-in-time image even if a
+control-loop write lands mid-span. Reads over 252 B split into multiple
+frames (§5.1), each independently snapshotted and CRC'd.
+
+## 5. Instruction set
+
+`INST` bit 7 = 0; opcode in bits [6:4], flags in bits [3:0]:
+
+| flag  | name           | meaning                                                                        |
+| ----- | -------------- | ------------------------------------------------------------------------------ |
+| bit 0 | HOLD / PROFILE | writes: staged, applied by COMMIT · reads: payload names a profile slot (§5.2) |
+| bit 1 | —              | reserved (0) — future extension                                                |
+| bit 2 | NOREPLY        | suppress the status frame                                                      |
+| bit 3 | PER_TARGET     | group op uses per-target addressing                                            |
+
+| op  | name    | payload                                                              | reply                                 |
+| --- | ------- | -------------------------------------------------------------------- | ------------------------------------- |
+| 0x0 | invalid | (INST 0x00 never valid, like ID 0x00)                                |                                       |
+| 0x1 | PING    | —                                                                    | status: model(2), fw(1) — no UID: 16 more bytes on the hottest liveness check; the UID is an internal value and MGMT ENUM (§9.2) is its only reader |
+| 0x2 | READ    | addr(2), count(2)                                                    | status: data(count)                   |
+| 0x3 | WRITE   | addr(2), data(n)                                                     | status: empty (ack)                   |
+| 0x4 | COMMIT  | — (broadcast)                                                        | none                                  |
+| 0x5 | GREAD   | addr(2), count(2), id-list — or PER_TARGET: [id, addr(2), count(2)]× | status chain (§6)                     |
+| 0x6 | GWRITE  | addr(2), count(1), [id, data(count)]× — or PER_TARGET variant        | none (NOREPLY implied unless flagged) |
+| 0x7 | MGMT    | sub-op byte + args (§9)                                              | per sub-op                            |
+
+Notes:
+
+- READ/WRITE collapse DXL's five read variants and three write variants:
+  a single-target read is a one-slot GREAD; WRITE+HOLD is RegWrite; COMMIT
+  is Action; GWRITE is SyncWrite; GWRITE+HOLD+COMMIT is the atomic fleet
+  update. Addressing mode is one flag, and it stops there.
+- Status result codes: see §5.3.
+- The control table is flat (address == offset, 1024 B); `addr` is
+  2 bytes, `count` is 2 bytes for reads (kept u16 for field alignment in
+  the payload view; values cap at 252, §5.1) and 1 byte per GWRITE slice.
+- **READ/GREAD addressing is unconstrained** — any `addr`, any `count`.
+  Every reply payload streams from the snapshot buffer (§4.2), which is
+  halfword-aligned by construction, so the table address carries no
+  constraint at all [F12 satisfied structurally]. WRITE addressing is
+  likewise unconstrained: inbound payloads validate through the ring
+  anchor, not the table address.
+
+### 5.1 Size limits
+
+`LEN` is the only size limit — one ceiling, no capability registers:
+
+- Payload caps at 252 B. Fleet-scale group ops fit in one frame: a
+  uniform GREAD lists 248 IDs — one shy of the full 249-ID unicast space
+  (§3.1) — a PER_TARGET GREAD 50 targets, a uniform 4 B-data GWRITE 49
+  targets.
+- Every frame sits whole in the ring until its CRC passes (§4.1), so
+  nothing is applied from an unverified frame — no partial-apply, no
+  rollback, and no per-transfer staging caps or capability registers.
+- Larger transfers split into multiple frames; a WRITE+HOLD sequence
+  with one COMMIT keeps a multi-frame update atomic. Reads are status
+  frames under the same ceiling: a whole-table dump is five READs.
+
+### 5.2 Read profiles (indirect addressing, span-granular)
+
+DXL's byte-granular indirect registers are deliberately not replicated:
+a byte remap forces the reply through a per-byte pointer chase, defeating
+both the copy-once TX path and the hardware CRC. The scattered-telemetry
+need they serve (position + velocity + current + temperature live in
+different table sections) is met span-granularly instead:
+
+- A **profile region** in the flat table (`0x280..0x2C0`): 4 slots × 8
+  packed span words, configured once with ordinary WRITEs — no new
+  instruction, no hidden state. A span word is
+  `u16 = [addr:10][count:6]` — raw byte addressing over the whole 1024 B
+  table, spans of 1..63 bytes. `count = 0` **disables** the word, and
+  disabled words are skipped rather than terminating the slot, so a host
+  can toggle one span with a single 2-byte write; the all-zero boot image
+  is an empty slot.
+- READ/GREAD with the PROFILE flag name a slot instead of addr+count
+  (uniform GREAD: `slot, id-list`; PER_TARGET: `[id, slot]×`). The
+  hot-loop instruction stays minimal; the span list costs wire bytes once
+  at setup and zero per cycle (the reason profiles beat inline
+  scatter-gather lists for cyclic telemetry).
+- Execution is §4.2's existing copy-once TX: each span is snapshotted at
+  its cumulative offset and the wire and CRC arms stream the one
+  contiguous copy, engine accumulating across arms [F6] — a scattered
+  read costs the same one-copy-per-reply as a single-span read. Spans
+  carry **no parity constraint** (addresses and lengths may be odd): the
+  snapshot buffer is halfword-based by construction and only the total's
+  parity engages the standard tail fold (§3.2) — same as §5's
+  unconstrained plain reads.
+- Errors are read-time (§5.3): a slot index past the region, an empty
+  slot, or a span leaving the table is `range`; a slot totalling past the
+  252 B reply ceiling (§5.1) is `limit`.
+- Scattered _writes_ need no counterpart: `WRITE+HOLD` per span plus one
+  `COMMIT` is already atomic — inline scatter-writes would add cross-span
+  validation complexity for no capability gain.
+
+Implementation note (tearing): the copy-once snapshot DMA (§4.2) reads the
+live table byte-serially, so a field updated mid-span by a control ISR can
+emit a torn multi-byte value in the snapshot — the wire and CRC then read
+that frozen copy, so tearing is bounded to the one copy rather than
+compounding per consumer, but it is not eliminated. Field-aligned spans
+and the single-writer discipline bound tearing to one field; consumers
+that care re-read.
+
+### 5.3 Errors: three layers
+
+There is no status opcode — a status frame is INST bit 7, and its result
+code shares the byte (bits [6:2], 32 values). Errors split by layer:
+
+1. **Frame-level** (CRC fail, malformed): **no reply, ever** — a corrupt
+   frame's ID is untrustworthy, so a servo cannot know it was addressed.
+   The host sees a timeout; the servo increments a diagnostics counter in
+   the telemetry region (CRC-fail count, framing-drop count) readable on
+   any later read. A latched "I saw a bad frame" reply code would be
+   answering a question nobody can safely ask.
+2. **Instruction-level** (valid frame, rejected request): the 5-bit result
+   code, empty payload — `OK`, `instruction` (unknown op/flags), `range`
+   (addr/count out of bounds, or a PROFILE read naming a bad, empty, or
+   table-overrunning slot — §5.2), `access` (read-only, or SAVE with
+   torque enabled),
+   `validation` (value rejected by field rules), `busy`, `limit`
+   (requested reply exceeds the frame ceiling, §5.1), `predecessor-silent`
+   (§6),
+   `hardware`. Exact numeric assignments live with the implementation.
+3. **Device-level** (alarms: overtemperature, overcurrent, encoder fault):
+   orthogonal to any one instruction's result, so it takes no result-code
+   space — status bit 0 (**ALERT**) is set on *every* status frame while
+   the alarm register is nonzero, prompting the host to read it. The same
+   alert-bit semantics as DXL, because they're right.
+
+## 6. Coordinated reads (status chains)
+
+GREAD replies arrive as a chain of ordinary status frames, one per listed
+servo, in list order. Sequencing is snoop-driven and break-framed, which
+makes it cheap and robust:
+
+- Slot 0 replies to the instruction like a unicast read (≥ reply gap after
+  instruction end, §7).
+- Slot k>0 counts _status_ frames (INST bit 7) on the wire since the
+  GREAD; when frame k−1 completes (its end is known at its LEN byte — no
+  timing inference), slot k starts after reply gap. Snoopers do **not**
+  CRC-validate predecessor statuses — the chain consumes nothing from the
+  body, only the framing-level end, so validation would buy nothing and
+  cost a CRC pass per snooped frame. A corrupt status mis-times one slot
+  at worst, bounded by the reclaim window below.
+- **Reclaim deadline** (DXL chains collapse silently past a dead
+  responder; here the recovery is specified): if slot k's predecessor
+  produces no break within RESPONSE_DEADLINE of its own trigger, slot k
+  takes the slot and sets `predecessor-silent` in its status error field.
+  The host sees both the gap and the flag. The window covers the
+  trigger→break lead only — once the predecessor's break is observed it
+  is alive, and the window suspends for a bounded max-frame allowance
+  while its frame plays out (completion re-sequences the chain; a frame
+  that garbles or wedges lets the suspended deadline fire as the
+  reclaim). Keying on the break rather than the frame end is what keeps
+  the default baud-independent: a frame's wire time exceeds 60 µs below
+  3 M, its break lead never does.
+- Error statuses keep the chain alive; only silence triggers reclaim.
+
+There is no FAST/regular split and no per-block checkpoint CRC: each chain
+element is a complete, independently CRC'd status frame, and the break
+delimiter gives every snooper hardware resync per element — the problem the
+DXL checkpoint format solved does not exist here.
+
+## 7. Timing rules
+
+| parameter               | value                                      | rationale                                                                                  |
+| ----------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| reply gap               | 12 µs after frame end, at every baud       | host TC→release margin — a register poke, i.e. a time-domain quantity: fixed µs neither balloons at 0.5 M (2 byte-times was 40 µs of mandated silence) nor thins at 3 M |
+| RESPONSE_DEADLINE       | config register, default 60 µs (all bauds) | chain reclaim (trigger→break lead, §6) + host timeout; NOT a reply-time prescription — a servo replies when ready |
+| break length (TX)       | exactly 10 bit-times (§3 law; 9-bit 0x00 character) | break ≡ 1 character: exact span algebra + LIN-detectable; SBK (~14 bits, F5) is off-law |
+| inter-frame gap (host)  | none required                              | breaks self-delimit; back-to-back host frames are legal                                    |
+
+Ping turnaround (instruction wire-end → status break fall) is **34.3 µs
+at 1 M and 44.3 µs at 3 M**, measured on the current transport, vs
+62.8 µs measured for a DXL 2.0 stack on the same silicon — the
+instruction's own 5 B + break costs nothing extra on top of that, since
+dispatch overlaps its arrival (speculation; see
+`osc-servo-transport.md`, dispatch speculation). The dominant turnaround
+components are the tail (hardware CRC-check + dispatch handoff), reply
+gap (12 µs), and the break itself (~4.7 µs, F5); see
+`osc-servo-transport.md` (tick-by-tick exchange trace) for the full
+trace and measured baseline table.
+
+The intended hot loop leans on writes being free of turnaround entirely:
+`GWRITE(HOLD|NOREPLY) × groups → COMMIT (broadcast, silent) → GREAD
+telemetry chain` — writes cost pure wire time (back-to-back frames are
+legal), the apply instant is one broadcast, and the telemetry chain is
+the implicit ack: a rejected write surfaces within one cycle as the
+ALERT bit on that servo's status (§5.3).
+
+## 8. Host requirements
+
+- Crystal-clocked UART with break send (any USB-serial with SBK, or the
+  pirate).
+- osc-CRC (textbook CRC-16/ARC, §3.2).
+- Drive discipline if on a buffer-less bus (release when idle) [F8].
+- Schedule the bus: one outstanding instruction / chain at a time;
+  timeout = RESPONSE_DEADLINE + frame time.
+- Fault pacing (§3.4): after traffic a servo may have received as garble
+  (wrong-baud probes, glitches), allow one starve horizon (64
+  byte-times) of bus silence before expecting crisp turnarounds — don't
+  hammer zero-gap retries into a parked resolver.
+
+## 9. Management plane (MGMT sub-ops)
+
+### 9.1 Rescue break
+
+A dominant low ≥ 300 µs at _any_ configured baud commands: switch the UART
+to the 0.5 M rescue rate — volatile only; ID retained, config registers
+untouched, nothing persisted. A reboot exits rescue back to the configured
+baud. The signal itself is baud-agnostic (raw GPIO low suffices at the
+host), so it reaches a servo whose rate is unknown, and it unifies a
+mixed-rate bus onto one channel in a single pulse. Detection is the slow
+loop's job, not the transport's: the break detector latches only at a
+span's END [F15], so no receive wake can observe a pulse in progress —
+the servo's main loop samples the line pin and the RX ring's DMA counter
+once per idle wake (~50 µs cadence off the ADC tick metronome) and
+declares rescue after ≥300 µs of continuous low with the ring frozen. The
+frozen-ring requirement is what makes the window aliasing-proof at any
+host baud: data cannot hold the line low a whole byte-time without
+completing a character, and a completed character rings and moves the
+counter — the pulse's own ringed `0x00` (it chars ~a byte-time in)
+re-anchors the window and everything after it is provably byte-less. The
+declaration lands while the pulse still holds the line, so the transport
+resyncs at a provably-still ring position. No EXTI storm, no edge
+capture, no wake-path branches. Hosts should send pulses of ~1 ms (the
+300 µs floor plus generous sampler-jitter margin under load; repeats are
+free and idempotent). Recovery flow: rescue break →
+talk at 0.5 M → fix the baud register → COMMIT/reboot. Limitation: it
+cannot interrupt a servo wedged mid-transmit (RX is muted during own TX
+[F9]) — it is config recovery, not a babble killer.
+
+### 9.2 UID enumeration and ID assignment
+
+The UID is a **fixed 16-byte field** — UUID-width, because the wire format
+is the long-lived ABI and no catalog MCU burns in more than 128 bits
+(64/96/128 all exist; 96 dominates the STM32-clone pool). A chip fills it
+LSB-first from its silicon ID and zero-pads the tail: the V006's
+factory-burned 96-bit ESIG (RM ch. 19) lands in the low 12 bytes, UNIID1's
+low byte first. Read once at bringup and held as an internal value — not a
+table register (it would spend 16 read-only table bytes on something only
+discovery reads; ENUM is its sole consumer). The pad costs the prefix tree
+nothing: descent depth is driven by where UIDs differ, and same-silicon
+chips differ in the low bits.
+
+Push-pull UART has no dominant-bit arbitration, so simultaneous responses
+are garbage — and garbage _is_ the collision signal:
+
+- `MGMT ENUM [prefix_len, prefix…]` (broadcast): `prefix_len` counts bits,
+  0..=128; the prefix carries `ceil(prefix_len/8)` bytes. The stream is
+  LSB-first — bit k of the UID is `uid[k/8] >> (k%8) & 1`, the same order
+  the UART shifts bits onto the wire. A servo whose UID begins with the
+  prefix replies `OK` with its full 16-byte UID; everyone else stays
+  silent. Mismatches and malformed queries draw no reply on the broadcast
+  wire — a nack storm is the one reply a broadcast must never produce
+  (unicast keeps the §5.3 layer-2 `instruction` verdict). Matching servos
+  are same-die replicas running cycle-identical firmware, so an unguarded
+  collision is a lie waiting to happen: they answer in unison, and two
+  near-equal frames superimposed sub-bit-aligned read back as ONE clean
+  frame — the walk records a unique match and the loser's subtree goes
+  invisible (measured: superimposed pair probes usually decode as the
+  dominant servo verbatim; the residue is literal wire-AND bytes).
+  Two rules keep the collision signal honest:
+  - **Kill exemption** — colliding IS a matcher's contract, so a staged
+    ENUM reply is exempt from any transport wire-safety kill a peer
+    matcher's leading reply-break would trigger.
+  - **Reply slot draw** — an ENUM reply delays its trigger by
+    `(fold(osc-CRC(uid)) XOR tick) mod ENUM_REPLY_SLOTS` byte-times
+    (16 slots). The UID term separates same-reel sequential serials; the
+    free-running tick term (boot-offset + drift entropy) makes every draw
+    fresh, so equal keys cannot hide a pair persistently — unison is a
+    per-probe 1-in-16 accident, never a property of the pair.
+
+  Host algorithm: clean reply with a quiet tail → unique match, CONFIRMED
+  by probing both one-bit children once (twins differing at that bit
+  split deterministically; twins agreeing re-roll their slot draws);
+  trailing energy behind a clean frame, garble, or CRC-fail → collision,
+  descend one bit and retry; timeout → empty subtree. O(bits · N)
+  exchanges plus two confirm probes per servo, boot-time only.
+- `MGMT ASSIGN [uid(16), new_id]` (broadcast): the servo whose UID matches
+  takes `new_id` — validated 1..=249 (the sole matcher may nack
+  `validation` without colliding), applied immediately so the ack already
+  leaves from the new id, and mirrored into the config ID register so a
+  later SAVE persists it; volatile until then. Solves the
+  duplicate-default-ID field pain.
+
+### 9.3 Clock discipline: the CAL break-pair ruler
+
+Most consumers of clock discipline are covered by design:
+
+- Reply timing is event-driven (break-led, when-ready) — nothing is
+  scheduled against a clock, so there is no grid for drift to skew.
+- HOST↔SERVO comms integrity has ≥3× margin over the worst possible HSI
+  state, measured: the chip cannot be detuned far enough to break framing
+  or data at 3 M [F10], and the 1 M default triples that.
+- Cross-servo simultaneity is an *event* problem, not a clock problem:
+  broadcast COMMIT applies a fleet's held writes in the same instant on
+  the shared wire.
+- Residual ±1 % scale error (velocity estimates, timeouts, PWM rate) is
+  far below what any consumer cares about.
+
+One consumer is NOT covered by the single-sided F10 margin: **servo→servo
+snoop**. A chain slot fires off its predecessor's *status frame* (§6), so
+one HSI receives another HSI — the clock budget is PAIRWISE, and factory
+spread reaches 7k+ ppm. At 3 M that garbles snooped status tails
+(crc/framing counters on every chained servo); trimming a fleet to a
+1.4 k ppm worst pair zeroes them, causally.
+
+A passive estimator of host byte cadence has neither reliable food nor
+hardware-anchored stamps; the reference is therefore explicit and
+hardware-anchored:
+
+**`MGMT CAL [gap_us(2 LE), gaps(1)]` (broadcast ONLY).** The host follows
+the frame with `gaps + 1` bare breaks spaced exactly `gap_us` apart, its
+crystal (any timer/DMA pacing) keeping the spacing. Each servo stamps its
+tick at every break-wake service entry: both ends of every gap ride the
+SAME ISR path, so entry latency cancels in the difference, and what
+remains is clock skew plus sub-µs jitter — ~±260 ppm from 8 × 400 µs
+gaps, a tenth of the smallest trim step. Contract and hygiene:
+
+- Broadcast-only: a unicast CAL decodes as an instruction error — its ack
+  would put the replier's own break on the wire where the train starts.
+  The whole fleet measures one train simultaneously.
+- The train follows the announce immediately; no frames inside the train.
+  Per-gap gate `|Δ − gap| ≤ gap/16` (wider than any legal clock state,
+  far under a missed/spurious break); a train with fewer than half its
+  announced gaps valid decides NOTHING. A silent train is abandoned by a
+  2-gap watchdog; a stray FE mid-train costs its gap, never the train.
+- The train's break bytes are ring noise the resolver's hunt scans off
+  silently (§3.3) — CAL is invisible to the link counters.
+- Breaks decode threshold-free across the entire HSITRIM throw [F10], so
+  CAL also *rescues* a servo railed by a bad trim — the ruler works below
+  the layer a bad trim breaks.
+
+Thermal drift between CALs is the **differential chain-pair tracker**'s
+job, passive and wire-invisible: adjacent break-wake stamps bracketing
+exactly ONE CRC-verified *silent* instruction (GWRITE, or WRITE/COMMIT
+with NOREPLY or broadcast — shapes no reply can follow, since a
+responder's turnaround rides its clock, not the host's) measure
+`seam + drift·span`. The host's queuing seam is unknown but stationary:
+the mean pair error over the 32 pairs after any trim decision IS the seam
+(baseline), and 128-pair windows read drift as their shift from it —
+anything constant (seam, FE latch offset, entry-path residue) dies in the
+subtraction. Byte-exactness (ring span == the verified footprint) and the
+same 1/16 gate qualify pairs; window verdicts past ±8 k ppm are not
+thermal and are discarded (a seam shift comes from a host behavior change
+the host knows about — it re-anchors with a CAL).
+
+Both feed the oscillator-trim loop (`steps = round(err/step_effect)`,
+clamped ±4/decision; step effect self-measured — chip trim steps are
+nonuniform, 1.4–3.2 k ppm/step measured), applied by the main loop
+between frames; the total is readable at `telemetry.clock.trim_steps`.
+Volatile by design: the host CALs at boot (~4 ms of bus per train) and at
+moments it knows its own behavior changed — not on a timer; the tracker
+holds the fleet through everything between.
+
+**Boot guidance: send at least two trains.** Full convergence is a
+two-point identification, not a precision problem: the first train's
+correction divides by the seeded nominal step effect, and a chip's true
+ppm-per-step is only knowable from the apply→remeasure pair — so chips
+whose steps are weaker than nominal land one step short on the first
+train and finish on the second. Longer trains cannot buy this back
+(train noise ~±260 ppm is already a tenth of the smallest step); more
+trains can. Converged = `trim_steps` read-back stable between trains;
+two suffice in practice, a third confirms.
+
+### 9.4 Config persistence (SAVE)
+
+DXL gates all EEPROM-region writes behind torque-off — a category error
+that conflates the storage medium with the data's mutability. The actual
+mid-motion hazard is the **flash program operation** (it stalls
+instruction fetch for milliseconds — lethal under a live control loop),
+so that is what gets gated:
+
+- Config-region writes are always allowed (normal field validation
+  applies) and hit only the live RAM table — volatile until saved.
+- `MGMT SAVE` is the only flash-touching operation: requires torque
+  disabled (else `access`), programs the config page (power-safe A/B
+  alternation on the reserved config pages), and acks **after**
+  completion — the servo is genuinely stalled during program, so hosts
+  use a SAVE-specific timeout (erase + program run 5–10 ms; ~50 ms is
+  comfortable guidance). FACTORY shares the stall and the timeout.
+- No write is torque-gated — there is no section lock. Field validation
+  rules still apply to every write; anything genuinely unsafe to change
+  mid-motion is the control kernel's job to sequence, not the table's to
+  forbid.
+- A config-dirty bit in telemetry reports modified-since-save.
+
+Side effects: flash wear drops from program-per-write to
+program-per-session, and the ~10 ms write stall stops ambushing hosts on
+ordinary config writes — it happens exactly once, at a moment the user
+chose, with torque provably off.
+
+### 9.5 Reboot / factory
+
+`MGMT REBOOT`, `MGMT FACTORY` — conventional semantics (as in DXL);
+payload details live with the implementation. FACTORY resets the saved
+config page, not just the live table.
+
+## 10. V006 resource map
+
+| resource            | use                                               |
+| ------------------- | ------------------------------------------------- |
+| USART1 + HDSEL, PC0 | the bus (rev B default config: full duplex, PC1 RX + PC2 TX_EN; the `half-duplex` feature frees both pins on rev-c) |
+| DMA1 CH5            | RX ring (circular, armed once)                    |
+| DMA1 CH4            | TX stream (enable-when-ready)                     |
+| DMA1 CH3 + SPI1     | CRC engine (no pins) [F6]                         |
+| DMA1 CH1 / CH2      | ADC / free                                        |
+| DMA1 CH6            | copy-once snapshot buffer (§4.2); CH7 free        |
+| SysTick             | framer deadlines A/B, reply gap, reclaim             |
+| TIM1/TIM2           | motor control, freed from transport duty          |
+| EXTI                | unused — no transport consumer at all (§9.3)      |
+
+Notably absent (vs a DXL-style transport): input-capture edge timing,
+TIM-compare TX kickoff, an RDT register and its tuning surface,
+byte-stuffing encode/unstuff, the FF-FF-FD hunter, software fold-CRC —
+and, on the direct wire, the 74LVC2G241 buffer + TX_EN pin (the rev B
+default board config keeps them).
+
+## 11. Measured foundation
+
+| #   | fact                                                                                       | source                |
+| --- | ------------------------------------------------------------------------------------------ | --------------------- |
+| F1  | FE fires 1:1 per break at 3 M, HSE host, 50/50                                             | bringup measurement, V006 |
+| F2  | break rings exactly one 0x00 via DMA; NDTR-exact framing                                   | bringup measurement, V006 |
+| F3  | any-length break = one event (932 µs low → 1 FE)                                           | bringup measurement, V006 |
+| F4  | mid-frame FE: no halt, byte rings, IRQs coalesce                                           | fault-injection matrix, V006 |
+| F5  | SBK break ≈ 14 bit-times, both chips, zero variance                                        | bringup measurement, V006 + V203 |
+| F6  | SPI CRC: 16-bit LSB-first = natural-order ARC (bitrev16 register), accumulates across DMA arms, 0.36 µs/B wall ~0 CPU | bringup measurement, V006 |
+| F7  | HDSEL direct wire works both directions, no buffer needed                                  | bringup measurement, V006 |
+| F8  | idle push-pull clamps other talkers; OD-idle/PP-talk is mandatory                          | bringup measurement, V006 |
+| F9  | V006 HDSEL has no own-TX echo                                                              | bringup measurement, V006 |
+| F10 | full HSITRIM throw −3.0..+3.4 %: framing AND data survive everywhere                       | HSITRIM sweep, V006   |
+| F11 | production table CRC = 635 ns/B pure CPU                                                   | bringup measurement, V006 |
+| F12 | DMA rounds odd MAR down; no unaligned 16-bit reads                                         | bringup measurement, V006 |
+| F13 | EXTI edge ISRs storm during traffic (own TX stretched 3×)                                  | HSITRIM sweep, V006   |
+| F14 | data decodes clean at ±3.4 % in both TX and RX directions                                  | HSITRIM sweep, V006   |
+| F15 | LBD runs sans LINEN, both chip families: length-qualified (≥10-bit spans only — 0 fires on framing-error injection and high-baud garble), safe flag-selective write-0 clear mid-traffic, one event per any-length span, **latched at the span's END** (== bit 10 for the 10-bit law break; a rescue pulse's wake arrives after the line rises), entry stamps 4 ticks p-p on a 400 µs grid; latched FE/NE/ORE with no interrupt enabled are harmless through marination | bringup measurement, V006 + V203 |

--- a/docs/osc-servo-transport.md
+++ b/docs/osc-servo-transport.md
@@ -1,0 +1,466 @@
+# osc servo transport — the deadline-pipelined receiver
+
+The servo-side transport of the osc-native protocol: how a sub-$0.20 MCU
+with no input capture and no crystal turns break-framed wire traffic into
+dispatched instructions and on-grid replies. Companion pillars:
+`osc-native-protocol.md` (the wire; §3.4 is the two-signal fault
+contract), `driver-pattern.md` (the layering). `[Fn]` cites the measured
+foundation in `osc-native-protocol.md` §11.
+
+Code is authoritative; when this doc and the code disagree, fix the doc.
+
+## 1. Architecture in one paragraph
+
+All byte movement is hardware. The CPU never receives or transmits a
+byte: DMA writes every received byte into a circular ring, DMA streams
+every reply out of buffers and the control table, and a DMA-fed SPI
+engine computes every CRC. Software is pure state machines — `Framer`,
+`Chain`, `TxEngine`, and the clock tracker — composed by `ServoBus`,
+driven by exactly two interrupt vectors at one priority, whose only jobs
+are to compute two kinds of numbers — *where* frames sit in the ring, and
+*when* something is due — and to react to two kinds of events: "a break
+happened" (the USART's length-qualified LIN break detector) and "it is
+time now" (one tick comparator, multiplexed over every deadline the
+transport has).
+
+## 2. Hardware ledger
+
+Every hardware resource the transport touches, and its duty cycle:
+
+| resource        | role                                             | budget/event |
+|-----------------|--------------------------------------------------|--------------|
+| USART1          | half-duplex wire; HDSEL, no self-echo (F9)       | —            |
+| USART1 vector   | PFIC HIGH. (a) LBD = break wake (length-qualified ≥10-bit low; flag-selective write-0 clear at entry, never a DATAR read; FE/NE/ORE have no interrupt enable — they latch silently, §7); (b) TC = TX arm drained | break body ~1 µs; TC body ~2–4 µs/arm |
+| SysTick CNT/CMP | the transport clock (48 MHz, 32-bit) + the ONE comparator | — |
+| SysTick vector  | PFIC HIGH. Deadline mux: framer A/B, covered, chain trigger — and dispatch, inline (every class except verdict-first runs at the covered checkpoint or the fast path, §6) | arithmetic slots ~1–5 µs; dispatch bodies ~10–70 µs |
+| DMA1 CH5        | USART1 RX → 512 B ring, circular, silent (no IRQ); **VERYHIGH, alone atop the ladder** (§7) | zero CPU |
+| DMA1 CH4        | TX arms → USART1 DR (header, snapshot payload, CRC tail); HIGH | zero CPU; TC surfaces as USART TC |
+| DMA1 CH3        | CRC feeds → SPI1 DR, 16-bit halfwords (RX span straight from the ring); MEDIUM, below CH6 | zero CPU, ~0.36 µs/B engine time |
+| SPI1            | CRC-16/ARC coprocessor (16-bit LSB-first, bitrev16 at the register), accumulates across feeds | runs ~8× wire speed (F6) |
+| DMA1 CH6        | snapshot copy → the 256 B snapshot buffer (reply payloads only — RX CRC feeds the ring directly); HIGH, above CH3 | ~0.125 µs/B, zero CPU |
+| DMA1 CH1        | ADC sample set → buffer; DMA HIGH (wins HIGH ties by channel number); TC vector = motor kernel tick at PFIC LOW | ~10 µs body |
+| PC0 CNF         | drive discipline: open-drain listening / push-pull TX window | flipped at trigger/release |
+| main loop       | deferred reboot poll + rescue line sampler (protocol §9.1: line pin + CH5 NDTR once per wfi wake — the break detector latches only at a span's END, so the slow loop is the only observer of a pulse in progress) | cold path; sampler ~0.3 µs/wake |
+
+Buffered boards (the default config; the `half-duplex` feature selects
+the direct wire) swap the wire rows: USART1 runs plain full duplex (no
+HDSEL, RX on PC1 through the 74LVC2G241's mute-gated receive buffer), and
+the PC0-CNF flip becomes the TX_EN (PC2) level — high claims the wire and
+mutes RX, low releases. Every discipline in this doc (the no-DATAR rule,
+F9 no-echo) holds identically; only the claim/release lines in `TxWire`
+differ.
+
+PFIC preemption is two-level (IPRIOR bit 7). USART1 + SysTick share HIGH
+and therefore serialize against each other; LOW holds only the motor
+kernel (DMA1_CH1 = 22), which HIGH preempts and which runs in the wire
+gaps between frames. Free and reserved: TIM2 (reserved: future encoders),
+TIM1 (motor PWM), SW (14), I2C1_EV (30), I2C1_ER (31).
+
+**Kernel ticks under load — measured and accepted.** Everything-at-HIGH
+means transport work preempts the kernel, and a kernel tick that pends
+while a ≥50 µs HIGH chunk runs coalesces with the next one (the PFIC pend
+bit is one bit). Silicon, against a 20.11 kHz idle tick baseline: tick
+loss ≈ 1.2–1.4× the transport-HIGH duty — 14% under a sustained 9-frame
+zero-gap flood (~11% duty), 23% under a 21-frame flood (~17% duty).
+Latency stays bounded (the longest HIGH chunk is ~60–80 µs ≈ 1–2 ticks);
+ticks are never starved outright. Accepted because the duty profile that
+loses ticks is rare in practice: config sessions run torque-off (kernel
+idle by definition), and the production hot loop is a few small GWRITEs +
+COMMIT + GREAD per cycle — short bursts, wire-gapped, single-digit duty.
+A use case that sustains heavy bus duty under live control is the signal
+to revisit (hardware-counted ticks, or an isolation lane).
+
+## 3. One exchange, tick by tick (ping at 1M; byte-time = 10 µs)
+
+```
+t=0    break's wire end. DMA has already ringed the 0x00. LBD ISR (~2 µs) —
+       a pure wake: the framer resolves from ring data and projects deadline
+       A = now + 3 byte-times at wire pace + ½ byte for the break tail
+       [F5]. No timestamp is recorded.
+t=10/20/30  ID, LEN, INST land in the ring by DMA. CPU idle.
+t=35   deadline A (SysTick): header parse + validate → footprint 6, frame
+       end computable. A ping's CRC-covered span IS its header, so the
+       covered checkpoint fires from this same wake:
+         · packet_end FROZEN by ring cadence: now + missing(2)·byte-times
+           (+ the 1.6% drift pad) — `now` and the cursor advance together,
+           so ISR lag cancels and the estimate is late by under a
+           byte-time, never early.
+         · CRC feed of the covered span starts (CH3 arm, ~1 µs of CPU)
+         · DISPATCH (inline, at HIGH): decode + dispatch run NOW, the
+           reply is built and staged into the TX engine — all before the
+           frame has ended. The verdict at deadline B will SEND or
+           DON'T-SEND it; the work is already done either way.
+       Deadline B armed at the frozen packet_end, exactly.
+t=40/50  the two wire-CRC bytes land. SPI engine finishes the covered span
+       long before (4 B ≈ 1.5 µs). CPU idle again.
+t≈55   deadline B (SysTick): the verdict — poll CRC result (ready) == wire
+       CRC → SEND: chain sequences the staged reply, trigger due at
+       packet_end + reply gap (12 µs, fixed at every baud). Body is a few µs —
+       the work already happened.
+t≈67   trigger (SysTick): INST finalized, PC0 → push-pull, break sent, first
+       DMA arm armed. Status break falls. TX CRC is computed by the same SPI
+       engine IN PARALLEL with transmission and patched into the final arm.
+t=…    per-arm TC ISRs stream the remaining arms; final TC releases the wire
+       and applies any deferred id/baud config.
+```
+
+Measured: 30.4 µs from instruction end to status break fall (§10). The
+estimate chain above — reply-gap grid plus sub-byte estimate lateness —
+accounts for roughly half; the remainder is trigger-body, break commit,
+and ISR-entry overheads.
+
+## 4. Why this is fast — first principles
+
+1. **Dispatch before the verdict — the spine.** Dispatch never waits on
+   the CRC. It runs the moment the covered span is ringed (frontier) or
+   the frame is complete (backlog), and STAGES its effects; the CRC
+   verdict then gates those effects, never the work. This is not an
+   optimization layered on a "safe" path — it IS the default, for every
+   class. The alternative (a non-dispatching path that schedules a CRC
+   check and blocks on the result before doing any work) spends ~5–7 µs
+   of HIGH per frame spinning on a finished engine, and in a zero-gap
+   burst those spins stack onto the burst-cycle critical path and widen
+   break-delivery lag — so no such path exists. The verdict gates two
+   effect kinds: the **wire effect** (a staged reply — SEND on pass,
+   DON'T-SEND on fail) and the **table effect** (staged writes — COMMIT
+   on pass, REVERT on fail). Ping/read stage only a wire effect; a
+   NOREPLY write only a table effect; a reply-bearing write both, under
+   one verdict.
+2. **Work hides under wire time.** The dispatch window (covered
+   checkpoint → frame end) runs decode + dispatch + reply build while the
+   last two CRC bytes are still in flight. Deadline B — the only step on
+   the reply's critical path — is reduced to "poll a finished CRC and arm
+   the trigger". The reply rides the reply-gap grid, not the dispatch
+   time.
+3. **The verdict is almost always PASS.** Dispatch bets the frame passes
+   CRC. On a clean bus that is ~100% of frames; the loser (a corrupted
+   frame) pays a revert + don't-send, which is off the happy path by
+   definition — and the frame-position ladder is untouched by it (§5), so
+   the hunt just starts one hop later, on corrupt frames only, inside the
+   host's retry contract.
+4. **Hardware CRC in both directions, in parallel.** RX: fed at the
+   covered checkpoint (or publish), chewing while the CRC bytes fly,
+   polled at the verdict. TX: fed per arm, patched into the trailing arm
+   before DMA reaches it. The CPU never computes or waits a full CRC.
+5. **Zero hops, everywhere.** Every stageable class (ping/read/gread,
+   write/gwrite) dispatches inline at HIGH — each stage hands off by
+   falling through within one ISR invocation or the next event's entry,
+   no cross-priority round-trip. The kernel-side cost is the measured,
+   accepted tick coalescing in §2.
+6. **Copy-once TX.** Reply payloads are DMA-snapshotted once
+   (~0.125 µs/B, fire-and-forget) and streamed from the snapshot by both
+   the wire and the CRC — snapshot-consistent reads for the price of one
+   copy hidden under reply gap (protocol §4.2).
+7. **One comparator, muxed.** Every deadline (framer A/B/covered, chain
+   trigger, rescue) folds onto SysTick CMP with pend-on-past semantics;
+   the drain loop consumes every slot due at the same wake.
+8. **The single-context CRC engine needs no arbitration protocol.** TX
+   generation and RX validation share one engine safely because both run
+   at HIGH — ownership is serialized by the PFIC, for free.
+
+## 5. Position and time from the stream
+
+The transport's central design rule: **position is derived from the
+stream, never sampled at ISR entry; times come from data-cadence
+projections, never wake arrival.**
+
+The rationale is staleness, not latency. A handler that samples the ring
+cursor at ISR entry and classifies the event by `ring[cursor−1]` reads
+the wrong byte whenever service lags the wire by a byte-time — and at 3M
+(3.33 µs/byte) any dispatch body guarantees that lag, while two pended
+breaks coalesce into one PFIC entry. The failure is silent: the cursor
+has moved past the break byte, the test reads frame data, the framer
+ignores the "garble", and a fully intact frame in the ring is never
+anchored. A queue of cursor snapshots inherits the same staleness at
+capture time — entry delay ≥ 1 byte-time makes the snapshot stale before
+it is stored. Latency merely amplifies staleness; deriving position from
+the stream removes the staleness, and latency stops meaning loss.
+
+### 5.1 The break wake carries nothing
+
+The break wake carries neither position nor time. It is a pure wake, and
+its handler does only the bounded wire work: staged-reply kill (from
+which broadcast-ENUM replies are exempt — colliding is their contract,
+and they ride a UID-keyed slot delay so twin matchers don't collide in
+undetectable unison, protocol §9.2) and chain suspend. Every aim and
+estimate is instead projected from live ring state at each resolve:
+
+```
+aim / estimate = now + missing·tpb (+ span·tpb ≫ 6 drift pad)
+```
+
+`now` and the cursor advance together, so ISR delivery lag — the thing a
+wake timestamp inherits wholesale (a 60 µs-late wake makes the reply
+60 µs late) — cancels out of the projection. The error is bounded by one
+byte-time plus one wake latency and is always on the LATE side: a byte
+counted as missing can only finish sooner than assumed, so a reply grid
+measured from the estimate never fires into its own frame's tail (the
+reply-gap safety property, sim-pinned). The reply-grid estimate is frozen
+at the covered checkpoint, where missing ≤ 2 makes it tightest. Aims are
+self-pacing for free: a stalled wire re-projects at each wake ≥ one
+byte-time out, so no recheck/park budget machinery exists; the
+64-byte-time progress-idle horizon (the starve horizon) is the sole death
+authority. One epsilon survives, on header aims only: the break rings at
+its wake point ~4 bit-times before the line rises [F5], so the first data
+byte sits that far outside the byte cadence.
+
+### 5.2 The ring is the queue
+
+Frames are contiguous: `next anchor = anchor + footprint` (stream
+continuity). The cursor is read only at provably-quiet bootstrap moments —
+boot (position 0 by construction) and rescue confirm (a held-low line
+delivers no start edges, so the cursor is still); the ring is armed once
+and never reloaded. From then on:
+
+- **Fast path (successor available).** If newer activity exists beyond
+  the current frame's computed end — its end byte is ringed and more
+  followed — then every byte of this frame is already present. Resolve it
+  purely from ring data: header, covered, CRC, dispatch, in one pass, no
+  deadlines. A backlog of N frames is walked N frames at a time with zero
+  scheduling; the 512 B ring (≥ 15 hot-loop frames) is the queue, and it
+  cannot "drop" an entry the way a snapshot queue can.
+- **Scheduled path (newest frame only).** The frame still arriving rides
+  the deadline pipeline: A (header) → covered checkpoint (dispatch, §6) →
+  B (verdict), every deadline a ring-cadence projection.
+
+### 5.3 Garble dies by data only
+
+Per the fault contract (protocol §3.4), no frame is dropped, killed, or
+rejected on wake evidence — wake-time observations (service-time cursors,
+latched re-fires) lie under exactly the conditions a busy fleet produces:
+coalesced or lagged break service at high ISR occupancy, and latched-flag
+re-fires after NOREPLY frames (nothing transmits, so nothing retires a
+flag). A death decision derived from them plants itself inside live
+frames. Data is the only death authority: a phantom candidate born from
+garble is killed by its footprint-fill CRC verdict or by the starve
+horizon — never by fault position. The cost is bounded, documented
+recovery latency (the host pacing rule, protocol §3.4) instead of
+fault-speed phantom kills; a phantom's CRC rejection flips the hunt on,
+and the hunt converges from ring data.
+
+Corruption recovery is bounded: a corrupted LEN mis-strides the ladder;
+the next resolution finds no `0x00` at the expected anchor (or the frame
+fails CRC) → drop + count, and the ladder re-verifies at every following
+boundary. Anchors are parity-free (protocol §3.2), so recovery needs no
+ring reload, only the next break's arrival. Loss is bounded to ≤ 2 frames
+per corruption event; the host's timeout+retry contract closes the loop.
+
+## 6. Instruction classes
+
+The class split is *stageability* — whether an instruction's effects can
+be staged behind the CRC verdict:
+
+- **Stageable — PING/READ/GREAD/WRITE/GWRITE.** Dispatch inline at HIGH
+  at the covered checkpoint (frontier) or the resolve wake (backlog); the
+  CRC feed chews underneath. The verdict at the frame end gates the
+  staged effects: SEND/DON'T-SEND of a reply, COMMIT/REVERT of a table
+  write.
+- **Verdict-first — COMMIT/MGMT.** Their effects cannot be staged (COMMIT
+  applies the whole buffer; MGMT reboots), so the CRC is checked FIRST
+  and dispatch runs only on a pass. Rare, short frames — the ~2 µs
+  blocking CRC poll is affordable where staging isn't possible.
+
+Backpressure is structural: at most one pending-verdict frame exists at a
+time (the pending frame IS the frontier), so the single staging slot and
+the single CRC accumulator are never contended. The kernel-isolation
+question is settled by measurement instead of structure: dispatch bodies
+preempt the kernel and coalesce ticks in proportion to bus duty (§2),
+which the intended duty profiles make negligible.
+
+## 7. The DMA priority ladder and receive-side discipline
+
+The receive side's one hazard window is the RX-DMA drain of an inbound
+byte racing the CPU: if the drain lags, the break wake enters with the
+ring cursor not yet advanced past the byte — the resolver sees a
+caught-up ladder and stays silent (no-reply). In isolation the drain is
+effectively instantaneous versus the interrupt (zero
+byte-still-undrained entries observed across soaks at 1M and 3M); the
+window opens ONLY under DMA1-arbiter contention, where a competitor
+delays the CH5 drain — 22% of frames at a moderate competing burst, 94%
+at a heavy one. The arbiter preempts **per-beat** (RX stays clean even
+against a 256-transfer competitor once it outranks it), so RX alone at
+the top bounds its drain wait to a single in-flight transfer — a couple
+of cycles, far under interrupt entry latency — regardless of the
+competitor's burst length.
+
+So the guarantee is the priority ladder, not a software mitigation:
+
+- **VERYHIGH:** CH5 RX — alone at the top.
+- **HIGH:** CH1 ADC, CH4 TX, CH6 snapshot (ADC wins the HIGH ties by
+  channel number, keeping its interleave ahead of the copy).
+- **MEDIUM:** CH3 CRC feed — below CH6 so a reply copy is written before
+  the feed reads it.
+
+With RX on top the break byte is always ringed before `on_break` reads
+ring state, so the framer needs no promise machinery from the wake.
+Silicon: 25k/25k zero-gap hot loops at 2M and 3M with zero
+no-reply/stale.
+
+**The no-DATAR rule.** The ladder protects only the byte already in RDR.
+A CPU DATAR read while a byte is mid-reception additionally kills the
+byte in the SHIFTER — no flag, no ring entry, no NDTR count — and no
+drain priority can help, because the byte dies before a DMA request ever
+exists. The window scales with bit time: unhittable at 2M/3M, systematic
+at 1M under one alignment. So nothing on the receive side ever touches
+DATAR. Silicon: 12k/12k plain floods at 1M and 0.5M with no RX-path DATAR
+read, versus 44/12k with one present.
+
+**LBD is the only receive interrupt.** Its clear at entry is a
+flag-selective STATR write — all bits 1 except LBD's 0, a constant write,
+never a read-modify-write (an RMW races concurrently-setting rc_w0 bits
+and arms the SR half of the error-clear pair). The per-character error
+flags (FE/NE/ORE) are never serviced: EIE stays 0 from boot, so a latched
+error flag pends nothing, storms nothing, and needs no retire protocol.
+The flags self-clear incidentally when ordinary traffic pairs a STATR
+read with the drain's DATAR access, but nothing observes or depends on
+it; at most they may be polled from a cold path as line-noise telemetry
+(protocol §3.4).
+
+The rationale for waking on LBD rather than the error flags is
+first-principles: the error flags are latched, positionless, and
+coalescing, so a wake built on them must be throttled against garble
+storms (wrong-baud traffic heard as continuous framing errors), and any
+mute needs a restore path that itself cannot be starved — a structural
+liability. A wake that never needs muting deletes the problem: LBD is
+length-qualified (only a genuine ≥10-bit dominant span sets it), so real
+errors never interrupt at all, and their consequences surface exactly
+where data-driven handling already looks (§5.3). Silicon: law breaks
+2000/2000 intact with the write-0 clear running mid-traffic; zero vector
+entries across framing-error injection and high-baud garble; reception
+perfect with FE latched throughout, entries == breaks for the whole run.
+
+## 8. Clock discipline
+
+Chain snoop is servo→servo (protocol §9.3): slot k>0 times its reply off
+the predecessor's snooped status frame, so the clock budget is
+pairwise-HSI — two uncalibrated RC oscillators against each other.
+Factory spread (7k+ ppm measured across five chips) garbles snooped
+status tails at 3M; trimming is what makes high-baud chains work. The
+host owns the only crystal on the bus, so it is the syntonization root:
+the servo measures the host's cadence and slews HSITRIM toward it.
+
+Two estimators feed the trim loop, both built on break-wake stamps at
+frame boundaries — hardware-anchored and same-ISR-flavor, so entry
+latency cancels in every pair. (Mid-frame progress stamps do not have
+this property: they are whole-byte-quantized with software-chosen phase,
+and they need frames far longer than real hot-loop traffic provides.)
+These stamps are the one sanctioned exception to §5's no-wake-time rule —
+the trim machinery's entire subject is the break-service stamp itself,
+and it is gated, paired, and baseline-anchored accordingly (protocol
+§3.4, §9.3).
+
+- **Absolute, rarely — MGMT CAL.** A broadcast instruction announcing N
+  breaks spaced exactly T µs; the servo stamps `deadline.now()` at each
+  break-wake entry, gates each gap at |Δ−T| ≤ T/16, and trims off the
+  sum. ~±260 ppm from 8 × 400 µs gaps. Fired at boot (≥2 trains — the
+  first identifies the chip's step effect, protocol §9.3 boot guidance)
+  and at host-known events, not on a timer. Break decode is
+  threshold-free across the full HSITRIM throw, so CAL also rescues a
+  railed servo.
+- **Differential, continuously — chain pairs.** Break-wake stamps of
+  adjacent host instructions (GWRITE→COMMIT seams):
+  `err = measured − footprint·tpb = seam + drift·span`. The host's
+  queuing seam is unknown but stationary; a baseline captured right after
+  each trim application subtracts it, so windows read pure drift. Any
+  constant — seam, detector latch offset, ISR flavor residue — dies in
+  the subtraction; only changes survive, and the sanity band catches
+  non-thermal jumps.
+
+Both feed the `TrimLoop`: `steps = round(err / step_effect)`, clamped ±4;
+round-to-nearest IS the deadband. The step effect is self-measured (chip
+steps are nonuniform, 1.4–3.2k ppm; sanity-banded 0.8–4k); the total is
+applied via HSITRIM between frames and mirrored read-only at
+`telemetry.clock.trim_steps`. Wire format, qualification rules, and the
+tracker's baseline mechanics are normative in protocol §9.3. DES:
+`tests/trim.rs` — trains converge/reject/watchdog, the tracker follows
+mid-run drift injection, constant seam+skew cancel exactly, solicited
+shapes never pair.
+
+## 9. Losslessness
+
+The zero-gap argument, from first principles:
+
+1. **Capture.** Every byte is DMA'd regardless of CPU state; breaks pend
+   and may coalesce, but §5 derives frame positions from the stream, so a
+   coalesced or delayed wake costs nothing — the fast path recovers every
+   completed frame from data.
+2. **Backlog.** Bounded by the ring (512 B ≈ 15 minimal hot-loop frames).
+   The consumer outruns the wire (~2× worst case); sustained overrun is a
+   THROUGHPUT invariant, pinned by the discrete-event flood test
+   (`zero_gap_flood` in `hot_loop.rs`: 100 zero-gap minimal writes +
+   READ, ring laps ~2×, dispatch-cost sweep inside the contract, zero
+   loss at 1M and 3M), not by a runtime guard.
+3. **Ordering.** At most one pending-verdict frame at a time (§6), so the
+   in-order ring walk preserves frame order. A backlog write commits
+   before the frame behind it dispatches — DES-pinned by
+   `backlog_write_then_read_processes_in_order`.
+4. **The host's side of the contract.** RESPONSE_DEADLINE must cover the
+   full reply path — decode + dispatch + verify, elastically late under a
+   backlog — not just the happy-path grid: with ~70 µs dispatch bodies a
+   60 µs default is dishonest, and a chain slot reclaims into a
+   live-but-slow predecessor (DES-pinned in `hot_loop.rs`). Deployments
+   tune the register to their measured worst case.
+
+## 10. Measured turnarounds
+
+Turnaround = instruction wire-end → status break fall. Read = 16 B READ,
+write = goal_position 4 B WRITE. Flash-layout swings between builds are
+±5 µs.
+
+| baud  | ping    | read 16 B | write 4 B |
+|-------|---------|-----------|-----------|
+| 0.5M  | 32.2 µs | —         | —         |
+| 1M    | 30.4 µs | 38.6 µs   | 87.7 µs   |
+| 2M    | 38.8 µs | —         | —         |
+| 3M    | 41.3 µs | —         | —         |
+
+Under burst load the elasticity is small: hot-loop mean turnaround at 1M
+is 35.4 µs, plain-flood 31.3 µs.
+
+The shape: the reply's tail after the instruction's wire end is
+`max(serialized CPU pipeline, reply-gap grid)`. The grid is flat (12 µs
+at every baud, protocol §7) and the estimate it hangs off is
+delivery-noise-free, so 0.5M/1M pings sit together — grid-bound. 2M/3M
+are pipeline-bound: the covered window shrinks below the dispatch body —
+at 3M a short frame is fully ringed before the first deadline wake even
+fires — so the pipeline serializes after the frame end.
+
+## 11. Glossary
+
+- **break** — line held low ≥ a byte-time; the out-of-band frame
+  delimiter. Rings as one 0x00 byte, sets LBD — the transport's only
+  receive wake (FE latches too, unserviced). Break framing is the strong
+  form of sync: DXL 2.0's `FF FF FD` hunting + byte stuffing is the
+  workaround for not having an out-of-band delimiter at all.
+- **garble** — line damage that is not a break: a corrupted byte (slot
+  occupied, CRC will fail) or a phantom byte (noise-invented byte between
+  frames). Raises no wake at all (sub-10-bit lows are invisible to the
+  detector, errors never interrupt); dies by data (§5.3).
+- **anchor / footprint** — a frame's start index in the ring / its total
+  ring length including the break byte.
+- **covered span** — everything the CRC protects: the frame minus its two
+  trailing CRC bytes.
+- **covered checkpoint** — the moment the covered span is fully ringed
+  (2 byte-times before frame end); the dispatch point.
+- **dispatch (the spine)** — decode + dispatch + reply build performed
+  before the CRC verdict — the default for every class, not an
+  optimization (§4). Effects STAGE; they do not apply until the verdict.
+- **verdict** — the CRC result at the frame end, gating the staged
+  effects: the **wire effect** (a staged reply — SEND on pass, DON'T-SEND
+  on fail) and the **table effect** (staged writes — COMMIT on pass,
+  REVERT on fail). Ping/read stage only wire; a NOREPLY write only table;
+  a reply-bearing write both, under one verdict.
+- **instruction class** — stageability (§6): *stageable*
+  (ping/read/gread/write/gwrite — dispatch inline at HIGH, effects gated
+  by the verdict), *verdict-first* (commit/mgmt, CRC checked before
+  dispatch).
+- **deadline A / B** — header-readable check / frame-end check, both
+  ring-cadence projections (`now + missing byte-times`) re-derived at
+  every wake (§5).
+- **reply gap** — the mandated wire gap between a frame and its reply
+  (12 µs, fixed at every baud — host TC→release is time-domain, protocol
+  §7); the reply grid.
+- **fast path / scheduled path** — §5.2's split: complete-in-ring frames
+  resolved from data with no clock / the newest frame timed by deadlines.
+- **starve horizon** — 64 byte-times of ring silence on a pending frame;
+  the fallback death authority for garble-born candidates (§5.3).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,83 @@
+# Testing: the three gears
+
+The transport is verified by three test gears, each proving something the others
+structurally cannot. Green across all three — `scripts/gears.sh` — is what lets
+us pronounce the tree good.
+
+| gear | proves | where | gate |
+|------|--------|-------|------|
+| **1 — unit** | the pieces are individually correct: codec, CRC vectors, control-table rules, driver internals | in-crate `#[cfg(test)]` across `firmware/lib/*` and `tools/bench` | CI |
+| **2 — DES** | the pieces compose correctly under adversarial sequencing, at every baud, deterministically | `firmware/lib/integration` (discrete-event sim) | CI |
+| **3 — bench** | the real silicon meets timing and survives zero-gap load under real ISR/DMA/drift | `tools/bench/tests/hardware` (hardware-in-the-loop) | on-rig |
+
+The division of labour is deliberate. **Gear 2 is wide but blind to time**: the
+sim dispatches with a *zero* CPU-time model, so it proves logical correctness and
+sequencing at every baud but cannot see ISR latency, wall-clock turnaround, HSI
+drift, or the frame-N-deadline-vs-frame-N+1-break window. **Gear 3 is the deep-
+on-timing, narrow-on-logic gear**: its whole job is the silicon-only failure
+modes gear 2 erases. So for every property the sim is structurally blind to,
+gear 3 carries one hardware assertion with a measured budget — it is complete on
+silicon-only properties, not on logic.
+
+## Running
+
+```sh
+scripts/gears.sh
+```
+
+Gears 1 and 2 are deterministic and need no hardware. Gear 3 needs a uart-pirate
+and a flashed V006; the script auto-detects the pirate and **skips** gear 3
+(rather than failing) when no rig is attached. Force-skip with `SKIP_BENCH=1`;
+point at a specific pirate with `BENCH_PORT=/dev/tty…`.
+
+The gears map to plain cargo invocations if you want to run one directly:
+
+```sh
+( cd firmware/lib && cargo test --workspace )            # gear 1 + 2
+( cd tools/bench  && cargo test --lib )                  # gear 1 (bench units)
+( cd tools/bench  && cargo test --test hardware -- --test-threads=1 )   # gear 3
+```
+
+## Gear 3 in detail
+
+The hardware suite drives a single flashed V006 over the pirate and asserts on
+the pirate's captured stamp stream — no wlink, no chip-counter reads; the wire is
+the failure surface. It sweeps the full baud matrix (0.5M / 1M / 2M / 3M).
+
+- **turnaround** (`turnaround.rs`) — THE metric: instruction wire-end → status
+  break fall, per baud, gated for ping AND read AND write. 1 M is the tuned
+  sweet spot (~35 µs ping); the ceiling is baud-aware because turnaround rises
+  at both higher and lower baud on this silicon, and the acked-WRITE gate sits
+  near the ~89 µs rules-dominated dispatch floor (the production hot loop pays
+  none of it — GWRITE is NOREPLY).
+- **rescue** (`rescue.rs`) — the §9.1 pulse reaches a servo at any baud, and
+  the full field-recovery flow (rescue → prefix-walk → ASSIGN → SAVE → reboot
+  → FACTORY). Both tests end with a rescue-based recovery tail so a transient
+  capture dropout never strands the bench unit.
+- **hot loop** (`hot_loop.rs`) — the production `[GWRITE(HOLD), COMMIT, GREAD]`
+  zero-gap loop, the silicon twin of the DES `hot_loop` suite. The GREAD must
+  read back the just-committed value every cycle; a stale read-back is a
+  silently-dropped frame.
+- **plain flood** (`hot_loop.rs`) — an aggressive `[WRITE(NOREPLY) × 8, READ]`
+  flood that surfaces the low-baud framer floor.
+- **ping / read / write / hold_commit / silence** — the single-servo
+  instruction-set happy path.
+
+Longer soak: `BENCH_BURST_CYCLES=25000 scripts/gears.sh`.
+
+### The strict burst gate
+
+The burst tests assert **zero failures** — no stale read-backs, no missed or
+malformed replies — at every baud, with no tolerance budget. That strictness
+is what root-caused the former "low-baud glitch" (a phantom rescue confirm
+aliasing data bits, and a CPU DATAR read killing the RX byte mid-reception —
+see `osc-servo-transport.md` §7 and `osc-native-protocol.md` §9.1); the
+tests went green on their own once the real bugs died, exactly as designed. Keep the gate strict: a red run prints
+the exact baud and the `stale` / `no-reply` / `other` breakdown, and the
+measurement helpers do not retry, so a first-exchange failure is a real
+signal too.
+
+The `tool-*` binaries in `tools/bench/src/bin` are the forensic instruments
+behind these tests — `tool-burst` shares the exact cycle engine the hot-loop
+test asserts on; `tool-reply-edges` dumps the IC edges when a reply artifact
+needs root-causing.

--- a/hardware/boards/osc-dev-v006/README.md
+++ b/hardware/boards/osc-dev-v006/README.md
@@ -17,7 +17,7 @@ Component sizing favours flexibility over board cost: 5 A / 40 V Schottky power-
 - **MCU** — CH32V006F8P6 (RISC-V, 48 MHz, 62 KB flash, 8 KB RAM).
 - **Motor driver** — TI DRV8212PDSGR. H-bridge with IN1/IN2 PWM. 4 A peak, 1.76 A RMS continuous, VM 1.65–11 V.
 - **LDO** — HT7533-1, 3.3 V logic rail.
-- **UART buffer** — 74LVC2G241 for half-duplex DXL.
+- **UART buffer** — 74LVC2G241 for the half-duplex TTL bus.
 - **Current shunt** — 10 mΩ, 1%, 333 mW (RS1) on the low side.
 - **Power input** — USB-C 5 V, 1S–2S LiPo (3.0–8.4 V) via JST-PH or screw terminal, or WCH-LinkE `+5V`. Any combination, OR'd through SS54s.
 - **Debug** — WCH-LinkE over the CH32V006's 1-wire SWDIO.
@@ -103,12 +103,12 @@ Intended as the upgrade path for higher-precision position feedback (e.g. a cust
 - Row 2: +3V3, GND
 - Row 3: SWD, +5V
 
-#### DXL TTL Bus — J9 / J10 / J11
+#### Servo TTL Bus — J9 / J10 / J11
 
-OpenServoCore uses **single-wire half-duplex UART (Dynamixel TTL)** as its physical bus. Two reasons:
+OpenServoCore uses **single-wire half-duplex UART (Dynamixel-TTL electrical layer)** as its physical bus. Two reasons:
 
 - **Three wires only** (`GND` / `V+` / `DATA`) — the same pin count as the original 3-wire hobby-servo cable, so a stock SG90/MG90 cable is reused as-is when swapping the OEM control board for an OSC swap board.
-- **Prior art.** Dynamixel TTL is a well-understood, well-documented bus with a mature protocol (Dynamixel 2.0). OSC copies the electrical and protocol layer rather than inventing a new one.
+- **Prior art.** Dynamixel TTL is a well-understood, well-documented electrical bus. OSC copies the electrical layer as-is; the wire protocol on top is **osc-native** — our own break-framed protocol, inspired by Dynamixel 2.0 but redesigned for sub-$0.20 MCUs ([spec](../../../docs/osc-native-protocol.md)).
 
 Three connectors share the same `GND` / `V+` / `DATA` net — pick whichever fits your wiring:
 
@@ -130,9 +130,9 @@ Selects which thermistor feeds `VNTC`. The center pin (`NTC`) is the common sign
 
 ### UART RX Route — JP2
 
-Selects whether the MCU's `RX` pin is connected to the DXL buffer or floated. This exists so the WCH-LinkE's `TX` / `RX` pins on **J4** can be used as a regular UART (for `printf` / log output, host comms, etc.) without contention against the DXL buffer.
+Selects whether the MCU's `RX` pin is connected to the bus buffer or floated. This exists so the WCH-LinkE's `TX` / `RX` pins on **J4** can be used as a regular UART (for `printf` / log output, host comms, etc.) without contention against the bus buffer.
 
-- `RX` ↔ `TTL`: connects `RX` to the 74LVC2G241 buffer output. Use this for normal **DXL bus operation**.
+- `RX` ↔ `TTL`: connects `RX` to the 74LVC2G241 buffer output. Use this for normal **servo-bus operation**.
 - `RX` ↔ `NC`: floats `RX`. Use this when you want the **LinkE's UART** to drive `RX` directly via J4 — otherwise the buffer would hold `RX` high and contend with the LinkE's `TX`.
 
 ## Test points
@@ -150,7 +150,7 @@ Probe pads line three edges of the board, grouped by rail family for easy scope 
 | `RX`    | MCU UART RX.                                                                                     |
 | `TX`    | MCU UART TX.                                                                                     |
 | `TX_EN` | TX Enable. 74LVC2G241 buffer direction                                                           |
-| `DATA`  | Buffered DXL bus                                                                                 |
+| `DATA`  | Buffered servo bus (TTL)                                                                                 |
 
 ### Vertical rail — motor control / analog
 

--- a/hardware/boards/osc-dev-v006/README.md
+++ b/hardware/boards/osc-dev-v006/README.md
@@ -108,7 +108,7 @@ Intended as the upgrade path for higher-precision position feedback (e.g. a cust
 OpenServoCore uses **single-wire half-duplex UART (Dynamixel-TTL electrical layer)** as its physical bus. Two reasons:
 
 - **Three wires only** (`GND` / `V+` / `DATA`) — the same pin count as the original 3-wire hobby-servo cable, so a stock SG90/MG90 cable is reused as-is when swapping the OEM control board for an OSC swap board.
-- **Prior art.** Dynamixel TTL is a well-understood, well-documented electrical bus. OSC copies the electrical layer as-is; the wire protocol on top is **osc-native** — our own break-framed protocol, inspired by Dynamixel 2.0 but redesigned for sub-$0.20 MCUs ([spec](../../../docs/osc-native-protocol.md)).
+- **Prior art.** Dynamixel TTL is a well-understood, well-documented electrical bus. OSC copies the electrical layer as-is; the wire protocol on top is **osc-native** — OSC's own break-framed protocol, inspired by Dynamixel 2.0 but redesigned for sub-$0.20 MCUs ([spec](../../../docs/osc-native-protocol.md)).
 
 Three connectors share the same `GND` / `V+` / `DATA` net — pick whichever fits your wiring:
 

--- a/hardware/boards/sg90-prod-ch32v006/README.md
+++ b/hardware/boards/sg90-prod-ch32v006/README.md
@@ -1,16 +1,16 @@
 # OSC SG90 CH32
 
 > ⚠️ **Designed, not spun. Pre-fabrication, pre-bringup.**
-> This board has never been fabbed. Numbers and behaviour described below are **design intent**, not measured. The schematic and layout exist; the firmware they're meant to run does not yet — firmware v2 is unstarted as of this writing. Don't fab this without doing your own review first, and expect changes when bringup finally happens.
+> This board has never been fabbed. Numbers and behaviour described below are **design intent**, not measured. The schematic and layout exist; firmware v2 now runs on the dev board (the bus transport is silicon-proven) but has never run on *this* board. Don't fab this without doing your own review first, and expect changes when bringup finally happens.
 
-OpenServoCore swap board for SG90-class hobby servos. Compact, double-sided, designed to physically replace the factory PCB inside an SG90 case. CH32V006-based, DXL-compatible half-duplex UART, drop-in mechanical fit.
+OpenServoCore swap board for SG90-class hobby servos. Compact, double-sided, designed to physically replace the factory PCB inside an SG90 case. CH32V006-based, single-wire TTL servo bus (osc-native protocol), drop-in mechanical fit.
 
 ## Overview
 
 - **MCU** — CH32V006F8U6 (RISC-V, 48 MHz, 62 KB flash, 8 KB RAM).
 - **Motor driver** — TI DRV8837 H-bridge (1.8 A peak, IN1/IN2 PWM).
 - **LDO** — TPAP2210K-3.3, 3.3 V logic rail.
-- **UART buffer** — SN74LVC1G07 open-drain for half-duplex DXL.
+- **UART buffer** — SN74LVC1G07 open-drain for the half-duplex TTL bus.
 - **Current shunt** — 25 mΩ, 1 % on the low side.
 - **Power input** — 3.3-8.4 V (1S-2S LiPo) via the servo cable.
 - **Debug** — 4-pad SWD interface for WCH-LinkE.
@@ -67,7 +67,7 @@ These are the targets the board was laid out around. None are measured.
 - **Position sensing** — 12-bit ADC on `VPOS` with an RC filter (10 kΩ + 100 nF, fc ≈ 160 Hz) to suppress wiper noise. Sub-degree resolution is the design goal; actual precision waits on bringup and firmware oversampling.
 - **Voltage sensing** — 20 kΩ / 10 kΩ dividers (ratio 0.333) on `VINS`, `VSNA`, `VSNB`. 8.4 V → 2.8 V at the ADC.
 - **Current sensing** — 25 mΩ low-side shunt, sized for the DRV8837's ~1.76 A peak via `R_shunt ≈ 44 mV / I_stall`, so the hardware stall-detect path trips near the driver's max output. Raw V_shunt = 25 mV at 1 A; firmware sets ADC sampling, gain path, and software overcurrent threshold.
-- **Communication** — DXL-style half-duplex UART. The SN74LVC1G07 open-drain buffer enables bidirectional comms over the single `DATA` line. Baud rate TBD — left to firmware v2 to choose.
+- **Communication** — single-wire half-duplex TTL servo bus (Dynamixel-TTL electrical layer; the wire protocol is [osc-native](../../../docs/osc-native-protocol.md)). The SN74LVC1G07 open-drain buffer enables bidirectional comms over the single `DATA` line. Bus rates: 0.5-3 Mbaud, default 1 M.
 - **Protection** — PESD5V0L1UL TVS on `DATA`.
 
 ## Assembly


### PR DESCRIPTION
Design docs for the v2 firmware, out of #20. These describe the tree as it is — the how-it-got-here stories are quarantined in design-history.md where they belong.

- **osc-native-protocol.md** — the wire spec: break framing, CRC, instruction set, management plane.
- **osc-servo-transport.md** — how a $0.15 MCU with no input capture and no crystal turns break-framed traffic into ~30 µs replies. All DMA, two ISRs, one comparator.
- **driver-pattern.md** — the firmware layering convention (services / drivers / providers / HAL), with the bus driver as the worked example.
- **design-history.md** — what I tried and threw away. I built a full DXL 2.0 stack, tuned it to 62.8 µs pings, then deleted it. The doc explains why that was the right order to do things in.
- **testing.md** — the three test gears and what each one can't prove.

Also updates the READMEs to match reality: the electrical layer is still Dynamixel TTL (a stock servo cable works), the protocol on it is OSC's own. No code.
