### PR TITLE
firmware: lib workspace foundations (units, log, osc-protocol)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-test:
+    name: build + test (firmware/lib)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: firmware/lib
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (nightly + clippy + rustfmt)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: firmware/lib
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --workspace --tests -- -D warnings
+      - name: cargo build
+        run: cargo build --workspace
+      - name: cargo test
+        run: cargo test --workspace

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -1,0 +1,19 @@
+# Rust artifacts
+/target/
+**/target/
+
+# Workspace lock files (not committed for lib workspaces)
+lib/Cargo.lock
+ch32/Cargo.lock
+
+# Rust-analyzer
+/rust-project.json
+
+# Probe-rs output
+*.elf
+*.bin
+
+# RTT / debug logs
+rtt.log
+logs/
+**/logs/

--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,0 +1,23 @@
+[workspace]
+resolver = "2"
+members = ["log", "osc-protocol", "units"]
+
+[workspace.package]
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[workspace.dependencies]
+heapless         = "0.9"
+bbqueue          = "0.7"
+portable-atomic  = { version = "1", default-features = false }
+critical-section = "1.2"
+bitflags         = "2"
+crc              = { version = "3", default-features = false }
+
+osc-units            = { path = "units" }
+osc-log              = { path = "log" }
+osc-protocol         = { path = "osc-protocol" }
+osc-core             = { path = "core" }
+osc-drivers          = { path = "drivers" }
+control-table        = { path = "control-table" }
+control-table-derive = { path = "control-table-derive" }

--- a/firmware/lib/log/Cargo.toml
+++ b/firmware/lib/log/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name    = "osc-log"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+defmt = { version = "1", optional = true }
+log   = { version = "0.4", optional = true }
+
+[features]
+default = []
+defmt   = ["dep:defmt"]
+log     = ["dep:log"]

--- a/firmware/lib/log/src/lib.rs
+++ b/firmware/lib/log/src/lib.rs
@@ -1,0 +1,38 @@
+//! Logging facade -- forwards to `defmt` on embedded, to `log` on host, else a
+//! no-op. Shared by the lib crates (`osc-core`, `osc-drivers`), each of which
+//! re-exports it as its own `log` module so call sites read `crate::log::*`.
+//!
+//! NOTE: `defmt`'s macros expand to absolute `::defmt::...` paths, so any crate
+//! that *invokes* a logging macro under the `defmt` feature must also carry its
+//! own `defmt` dependency -- re-exporting from here is not enough. The `log` and
+//! no-op backends are hygienic and need nothing. Crates that only forward the
+//! facade (never invoke) can drop the dep entirely.
+
+#![no_std]
+
+#[cfg(feature = "defmt")]
+pub use defmt::{debug, error, info, trace, warn};
+
+#[cfg(all(feature = "log", not(feature = "defmt")))]
+pub use log::{debug, error, info, trace, warn};
+
+#[cfg(not(any(feature = "defmt", feature = "log")))]
+pub use noop::*;
+
+#[cfg(not(any(feature = "defmt", feature = "log")))]
+mod noop {
+    // Tuple binding keeps referenced vars "used" so call sites stay warning-clean.
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! __osc_log_noop {
+        ($($arg:tt)*) => {{
+            let _ = ($($arg)*);
+        }};
+    }
+
+    pub use crate::__osc_log_noop as debug;
+    pub use crate::__osc_log_noop as error;
+    pub use crate::__osc_log_noop as info;
+    pub use crate::__osc_log_noop as trace;
+    pub use crate::__osc_log_noop as warn;
+}

--- a/firmware/lib/osc-protocol/Cargo.toml
+++ b/firmware/lib/osc-protocol/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name    = "osc-protocol"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dev-dependencies]
+osc-protocol = { path = ".", features = ["software-crc"] }
+
+[features]
+default      = []
+# Reference implementation of osc-CRC-16 (protocol sec 3.2). Off by default so chips
+# bring their own (V006: SPI engine + DMA); hosts and tests turn it on.
+software-crc = []

--- a/firmware/lib/osc-protocol/src/bytes.rs
+++ b/firmware/lib/osc-protocol/src/bytes.rs
@@ -1,0 +1,175 @@
+//! A frame's bytes as up to two contiguous segments (`docs/osc-native-protocol.md`
+//! sec 3.1). The RX ring hands frames to the parser in place; a frame that wraps
+//! the ring seam arrives as head + tail. `tail` is empty in the common case, so
+//! the contiguous accessors branch once and stay cheap.
+
+/// A frame's bytes as up to two contiguous segments -- `tail` logically follows
+/// `head`. Every accessor is non-panicking (bounds-checked, `Option` returns).
+#[derive(Copy, Clone)]
+pub struct FrameBytes<'a> {
+    head: &'a [u8],
+    tail: &'a [u8],
+}
+
+impl<'a> FrameBytes<'a> {
+    #[inline]
+    pub fn new(head: &'a [u8], tail: &'a [u8]) -> Self {
+        Self { head, tail }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.head.len() + self.tail.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.head.is_empty() && self.tail.is_empty()
+    }
+
+    /// Byte `i` in the logical concatenation, or `None` past the end.
+    #[inline]
+    pub fn u8_at(&self, i: usize) -> Option<u8> {
+        let hlen = self.head.len();
+        if i < hlen {
+            self.head.get(i).copied()
+        } else {
+            self.tail.get(i - hlen).copied()
+        }
+    }
+
+    /// Little-endian `u16` at logical offset `i`.
+    #[inline]
+    pub fn u16_le_at(&self, i: usize) -> Option<u16> {
+        Some(u16::from_le_bytes([self.u8_at(i)?, self.u8_at(i + 1)?]))
+    }
+
+    /// The `len`-byte sub-range at logical offset `start`, itself possibly
+    /// spanning the seam. `None` if `[start, start+len)` leaves the view.
+    #[inline]
+    pub fn sub(&self, start: usize, len: usize) -> Option<FrameBytes<'a>> {
+        let end = start.checked_add(len)?;
+        if end > self.len() {
+            return None;
+        }
+        let hlen = self.head.len();
+        if start >= hlen {
+            let s = start - hlen;
+            Some(FrameBytes::new(self.tail.get(s..s + len)?, &[]))
+        } else if end <= hlen {
+            Some(FrameBytes::new(self.head.get(start..end)?, &[]))
+        } else {
+            Some(FrameBytes::new(
+                self.head.get(start..)?,
+                self.tail.get(..end - hlen)?,
+            ))
+        }
+    }
+
+    /// The raw head/tail spans, for callers that copy or forward them directly
+    /// (the control-table split write, staged push).
+    #[inline]
+    pub fn segments(&self) -> (&'a [u8], &'a [u8]) {
+        (self.head, self.tail)
+    }
+
+    /// Copy the whole view into `dst`; `None` (nothing copied) if `dst` is
+    /// shorter than the view.
+    #[inline]
+    pub fn copy_into(&self, dst: &mut [u8]) -> Option<()> {
+        let (d0, d1) = dst.split_at_mut_checked(self.head.len())?;
+        d0.copy_from_slice(self.head);
+        d1.get_mut(..self.tail.len())?.copy_from_slice(self.tail);
+        Some(())
+    }
+
+    /// The logical bytes in order.
+    #[inline]
+    pub fn bytes(&self) -> impl Iterator<Item = u8> + 'a {
+        let (head, tail) = (self.head, self.tail);
+        head.iter().chain(tail.iter()).copied()
+    }
+}
+
+impl<'a> From<&'a [u8]> for FrameBytes<'a> {
+    #[inline]
+    fn from(bytes: &'a [u8]) -> Self {
+        FrameBytes::new(bytes, &[])
+    }
+}
+
+impl PartialEq for FrameBytes<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.bytes().eq(other.bytes())
+    }
+}
+
+impl Eq for FrameBytes<'_> {}
+
+impl core::fmt::Debug for FrameBytes<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.bytes()).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split_eq(full: &[u8]) {
+        for k in 0..=full.len() {
+            let fb = FrameBytes::new(&full[..k], &full[k..]);
+            assert_eq!(fb.len(), full.len());
+            assert_eq!(fb.is_empty(), full.is_empty());
+            for (i, &b) in full.iter().enumerate() {
+                assert_eq!(fb.u8_at(i), Some(b));
+            }
+            assert_eq!(fb.u8_at(full.len()), None);
+            // Whole-view equality is split-invariant.
+            assert_eq!(fb, FrameBytes::from(full));
+        }
+    }
+
+    #[test]
+    fn accessors_are_split_invariant() {
+        split_eq(&[]);
+        split_eq(&[0xAA]);
+        split_eq(&[1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn u16_le_across_seam() {
+        let full = [0x11, 0x22, 0x33, 0x44];
+        for k in 0..=full.len() {
+            let fb = FrameBytes::new(&full[..k], &full[k..]);
+            assert_eq!(fb.u16_le_at(0), Some(0x2211));
+            assert_eq!(fb.u16_le_at(2), Some(0x4433));
+            assert_eq!(fb.u16_le_at(3), None);
+        }
+    }
+
+    #[test]
+    fn sub_spans_seam() {
+        let full = [10, 11, 12, 13, 14, 15];
+        for k in 0..=full.len() {
+            let fb = FrameBytes::new(&full[..k], &full[k..]);
+            let s = fb.sub(1, 4).unwrap();
+            assert_eq!(s, FrameBytes::from(&full[1..5]));
+            assert_eq!(fb.sub(4, 3), None);
+            assert_eq!(fb.sub(0, full.len()), Some(fb));
+        }
+    }
+
+    #[test]
+    fn copy_into_stitches() {
+        let full = [1u8, 2, 3, 4, 5];
+        for k in 0..=full.len() {
+            let fb = FrameBytes::new(&full[..k], &full[k..]);
+            let mut dst = [0u8; 5];
+            assert_eq!(fb.copy_into(&mut dst), Some(()));
+            assert_eq!(dst, full);
+            let mut small = [0u8; 4];
+            assert_eq!(fb.copy_into(&mut small), None);
+        }
+    }
+}

--- a/firmware/lib/osc-protocol/src/crc.rs
+++ b/firmware/lib/osc-protocol/src/crc.rs
@@ -1,0 +1,100 @@
+//! Reference osc-CRC-16 (`docs/osc-native-protocol.md` sec 3.2). Servos use the
+//! SPI CRC engine for frame spans; this software flavor covers the odd-byte
+//! tail fold (sec 3.2) and the ENUM slot key (sec 9.2). Bitwise, no table --
+//! smallest code wins.
+//!
+//! Flavor: **CRC-16/ARC** -- poly `0x8005` reflected (`0xA001`), init `0x0000`,
+//! reflected input and output, no output XOR. Check: `crc("123456789") =
+//! 0xBB3D`. Byte-wise and prefix-free; a leading `0x00` is a no-op (init = 0),
+//! which is what lets hardware receivers feed the anchor-inclusive ring span
+//! in place (sec 3.2).
+
+const POLY_REFLECTED: u16 = 0xA001;
+
+#[inline]
+fn update(mut crc: u16, byte: u8) -> u16 {
+    crc ^= byte as u16;
+    for _ in 0..8 {
+        crc = if crc & 1 != 0 {
+            (crc >> 1) ^ POLY_REFLECTED
+        } else {
+            crc >> 1
+        };
+    }
+    crc
+}
+
+/// osc-CRC-16 over `covered` (the frame bytes `ID .. PAD`; an anchor-inclusive
+/// span with its leading `0x00` yields the same value).
+#[inline]
+pub fn osc_crc(covered: &[u8]) -> u16 {
+    osc_crc_continue(0, covered)
+}
+
+/// Accumulate `chunk` into a running CRC -- byte-wise, so chunks may split
+/// anywhere (mirrors the hardware engine spanning DMA arms).
+/// `osc_crc(x) == osc_crc_continue(0, x)`.
+pub fn osc_crc_continue(mut crc: u16, chunk: &[u8]) -> u16 {
+    for &b in chunk {
+        crc = update(crc, b);
+    }
+    crc
+}
+
+/// Reverse the bit order of a 16-bit value. The V006 SPI CRC unit's register
+/// holds the bit-reversed checksum in LSB-first mode (sec 3.2, spike
+/// `spi_crc_lsb_copy`): chip providers apply this once per frame. Three
+/// parallel in-byte swap stages, then the byte swap -- no table, no multiply.
+#[inline]
+pub fn bitrev16(v: u16) -> u16 {
+    let mut x = v as u32;
+    x = ((x & 0x5555) << 1) | ((x >> 1) & 0x5555);
+    x = ((x & 0x3333) << 2) | ((x >> 2) & 0x3333);
+    x = ((x & 0x0f0f) << 4) | ((x >> 4) & 0x0f0f);
+    (x as u16).swap_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_check_value() {
+        assert_eq!(osc_crc(b"123456789"), 0xBB3D);
+    }
+
+    #[test]
+    fn spec_vectors() {
+        assert_eq!(osc_crc(&[0x01, 0x03, 0x10]), 0xFC50);
+        assert_eq!(osc_crc(&[0x05, 0x07, 0x30, 0x80, 0x01, 0x2C, 0x01]), 0xB3B1);
+        assert_eq!(osc_crc(&[0x03, 0x07, 0x20, 0x00, 0x02, 0x08, 0x00]), 0x7015);
+        assert_eq!(osc_crc(&[0x02, 0x07, 0x32, 0x00, 0x01, 0xAA, 0x00]), 0xD334);
+    }
+
+    #[test]
+    fn leading_zero_is_a_noop() {
+        assert_eq!(
+            osc_crc(&[0x00, 0x01, 0x03, 0x10]),
+            osc_crc(&[0x01, 0x03, 0x10])
+        );
+    }
+
+    #[test]
+    fn split_anywhere_matches_whole() {
+        let v = [0x05, 0x07, 0x30, 0x80, 0x01, 0x2C, 0x01];
+        let whole = osc_crc(&v);
+        for split in 0..=v.len() {
+            let (a, b) = v.split_at(split);
+            let crc = osc_crc_continue(osc_crc_continue(0, a), b);
+            assert_eq!(crc, whole, "split at {split}");
+        }
+    }
+
+    #[test]
+    fn bitrev16_matches_silicon_fingerprint() {
+        // spi_crc_lsb_copy: TCRCR("12345678") = 0xB93C = bitrev16(ARC 0x3C9D).
+        assert_eq!(osc_crc(b"12345678"), 0x3C9D);
+        assert_eq!(bitrev16(0x3C9D), 0xB93C);
+        assert_eq!(bitrev16(bitrev16(0x1234)), 0x1234);
+    }
+}

--- a/firmware/lib/osc-protocol/src/frame.rs
+++ b/firmware/lib/osc-protocol/src/frame.rs
@@ -1,0 +1,452 @@
+//! osc-native RX views: a `#[repr(C)]` header over ring bytes plus zero-copy
+//! payload parsers (`docs/osc-native-protocol.md` sec 3.1, sec 5). Layout only -- the
+//! chip owns the ring and its cursor; these borrow into it.
+
+use crate::bytes::FrameBytes;
+use crate::wire::{self, Id, Inst, MgmtOp};
+
+/// Why a header cannot be dispatched. Frame-level rejects (sec 5.3 layer 1): the
+/// frame is dropped, no reply.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum FrameError {
+    ShortLen,
+    BadId,
+    BadOpcode,
+}
+
+/// The four fixed bytes at a frame anchor: the break's `0x00` ring byte, then
+/// `ID`, `LEN`, `INST` (sec 3.1). All fields are `u8`-transparent, so the struct
+/// is four bytes at alignment 1 and any bit pattern is a valid `Header` -- that
+/// is what makes the pointer casts below sound.
+#[repr(C)]
+pub struct Header {
+    pub brk: u8,
+    pub id: Id,
+    pub len: u8,
+    pub inst: Inst,
+}
+
+impl Header {
+    pub const SIZE: usize = 4;
+
+    #[inline]
+    pub fn from_bytes(b: &[u8; 4]) -> &Header {
+        // SAFETY: `Header` is four repr(transparent) u8 newtypes (size 4,
+        // align 1); every 4-byte pattern is a valid `Header`, and the borrow's
+        // lifetime is tied to `b`.
+        unsafe { &*(b.as_ptr() as *const Header) }
+    }
+
+    /// # Safety
+    /// `p` must point to 4 readable bytes. The caller picks the lifetime `'a`
+    /// and must keep the ring memory valid for it.
+    #[inline]
+    pub unsafe fn from_anchor<'a>(p: *const u8) -> &'a Header {
+        // SAFETY: caller guarantees 4 readable bytes at `p`; `Header` is 4
+        // u8-transparent fields (align 1), valid for any bit pattern.
+        unsafe { &*(p as *const Header) }
+    }
+
+    /// `LEN` must cover INST + CRC (>= 3, sec 3.1), `ID` addressable, and -- for
+    /// instruction frames -- the opcode nonzero (sec 5).
+    pub fn validate(&self) -> Result<(), FrameError> {
+        if self.len < 3 {
+            return Err(FrameError::ShortLen);
+        }
+        if !self.id.is_valid() {
+            return Err(FrameError::BadId);
+        }
+        if !self.inst.is_status() && self.inst.opcode().is_none() {
+            return Err(FrameError::BadOpcode);
+        }
+        Ok(())
+    }
+
+    /// Ring bytes from the anchor to the frame's end, exclusive (sec 3.1).
+    #[inline]
+    pub fn frame_end(&self) -> usize {
+        wire::footprint(self.len)
+    }
+
+    #[inline]
+    pub fn covered_len(&self) -> usize {
+        wire::covered_len(self.len)
+    }
+
+    #[inline]
+    pub fn payload_len(&self) -> u8 {
+        wire::payload_len(self.len)
+    }
+}
+
+/// READ / GREAD span request: `addr(2), count(2)` little-endian (sec 5).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ReadReq {
+    pub addr: u16,
+    pub count: u16,
+}
+
+impl ReadReq {
+    #[inline]
+    pub fn parse(payload: FrameBytes) -> Option<ReadReq> {
+        if payload.len() != 4 {
+            return None;
+        }
+        Some(ReadReq {
+            addr: payload.u16_le_at(0)?,
+            count: payload.u16_le_at(2)?,
+        })
+    }
+}
+
+/// READ+PROFILE slot request: `slot(1)` names a profile slot instead of
+/// addr+count (sec 5.2).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ProfileReq {
+    pub slot: u8,
+}
+
+impl ProfileReq {
+    #[inline]
+    pub fn parse(payload: FrameBytes) -> Option<ProfileReq> {
+        if payload.len() != 1 {
+            return None;
+        }
+        Some(ProfileReq {
+            slot: payload.u8_at(0)?,
+        })
+    }
+}
+
+/// WRITE request: `addr(2)` little-endian, then the data bytes (sec 5).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct WriteReq<'a> {
+    pub addr: u16,
+    pub data: FrameBytes<'a>,
+}
+
+impl<'a> WriteReq<'a> {
+    #[inline]
+    pub fn parse(payload: FrameBytes<'a>) -> Option<WriteReq<'a>> {
+        let addr = payload.u16_le_at(0)?;
+        let data = payload.sub(2, payload.len().checked_sub(2)?)?;
+        Some(WriteReq { addr, data })
+    }
+}
+
+/// MGMT request: sub-op byte, then its args (sec 9).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct MgmtReq<'a> {
+    pub op: MgmtOp,
+    pub args: FrameBytes<'a>,
+}
+
+impl<'a> MgmtReq<'a> {
+    #[inline]
+    pub fn parse(payload: FrameBytes<'a>) -> Option<MgmtReq<'a>> {
+        let op = MgmtOp::from_byte(payload.u8_at(0)?)?;
+        let args = payload.sub(1, payload.len().checked_sub(1)?)?;
+        Some(MgmtReq { op, args })
+    }
+}
+
+/// MGMT ENUM args: `prefix_len(1)` in bits (0..=128), then the
+/// `ceil(prefix_len/8)`-byte prefix (sec 9.2). Unused prefix bytes are zero.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EnumReq {
+    pub prefix_len: u8,
+    pub prefix: [u8; wire::UID_LEN],
+}
+
+impl EnumReq {
+    pub const MAX_PREFIX_BITS: u8 = (wire::UID_LEN * 8) as u8;
+
+    #[inline]
+    pub fn parse(args: FrameBytes) -> Option<EnumReq> {
+        let prefix_len = args.u8_at(0)?;
+        if prefix_len > Self::MAX_PREFIX_BITS {
+            return None;
+        }
+        let n = prefix_len.div_ceil(8) as usize;
+        if args.len() != 1 + n {
+            return None;
+        }
+        let mut prefix = [0u8; wire::UID_LEN];
+        args.sub(1, n)?.copy_into(&mut prefix[..n])?;
+        Some(EnumReq { prefix_len, prefix })
+    }
+}
+
+/// sec 9.2: does `uid` begin with the `prefix_len`-bit prefix? The prefix is an
+/// LSB-first bit stream -- bit `k` is `uid[k/8] >> (k%8) & 1`, the order the
+/// UART itself shifts bits onto the wire.
+pub fn uid_prefix_matches(
+    uid: &[u8; wire::UID_LEN],
+    prefix_len: u8,
+    prefix: &[u8; wire::UID_LEN],
+) -> bool {
+    let full = (prefix_len / 8) as usize;
+    let rem = prefix_len % 8;
+    if uid[..full] != prefix[..full] {
+        return false;
+    }
+    rem == 0 || (uid[full] ^ prefix[full]) & ((1 << rem) - 1) == 0
+}
+
+/// MGMT ASSIGN args: `uid(16)`, `new_id(1)` (sec 9.2).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct AssignReq {
+    pub uid: [u8; wire::UID_LEN],
+    pub new_id: u8,
+}
+
+impl AssignReq {
+    #[inline]
+    pub fn parse(args: FrameBytes) -> Option<AssignReq> {
+        if args.len() != wire::UID_LEN + 1 {
+            return None;
+        }
+        let mut uid = [0u8; wire::UID_LEN];
+        args.sub(0, wire::UID_LEN)?.copy_into(&mut uid)?;
+        Some(AssignReq {
+            uid,
+            new_id: args.u8_at(wire::UID_LEN)?,
+        })
+    }
+}
+
+/// MGMT CAL args: `gap_us(2 LE)`, `gaps(1)` (sec 9.3) -- the host follows the
+/// frame with `gaps + 1` bare breaks spaced exactly `gap_us` apart, its
+/// crystal keeping the spacing. Zero in either field is no train.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CalReq {
+    pub gap_us: u16,
+    pub gaps: u8,
+}
+
+impl CalReq {
+    #[inline]
+    pub fn parse(args: FrameBytes) -> Option<CalReq> {
+        if args.len() != 3 {
+            return None;
+        }
+        let gap_us = args.u16_le_at(0)?;
+        let gaps = args.u8_at(2)?;
+        if gap_us == 0 || gaps == 0 {
+            return None;
+        }
+        Some(CalReq { gap_us, gaps })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::{Opcode, ResultCode};
+
+    #[test]
+    fn header_over_ping_vector() {
+        let h = Header::from_bytes(&[0x00, 0x01, 0x03, 0x10]);
+        assert_eq!(h.brk, 0x00);
+        assert_eq!(h.id, Id::new(1));
+        assert_eq!(h.len, 3);
+        assert_eq!(h.inst.opcode(), Some(Opcode::Ping));
+        assert_eq!(h.payload_len(), 0);
+        assert_eq!(h.covered_len(), 4);
+        assert_eq!(h.frame_end(), 6);
+        assert_eq!(h.validate(), Ok(()));
+    }
+
+    #[test]
+    fn header_payload_len() {
+        // Odd-payload WRITE vector: LEN 6 -> p = 3 (no pad, sec 3.1).
+        let h = Header::from_bytes(&[0x00, 0x02, 0x06, 0x30]);
+        assert_eq!(h.payload_len(), 3);
+        assert_eq!(h.frame_end(), 9);
+    }
+
+    #[test]
+    fn validate_rejects() {
+        assert_eq!(
+            Header::from_bytes(&[0x00, 0x01, 0x02, 0x10]).validate(),
+            Err(FrameError::ShortLen)
+        );
+        // Even LEN is legal (sec 3.1: any LEN >= 3).
+        assert_eq!(
+            Header::from_bytes(&[0x00, 0x01, 0x04, 0x10]).validate(),
+            Ok(())
+        );
+        assert_eq!(
+            Header::from_bytes(&[0x00, 0x00, 0x03, 0x10]).validate(),
+            Err(FrameError::BadId)
+        );
+        assert_eq!(
+            Header::from_bytes(&[0x00, 0x01, 0x03, 0x00]).validate(),
+            Err(FrameError::BadOpcode)
+        );
+    }
+
+    fn fb(b: &[u8]) -> FrameBytes<'_> {
+        FrameBytes::from(b)
+    }
+
+    #[test]
+    fn read_req_parse() {
+        assert_eq!(
+            ReadReq::parse(fb(&[0x00, 0x02, 0x08, 0x00])),
+            Some(ReadReq {
+                addr: 0x0200,
+                count: 8
+            })
+        );
+        assert_eq!(ReadReq::parse(fb(&[0x00, 0x02, 0x08])), None);
+        assert_eq!(ReadReq::parse(fb(&[0, 0, 0, 0, 0])), None);
+    }
+
+    #[test]
+    fn profile_req_parse() {
+        assert_eq!(ProfileReq::parse(fb(&[2])), Some(ProfileReq { slot: 2 }));
+        assert_eq!(ProfileReq::parse(fb(&[])), None);
+        assert_eq!(ProfileReq::parse(fb(&[2, 0])), None);
+    }
+
+    #[test]
+    fn write_req_parse() {
+        assert_eq!(
+            WriteReq::parse(fb(&[0x80, 0x01, 0x2C, 0x01])),
+            Some(WriteReq {
+                addr: 0x0180,
+                data: fb(&[0x2C, 0x01])
+            })
+        );
+        // Empty data is legal (>= 2 bytes = addr only).
+        assert_eq!(
+            WriteReq::parse(fb(&[0x00, 0x01])),
+            Some(WriteReq {
+                addr: 0x0100,
+                data: fb(&[])
+            })
+        );
+        assert_eq!(WriteReq::parse(fb(&[0x80])), None);
+    }
+
+    #[test]
+    fn mgmt_req_parse() {
+        assert_eq!(
+            MgmtReq::parse(fb(&[0x02, 0xAA])),
+            Some(MgmtReq {
+                op: MgmtOp::Assign,
+                args: fb(&[0xAA])
+            })
+        );
+        assert_eq!(MgmtReq::parse(fb(&[])), None);
+        assert_eq!(MgmtReq::parse(fb(&[0x00])), None);
+    }
+
+    #[test]
+    fn cal_req_parse() {
+        // 400 us gaps, 8 of them: `[0x06, 0x90, 0x01, 0x08]` MGMT payload.
+        assert_eq!(
+            CalReq::parse(fb(&[0x90, 0x01, 0x08])),
+            Some(CalReq {
+                gap_us: 400,
+                gaps: 8
+            })
+        );
+        // Wrong arg count, zero gap, zero count: no train.
+        assert_eq!(CalReq::parse(fb(&[0x90, 0x01])), None);
+        assert_eq!(CalReq::parse(fb(&[0x90, 0x01, 0x08, 0x00])), None);
+        assert_eq!(CalReq::parse(fb(&[0x00, 0x00, 0x08])), None);
+        assert_eq!(CalReq::parse(fb(&[0x90, 0x01, 0x00])), None);
+    }
+
+    #[test]
+    fn enum_req_parse() {
+        // Empty prefix: the tree root, matches every servo.
+        assert_eq!(
+            EnumReq::parse(fb(&[0])),
+            Some(EnumReq {
+                prefix_len: 0,
+                prefix: [0; 16]
+            })
+        );
+        // 10 bits -> 2 prefix bytes, upper bytes zero-filled.
+        let e = EnumReq::parse(fb(&[10, 0xAB, 0x03])).unwrap();
+        assert_eq!(e.prefix_len, 10);
+        assert_eq!(e.prefix[..2], [0xAB, 0x03]);
+        assert_eq!(e.prefix[2..], [0; 14]);
+        // Full 128-bit prefix.
+        let mut full = [0u8; 17];
+        full[0] = 128;
+        for (i, b) in full[1..].iter_mut().enumerate() {
+            *b = i as u8 + 1;
+        }
+        let e = EnumReq::parse(fb(&full)).unwrap();
+        assert_eq!(e.prefix, full[1..]);
+        // Rejects: over-long prefix_len, byte count not matching prefix_len.
+        assert_eq!(EnumReq::parse(fb(&[129])), None);
+        assert_eq!(EnumReq::parse(fb(&[10, 0xAB])), None);
+        assert_eq!(EnumReq::parse(fb(&[8, 0xAB, 0xCD])), None);
+        assert_eq!(EnumReq::parse(fb(&[])), None);
+    }
+
+    #[test]
+    fn uid_prefix_match_boundaries() {
+        let mut uid = [0u8; 16];
+        uid[0] = 0b1010_0101;
+        uid[1] = 0xFF;
+        uid[15] = 0x80;
+        let m = |len: u8, prefix: &[u8]| {
+            let mut p = [0u8; 16];
+            p[..prefix.len()].copy_from_slice(prefix);
+            uid_prefix_matches(&uid, len, &p)
+        };
+        // Length 0 matches everything.
+        assert!(m(0, &[]));
+        // Bit 0 is the LSB of byte 0 (LSB-first stream).
+        assert!(m(1, &[0b1]));
+        assert!(!m(1, &[0b0]));
+        // Partial byte: only the low `rem` bits compare.
+        assert!(m(3, &[0b101]));
+        assert!(!m(3, &[0b111])); // bit 1 differs
+        assert!(m(3, &[0b1111_1101])); // high bits past the prefix are masked off
+        // Byte boundary: 8 bits = whole first byte.
+        assert!(m(8, &[0b1010_0101]));
+        assert!(!m(8, &[0b0010_0101]));
+        // 127 bits: everything but the UID's top bit.
+        let mut p = uid;
+        p[15] = 0x00; // differs only in bit 127
+        assert!(uid_prefix_matches(&uid, 127, &p));
+        assert!(!uid_prefix_matches(&uid, 128, &p));
+        // 128 bits: exact match.
+        assert!(uid_prefix_matches(&uid, 128, &uid));
+    }
+
+    #[test]
+    fn assign_req_parse() {
+        let mut args = [0u8; 17];
+        for (i, b) in args[..16].iter_mut().enumerate() {
+            *b = i as u8 + 1;
+        }
+        args[16] = 7;
+        let want: [u8; 16] = args[..16].try_into().unwrap();
+        assert_eq!(
+            AssignReq::parse(fb(&args)),
+            Some(AssignReq {
+                uid: want,
+                new_id: 7
+            })
+        );
+        assert_eq!(AssignReq::parse(fb(&args[..16])), None);
+        assert_eq!(AssignReq::parse(fb(&[])), None);
+    }
+
+    #[test]
+    fn status_frame_validates() {
+        let bytes = [0x00, 0x07, 0x03, Inst::status(ResultCode::Ok, false).0];
+        let h = Header::from_bytes(&bytes);
+        assert!(h.inst.is_status());
+        assert_eq!(h.inst.opcode(), None);
+        assert_eq!(h.validate(), Ok(()));
+    }
+}

--- a/firmware/lib/osc-protocol/src/group.rs
+++ b/firmware/lib/osc-protocol/src/group.rs
@@ -1,0 +1,577 @@
+//! Group instruction payload views (`docs/osc-native-protocol.md` sec 5, sec 6).
+//!
+//! GREAD and GWRITE each come in a uniform and a PER_TARGET form. Frames
+//! arrive whole and CRC-verified, so `parse` performs all structural
+//! validation up front (payloads cap at 252 B, sec 5.1, so even the
+//! variable-stride walk is trivially cheap); the iterators then run over
+//! known-well-formed bytes and stay branch-light. A servo's reply slot is its
+//! 0-based position in the listed order (sec 6) -- `slot_of` / `find` report it.
+//!
+//! Duplicate IDs are legal on the wire; first match wins in `find`/`slot_of`.
+
+use crate::bytes::FrameBytes;
+use crate::wire::Id;
+
+/// A resolved PER_TARGET GREAD entry: one span request for one servo.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GreadTarget {
+    pub id: Id,
+    pub addr: u16,
+    pub count: u16,
+}
+
+/// A resolved PER_TARGET GWRITE entry: one servo's own span and data.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GwriteTarget<'a> {
+    pub id: Id,
+    pub addr: u16,
+    pub data: FrameBytes<'a>,
+}
+
+/// A resolved PER_TARGET GREAD+PROFILE entry: one profile slot for one servo.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GreadProfileTarget {
+    pub id: Id,
+    pub slot: u8,
+}
+
+/// Uniform GREAD: `addr(2) count(2) id-list(1 each)` -- one span, many servos,
+/// replies chain in list order.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GreadUniform<'a> {
+    pub addr: u16,
+    pub count: u16,
+    ids: FrameBytes<'a>,
+}
+
+impl<'a> GreadUniform<'a> {
+    pub fn parse(payload: FrameBytes<'a>) -> Option<Self> {
+        let addr = payload.u16_le_at(0)?;
+        let count = payload.u16_le_at(2)?;
+        let ids = payload.sub(4, payload.len().checked_sub(4)?)?;
+        if ids.is_empty() {
+            return None;
+        }
+        Some(Self { addr, count, ids })
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = Id> + 'a {
+        self.ids.bytes().map(Id::new)
+    }
+
+    pub fn slot_of(&self, id: Id) -> Option<u8> {
+        self.ids
+            .bytes()
+            .position(|b| b == id.as_byte())
+            .map(|p| p as u8)
+    }
+}
+
+/// PER_TARGET GREAD: `[id(1) addr(2) count(2)]x` -- fixed 5-byte entries.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GreadPerTarget<'a> {
+    entries: FrameBytes<'a>,
+}
+
+impl<'a> GreadPerTarget<'a> {
+    pub fn parse(payload: FrameBytes<'a>) -> Option<Self> {
+        if payload.is_empty() || !payload.len().is_multiple_of(5) {
+            return None;
+        }
+        Some(Self { entries: payload })
+    }
+
+    pub fn iter(&self) -> GreadPerTargetIter<'a> {
+        GreadPerTargetIter { rest: self.entries }
+    }
+
+    pub fn find(&self, id: Id) -> Option<(u8, GreadTarget)> {
+        self.iter()
+            .enumerate()
+            .find(|(_, t)| t.id == id)
+            .map(|(i, t)| (i as u8, t))
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct GreadPerTargetIter<'a> {
+    rest: FrameBytes<'a>,
+}
+
+impl Iterator for GreadPerTargetIter<'_> {
+    type Item = GreadTarget;
+
+    fn next(&mut self) -> Option<GreadTarget> {
+        if self.rest.len() < 5 {
+            return None;
+        }
+        let id = self.rest.u8_at(0)?;
+        let addr = self.rest.u16_le_at(1)?;
+        let count = self.rest.u16_le_at(3)?;
+        self.rest = self.rest.sub(5, self.rest.len() - 5)?;
+        Some(GreadTarget {
+            id: Id::new(id),
+            addr,
+            count,
+        })
+    }
+}
+
+/// Uniform GREAD+PROFILE: `slot(1) id-list(1 each)` -- one profile slot, many
+/// servos, replies chain in list order (sec 5.2).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GreadProfileUniform<'a> {
+    pub slot: u8,
+    ids: FrameBytes<'a>,
+}
+
+impl<'a> GreadProfileUniform<'a> {
+    pub fn parse(payload: FrameBytes<'a>) -> Option<Self> {
+        let slot = payload.u8_at(0)?;
+        let ids = payload.sub(1, payload.len().checked_sub(1)?)?;
+        if ids.is_empty() {
+            return None;
+        }
+        Some(Self { slot, ids })
+    }
+
+    pub fn ids(&self) -> impl Iterator<Item = Id> + 'a {
+        self.ids.bytes().map(Id::new)
+    }
+
+    pub fn slot_of(&self, id: Id) -> Option<u8> {
+        self.ids
+            .bytes()
+            .position(|b| b == id.as_byte())
+            .map(|p| p as u8)
+    }
+}
+
+/// PER_TARGET GREAD+PROFILE: `[id(1) slot(1)]x` -- fixed 2-byte entries.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GreadProfilePerTarget<'a> {
+    entries: FrameBytes<'a>,
+}
+
+impl<'a> GreadProfilePerTarget<'a> {
+    pub fn parse(payload: FrameBytes<'a>) -> Option<Self> {
+        if payload.is_empty() || !payload.len().is_multiple_of(2) {
+            return None;
+        }
+        Some(Self { entries: payload })
+    }
+
+    pub fn iter(&self) -> GreadProfilePerTargetIter<'a> {
+        GreadProfilePerTargetIter { rest: self.entries }
+    }
+
+    pub fn find(&self, id: Id) -> Option<(u8, GreadProfileTarget)> {
+        self.iter()
+            .enumerate()
+            .find(|(_, t)| t.id == id)
+            .map(|(i, t)| (i as u8, t))
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct GreadProfilePerTargetIter<'a> {
+    rest: FrameBytes<'a>,
+}
+
+impl Iterator for GreadProfilePerTargetIter<'_> {
+    type Item = GreadProfileTarget;
+
+    fn next(&mut self) -> Option<GreadProfileTarget> {
+        if self.rest.len() < 2 {
+            return None;
+        }
+        let id = self.rest.u8_at(0)?;
+        let slot = self.rest.u8_at(1)?;
+        self.rest = self.rest.sub(2, self.rest.len() - 2)?;
+        Some(GreadProfileTarget {
+            id: Id::new(id),
+            slot,
+        })
+    }
+}
+
+/// Uniform GWRITE: `addr(2) count(1) [id(1) data(count)]x` -- fixed-stride
+/// entries after the 3-byte head.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GwriteUniform<'a> {
+    pub addr: u16,
+    pub count: u8,
+    entries: FrameBytes<'a>,
+}
+
+impl<'a> GwriteUniform<'a> {
+    pub fn parse(payload: FrameBytes<'a>) -> Option<Self> {
+        let addr = payload.u16_le_at(0)?;
+        let count = payload.u8_at(2)?;
+        if count == 0 {
+            return None;
+        }
+        let entries = payload.sub(3, payload.len().checked_sub(3)?)?;
+        let stride = 1 + count as usize;
+        // Reject a ragged tail without a divide (rv32ec +zmmul has no hardware
+        // remainder): walk in stride steps. Bounded -- payloads cap at 252 B.
+        let mut rem = entries.len();
+        if rem == 0 {
+            return None;
+        }
+        while rem >= stride {
+            rem -= stride;
+        }
+        if rem != 0 {
+            return None;
+        }
+        Some(Self {
+            addr,
+            count,
+            entries,
+        })
+    }
+
+    pub fn iter(&self) -> GwriteUniformIter<'a> {
+        GwriteUniformIter {
+            rest: self.entries,
+            stride: 1 + self.count as usize,
+        }
+    }
+
+    pub fn find(&self, id: Id) -> Option<FrameBytes<'a>> {
+        self.iter().find(|(i, _)| *i == id).map(|(_, d)| d)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct GwriteUniformIter<'a> {
+    rest: FrameBytes<'a>,
+    stride: usize,
+}
+
+impl<'a> Iterator for GwriteUniformIter<'a> {
+    type Item = (Id, FrameBytes<'a>);
+
+    fn next(&mut self) -> Option<(Id, FrameBytes<'a>)> {
+        if self.rest.len() < self.stride {
+            return None;
+        }
+        let id = self.rest.u8_at(0)?;
+        let data = self.rest.sub(1, self.stride - 1)?;
+        self.rest = self.rest.sub(self.stride, self.rest.len() - self.stride)?;
+        Some((Id::new(id), data))
+    }
+}
+
+/// PER_TARGET GWRITE: `[id(1) addr(2) count(1) data(count)]x` -- variable
+/// stride, each entry's `count` sizes its own data.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GwritePerTarget<'a> {
+    entries: FrameBytes<'a>,
+}
+
+impl<'a> GwritePerTarget<'a> {
+    pub fn parse(payload: FrameBytes<'a>) -> Option<Self> {
+        if payload.is_empty() {
+            return None;
+        }
+        let mut rest = payload;
+        while !rest.is_empty() {
+            let count = rest.u8_at(3)? as usize;
+            let skip = 4 + count;
+            rest = rest.sub(skip, rest.len().checked_sub(skip)?)?;
+        }
+        Some(Self { entries: payload })
+    }
+
+    pub fn iter(&self) -> GwritePerTargetIter<'a> {
+        GwritePerTargetIter { rest: self.entries }
+    }
+
+    pub fn find(&self, id: Id) -> Option<GwriteTarget<'a>> {
+        self.iter().find(|t| t.id == id)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct GwritePerTargetIter<'a> {
+    rest: FrameBytes<'a>,
+}
+
+impl<'a> Iterator for GwritePerTargetIter<'a> {
+    type Item = GwriteTarget<'a>;
+
+    fn next(&mut self) -> Option<GwriteTarget<'a>> {
+        if self.rest.len() < 4 {
+            return None;
+        }
+        let id = self.rest.u8_at(0)?;
+        let addr = self.rest.u16_le_at(1)?;
+        let count = self.rest.u8_at(3)? as usize;
+        let data = self.rest.sub(4, count)?;
+        self.rest = self.rest.sub(4 + count, self.rest.len() - (4 + count))?;
+        Some(GwriteTarget {
+            id: Id::new(id),
+            addr,
+            data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fb(b: &[u8]) -> FrameBytes<'_> {
+        FrameBytes::from(b)
+    }
+
+    #[test]
+    fn gread_uniform_fields_and_slots() {
+        // addr=0x0084 count=8, ids [1, 2, 5].
+        let p = [0x84, 0x00, 0x08, 0x00, 1, 2, 5];
+        let g = GreadUniform::parse(fb(&p)).unwrap();
+        assert_eq!(g.addr, 0x0084);
+        assert_eq!(g.count, 8);
+        let ids: [Id; 3] = [Id::new(1), Id::new(2), Id::new(5)];
+        assert!(g.ids().eq(ids));
+        assert_eq!(g.slot_of(Id::new(1)), Some(0));
+        assert_eq!(g.slot_of(Id::new(2)), Some(1));
+        assert_eq!(g.slot_of(Id::new(5)), Some(2));
+        assert_eq!(g.slot_of(Id::new(9)), None);
+    }
+
+    #[test]
+    fn gread_uniform_rejects_empty_and_short() {
+        // Head present but no IDs listed.
+        assert_eq!(GreadUniform::parse(fb(&[0x84, 0x00, 0x08, 0x00])), None);
+        // Fewer than the 4 head bytes.
+        assert_eq!(GreadUniform::parse(fb(&[0x84, 0x00, 0x08])), None);
+    }
+
+    #[test]
+    fn gread_per_target_iteration_and_find() {
+        // id 10 addr 0x0200 count 4 * id 20 addr 0x0010 count 2.
+        let p = [10, 0x00, 0x02, 0x04, 0x00, 20, 0x10, 0x00, 0x02, 0x00];
+        let g = GreadPerTarget::parse(fb(&p)).unwrap();
+        let got: [GreadTarget; 2] = [g.iter().next().unwrap(), g.iter().nth(1).unwrap()];
+        assert_eq!(
+            got,
+            [
+                GreadTarget {
+                    id: Id::new(10),
+                    addr: 0x0200,
+                    count: 4
+                },
+                GreadTarget {
+                    id: Id::new(20),
+                    addr: 0x0010,
+                    count: 2
+                },
+            ]
+        );
+        let (slot, entry) = g.find(Id::new(20)).unwrap();
+        assert_eq!(slot, 1);
+        assert_eq!(entry.addr, 0x0010);
+        assert_eq!(g.find(Id::new(99)), None);
+    }
+
+    #[test]
+    fn gread_per_target_rejects_ragged() {
+        // 9 bytes: not a whole number of 5-byte entries.
+        assert!(GreadPerTarget::parse(fb(&[0; 9])).is_none());
+        assert!(GreadPerTarget::parse(fb(&[])).is_none());
+    }
+
+    #[test]
+    fn gread_profile_uniform_fields_and_slots() {
+        // profile slot 2, ids [1, 2, 5].
+        let p = [2, 1, 2, 5];
+        let g = GreadProfileUniform::parse(fb(&p)).unwrap();
+        assert_eq!(g.slot, 2);
+        let ids: [Id; 3] = [Id::new(1), Id::new(2), Id::new(5)];
+        assert!(g.ids().eq(ids));
+        assert_eq!(g.slot_of(Id::new(5)), Some(2));
+        assert_eq!(g.slot_of(Id::new(9)), None);
+    }
+
+    #[test]
+    fn gread_profile_uniform_rejects_empty_and_short() {
+        // Slot byte present but no IDs listed.
+        assert_eq!(GreadProfileUniform::parse(fb(&[2])), None);
+        assert_eq!(GreadProfileUniform::parse(fb(&[])), None);
+    }
+
+    #[test]
+    fn gread_profile_per_target_iteration_and_find() {
+        // id 10 slot 0 * id 20 slot 3.
+        let p = [10, 0, 20, 3];
+        let g = GreadProfilePerTarget::parse(fb(&p)).unwrap();
+        let got: [GreadProfileTarget; 2] = [g.iter().next().unwrap(), g.iter().nth(1).unwrap()];
+        assert_eq!(
+            got,
+            [
+                GreadProfileTarget {
+                    id: Id::new(10),
+                    slot: 0
+                },
+                GreadProfileTarget {
+                    id: Id::new(20),
+                    slot: 3
+                },
+            ]
+        );
+        let (chain_slot, entry) = g.find(Id::new(20)).unwrap();
+        assert_eq!(chain_slot, 1);
+        assert_eq!(entry.slot, 3);
+        assert_eq!(g.find(Id::new(99)), None);
+    }
+
+    #[test]
+    fn gread_profile_per_target_rejects_ragged() {
+        assert!(GreadProfilePerTarget::parse(fb(&[10, 0, 20])).is_none());
+        assert!(GreadProfilePerTarget::parse(fb(&[])).is_none());
+    }
+
+    #[test]
+    fn gwrite_uniform_slices_and_find() {
+        // addr 0x0180 count 4 * id 1 data [1,2,3,4] * id 2 data [5,6,7,8].
+        let p = [0x80, 0x01, 4, 1, 1, 2, 3, 4, 2, 5, 6, 7, 8];
+        let g = GwriteUniform::parse(fb(&p)).unwrap();
+        assert_eq!(g.addr, 0x0180);
+        assert_eq!(g.count, 4);
+        let entries: [(Id, FrameBytes); 2] = [
+            (Id::new(1), fb(&[1, 2, 3, 4])),
+            (Id::new(2), fb(&[5, 6, 7, 8])),
+        ];
+        assert!(g.iter().eq(entries));
+        assert_eq!(g.find(Id::new(2)), Some(fb(&[5, 6, 7, 8])));
+        assert_eq!(g.find(Id::new(3)), None);
+    }
+
+    #[test]
+    fn gwrite_uniform_rejects_ragged_and_zero_count() {
+        // Trailing byte past the last whole entry.
+        let ragged = [0x80, 0x01, 4, 1, 1, 2, 3, 4, 2];
+        assert!(GwriteUniform::parse(fb(&ragged)).is_none());
+        // count 0 has no valid stride.
+        assert!(GwriteUniform::parse(fb(&[0x80, 0x01, 0])).is_none());
+    }
+
+    #[test]
+    fn gwrite_per_target_mixed_counts() {
+        // id 3 addr 0x0000 count 2 [AA BB] * id 4 addr 0x0100 count 4 [1 2 3 4].
+        let p = [3, 0x00, 0x00, 2, 0xAA, 0xBB, 4, 0x00, 0x01, 4, 1, 2, 3, 4];
+        let g = GwritePerTarget::parse(fb(&p)).unwrap();
+        let targets: [GwriteTarget; 2] = [g.iter().next().unwrap(), g.iter().nth(1).unwrap()];
+        assert_eq!(
+            targets,
+            [
+                GwriteTarget {
+                    id: Id::new(3),
+                    addr: 0x0000,
+                    data: fb(&[0xAA, 0xBB])
+                },
+                GwriteTarget {
+                    id: Id::new(4),
+                    addr: 0x0100,
+                    data: fb(&[1, 2, 3, 4])
+                },
+            ]
+        );
+        assert_eq!(g.find(Id::new(4)).unwrap().data, fb(&[1, 2, 3, 4]));
+        assert_eq!(g.find(Id::new(9)), None);
+    }
+
+    #[test]
+    fn gwrite_per_target_rejects_truncated() {
+        // Final entry claims count 4 but only 3 data bytes follow.
+        let p = [3, 0x00, 0x00, 2, 0xAA, 0xBB, 4, 0x00, 0x01, 4, 1, 2, 3];
+        assert!(GwritePerTarget::parse(fb(&p)).is_none());
+        assert!(GwritePerTarget::parse(fb(&[])).is_none());
+    }
+
+    #[test]
+    fn gwrite_uniform_goal_position_hot_path() {
+        // SyncWrite-style: goal position (addr 0x0074), 4 B each, 3 servos.
+        let p = [
+            0x74, 0x00, 4, // addr, count
+            1, 0x00, 0x08, 0x00, 0x00, // id 1
+            2, 0x00, 0x0C, 0x00, 0x00, // id 2 (middle)
+            3, 0x00, 0x10, 0x00, 0x00, // id 3
+        ];
+        let g = GwriteUniform::parse(fb(&p)).unwrap();
+        assert_eq!(g.find(Id::new(2)), Some(fb(&[0x00, 0x0C, 0x00, 0x00])));
+    }
+
+    /// Every group payload parses identically no matter where the ring seam
+    /// splits it: the contiguous parse equals the split parse at every point.
+    #[test]
+    fn group_parse_is_seam_split_invariant() {
+        let gread_uniform = [0x84, 0x00, 0x08, 0x00, 1, 2, 5];
+        let gread_per_target = [10, 0x00, 0x02, 0x04, 0x00, 20, 0x10, 0x00, 0x02, 0x00];
+        let gwrite_uniform = [0x80, 0x01, 4, 1, 1, 2, 3, 4, 2, 5, 6, 7, 8];
+        let gwrite_per_target = [3, 0x00, 0x00, 2, 0xAA, 0xBB, 4, 0x00, 0x01, 4, 1, 2, 3, 4];
+        let gread_profile_uniform = [2, 1, 2, 5];
+        let gread_profile_per_target = [10, 0, 20, 3];
+
+        for k in 0..=gread_uniform.len() {
+            let s = FrameBytes::new(&gread_uniform[..k], &gread_uniform[k..]);
+            assert_eq!(
+                GreadUniform::parse(s),
+                GreadUniform::parse(fb(&gread_uniform))
+            );
+            let g = GreadUniform::parse(s).unwrap();
+            assert_eq!(g.slot_of(Id::new(5)), Some(2));
+        }
+        for k in 0..=gread_per_target.len() {
+            let s = FrameBytes::new(&gread_per_target[..k], &gread_per_target[k..]);
+            assert_eq!(
+                GreadPerTarget::parse(s),
+                GreadPerTarget::parse(fb(&gread_per_target))
+            );
+            let g = GreadPerTarget::parse(s).unwrap();
+            assert_eq!(g.find(Id::new(20)).unwrap().1.addr, 0x0010);
+        }
+        for k in 0..=gwrite_uniform.len() {
+            let s = FrameBytes::new(&gwrite_uniform[..k], &gwrite_uniform[k..]);
+            assert_eq!(
+                GwriteUniform::parse(s),
+                GwriteUniform::parse(fb(&gwrite_uniform))
+            );
+            let g = GwriteUniform::parse(s).unwrap();
+            assert_eq!(g.find(Id::new(2)), Some(fb(&[5, 6, 7, 8])));
+        }
+        for k in 0..=gwrite_per_target.len() {
+            let s = FrameBytes::new(&gwrite_per_target[..k], &gwrite_per_target[k..]);
+            assert_eq!(
+                GwritePerTarget::parse(s),
+                GwritePerTarget::parse(fb(&gwrite_per_target))
+            );
+            let g = GwritePerTarget::parse(s).unwrap();
+            assert_eq!(g.find(Id::new(4)).unwrap().data, fb(&[1, 2, 3, 4]));
+        }
+        for k in 0..=gread_profile_uniform.len() {
+            let s = FrameBytes::new(&gread_profile_uniform[..k], &gread_profile_uniform[k..]);
+            assert_eq!(
+                GreadProfileUniform::parse(s),
+                GreadProfileUniform::parse(fb(&gread_profile_uniform))
+            );
+            let g = GreadProfileUniform::parse(s).unwrap();
+            assert_eq!(g.slot_of(Id::new(5)), Some(2));
+        }
+        for k in 0..=gread_profile_per_target.len() {
+            let s = FrameBytes::new(
+                &gread_profile_per_target[..k],
+                &gread_profile_per_target[k..],
+            );
+            assert_eq!(
+                GreadProfilePerTarget::parse(s),
+                GreadProfilePerTarget::parse(fb(&gread_profile_per_target))
+            );
+            let g = GreadProfilePerTarget::parse(s).unwrap();
+            assert_eq!(g.find(Id::new(20)).unwrap().1.slot, 3);
+        }
+    }
+}

--- a/firmware/lib/osc-protocol/src/lib.rs
+++ b/firmware/lib/osc-protocol/src/lib.rs
@@ -1,0 +1,17 @@
+//! osc-native wire protocol (`docs/osc-native-protocol.md`).
+//!
+//! Layout types over ring memory plus pure span math. The break anchors a
+//! frame and the header makes its end computable, so there is no streaming
+//! parser here: the chip owns timing (framer deadlines, DMA, CRC engine),
+//! this crate owns layout -- `#[repr(C)]` views, offset arithmetic, and the
+//! osc-CRC-16 definition.
+#![no_std]
+
+pub mod bytes;
+pub mod crc;
+pub mod frame;
+pub mod group;
+pub mod reply;
+pub mod wire;
+
+pub use bytes::FrameBytes;

--- a/firmware/lib/osc-protocol/src/reply.rs
+++ b/firmware/lib/osc-protocol/src/reply.rs
@@ -1,0 +1,179 @@
+//! osc-native TX frame buffer: one halfword-aligned scratch that both servo
+//! statuses and host instructions encode into (`docs/osc-native-protocol.md`
+//! sec 3.1, sec 3.2, sec 4.2). The literal `0x00` at offset 0 is the CRC prefix -- the
+//! CRC-engine DMA reads from offset 0, the UART TX DMA from offset 1.
+
+use crate::wire::{self, Id, Inst};
+
+/// A frame under construction: `[0x00][ID][LEN][INST][payload][PAD?][crc][crc]`.
+///
+/// Alignment matters twice over -- the hardware CRC DMA reads halfwords from
+/// offset 0 (sec 3.2, needs 2), and payload copies land at offset 4, so word
+/// alignment lets `copy_from_slice` word-copy from word-aligned sources
+/// instead of byte-looping. `N` bounds the largest frame this buffer can
+/// hold; the finished `LEN` is read back from `bytes[2]`, so the struct stays
+/// just the array.
+#[repr(C, align(4))]
+pub struct FrameBuf<const N: usize> {
+    bytes: [u8; N],
+}
+
+impl<const N: usize> FrameBuf<N> {
+    /// Smallest layout is the empty-payload frame: prefix + header + CRC.
+    const MIN: usize = 6;
+
+    #[inline]
+    pub const fn new() -> Self {
+        const { assert!(N >= Self::MIN) }
+        Self { bytes: [0; N] }
+    }
+
+    /// Lay down the fixed prefix; `LEN` (byte 2) stays a placeholder until
+    /// [`finish`](Self::finish). `inst` is written as-is.
+    #[inline]
+    pub fn start(&mut self, id: Id, inst: Inst) {
+        self.bytes[0] = wire::ALIGN_BYTE;
+        self.bytes[1] = id.as_byte();
+        self.bytes[2] = 0;
+        self.bytes[3] = inst.0;
+    }
+
+    /// The payload region, leaving room for the CRC.
+    #[inline]
+    pub fn payload_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes[4..N - 2]
+    }
+
+    /// Seal the layout for a `p`-byte payload: write `LEN`. CRC bytes are
+    /// filled by [`set_crc`](Self::set_crc).
+    #[inline]
+    pub fn finish(&mut self, p: u8) {
+        debug_assert!(p <= wire::MAX_PAYLOAD);
+        debug_assert!((p as usize) <= N - 6);
+        self.bytes[2] = wire::len_for(p);
+    }
+
+    /// CRC-covered span `[0, covered_len)` -- valid after `finish`.
+    #[inline]
+    pub fn covered(&self) -> &[u8] {
+        &self.bytes[..wire::covered_len(self.bytes[2])]
+    }
+
+    /// Write the little-endian CRC into the two bytes after the covered span.
+    #[inline]
+    pub fn set_crc(&mut self, crc: u16) {
+        let end = wire::covered_len(self.bytes[2]);
+        self.bytes[end..end + 2].copy_from_slice(&crc.to_le_bytes());
+    }
+
+    /// The whole frame `[0, footprint)`. The chip's UART DMA sends `frame()[1..]`
+    /// and the CRC DMA reads `frame()` from offset 0.
+    #[inline]
+    pub fn frame(&self) -> &[u8] {
+        &self.bytes[..wire::footprint(self.bytes[2])]
+    }
+
+    /// Raw storage -- escape hatch for the chip driver's zero-copy tail layout
+    /// (sec 4.2), where the buffer holds only header and CRC tail around an
+    /// externally streamed payload. Layout invariants become the caller's.
+    #[inline]
+    pub fn bytes(&self) -> &[u8; N] {
+        &self.bytes
+    }
+
+    /// Mutable counterpart of [`bytes`](Self::bytes); same contract.
+    #[inline]
+    pub fn bytes_mut(&mut self) -> &mut [u8; N] {
+        &mut self.bytes
+    }
+
+    /// Compute and store the CRC over the covered span, returning the frame.
+    #[cfg(feature = "software-crc")]
+    #[inline]
+    pub fn seal(&mut self) -> &[u8] {
+        let crc = crate::crc::osc_crc(self.covered());
+        self.set_crc(crc);
+        self.frame()
+    }
+}
+
+impl<const N: usize> Default for FrameBuf<N> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(test, feature = "software-crc"))]
+mod tests {
+    use super::*;
+    use crate::frame::Header;
+    use crate::wire::{Opcode, ResultCode};
+
+    #[test]
+    fn ping_vector() {
+        let mut b = FrameBuf::<16>::new();
+        b.start(Id::new(1), Inst::instruction(Opcode::Ping, 0));
+        b.finish(0);
+        assert_eq!(b.seal(), &[0x00, 0x01, 0x03, 0x10, 0x50, 0xFC]);
+    }
+
+    #[test]
+    fn write_vector() {
+        let mut b = FrameBuf::<16>::new();
+        b.start(Id::new(5), Inst::instruction(Opcode::Write, 0));
+        let pl = b.payload_mut();
+        pl[..2].copy_from_slice(&0x0180u16.to_le_bytes());
+        pl[2] = 0x2C;
+        pl[3] = 0x01;
+        b.finish(4);
+        assert_eq!(
+            b.seal(),
+            &[0x00, 0x05, 0x07, 0x30, 0x80, 0x01, 0x2C, 0x01, 0xB1, 0xB3]
+        );
+    }
+
+    #[test]
+    fn read_vector() {
+        let mut b = FrameBuf::<16>::new();
+        b.start(Id::new(3), Inst::instruction(Opcode::Read, 0));
+        let pl = b.payload_mut();
+        pl[..2].copy_from_slice(&0x0200u16.to_le_bytes());
+        pl[2..4].copy_from_slice(&8u16.to_le_bytes());
+        b.finish(4);
+        assert_eq!(
+            b.seal(),
+            &[0x00, 0x03, 0x07, 0x20, 0x00, 0x02, 0x08, 0x00, 0x15, 0x70]
+        );
+    }
+
+    #[test]
+    fn write_odd_payload_vector() {
+        let mut b = FrameBuf::<16>::new();
+        b.start(Id::new(2), Inst::instruction(Opcode::Write, 0));
+        let pl = b.payload_mut();
+        pl[..2].copy_from_slice(&0x0100u16.to_le_bytes());
+        pl[2] = 0xAA;
+        b.finish(3);
+        let frame = b.seal();
+        assert_eq!(frame[3], 0x30);
+        assert_eq!(
+            frame,
+            &[0x00, 0x02, 0x06, 0x30, 0x00, 0x01, 0xAA, 0x07, 0x0D]
+        );
+    }
+
+    #[test]
+    fn status_frame_round_trips() {
+        let mut b = FrameBuf::<16>::new();
+        b.start(Id::new(7), Inst::status(ResultCode::Ok, false));
+        b.finish(0);
+        let frame = b.seal();
+
+        let h = Header::from_bytes(frame[..4].try_into().unwrap());
+        assert_eq!(h.id, Id::new(7));
+        assert!(h.inst.is_status());
+        assert_eq!(h.inst.result(), Some(ResultCode::Ok));
+        assert_eq!(h.validate(), Ok(()));
+    }
+}

--- a/firmware/lib/osc-protocol/src/wire.rs
+++ b/firmware/lib/osc-protocol/src/wire.rs
@@ -1,0 +1,400 @@
+//! osc-native wire primitives: ID, packed `INST` byte, and frame span math
+//! (`docs/osc-native-protocol.md` sec 3, sec 5, sec 9). Layout only -- no buffering.
+
+/// Frame ID byte. `0x01..=0xF9` unicast, `0xFE` broadcast; `0x00`/`0xFF` and
+/// `0xFA..=0xFD` never address a servo on the wire (sec 3.1).
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Id(pub u8);
+
+impl Id {
+    pub const BROADCAST: Self = Self(0xFE);
+
+    #[inline]
+    pub const fn new(b: u8) -> Self {
+        Self(b)
+    }
+
+    /// Validated unicast constructor; accepts only `0x01..=0xF9`.
+    #[inline]
+    pub const fn try_unicast(b: u8) -> Option<Self> {
+        match b {
+            0x01..=0xF9 => Some(Self(b)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub const fn as_byte(self) -> u8 {
+        self.0
+    }
+
+    #[inline]
+    pub const fn is_broadcast(self) -> bool {
+        self.0 == 0xFE
+    }
+
+    #[inline]
+    pub const fn is_unicast(self) -> bool {
+        matches!(self.0, 0x01..=0xF9)
+    }
+
+    #[inline]
+    pub const fn is_valid(self) -> bool {
+        self.is_unicast() || self.is_broadcast()
+    }
+
+    /// Servo-side "is this frame for me": true when the frame ID (`self`) is
+    /// broadcast or equals the servo's own `other`.
+    #[inline]
+    pub const fn addresses(self, other: Id) -> bool {
+        self.is_broadcast() || self.0 == other.0
+    }
+}
+
+/// Instruction opcode, `INST` bits [6:4] (sec 5). `0x0` is invalid.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Opcode {
+    Ping = 0x1,
+    Read = 0x2,
+    Write = 0x3,
+    Commit = 0x4,
+    Gread = 0x5,
+    Gwrite = 0x6,
+    Mgmt = 0x7,
+}
+
+impl Opcode {
+    /// `b` is the already-extracted 3-bit field; `0x0` and `>0x7` reject.
+    #[inline]
+    pub const fn from_bits(b: u8) -> Option<Opcode> {
+        match b {
+            0x1 => Some(Opcode::Ping),
+            0x2 => Some(Opcode::Read),
+            0x3 => Some(Opcode::Write),
+            0x4 => Some(Opcode::Commit),
+            0x5 => Some(Opcode::Gread),
+            0x6 => Some(Opcode::Gwrite),
+            0x7 => Some(Opcode::Mgmt),
+            _ => None,
+        }
+    }
+}
+
+/// Status result code, `INST` bits [6:2] (sec 5.3). `9..=31` reserved/invalid.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ResultCode {
+    Ok = 0,
+    Instruction = 1,
+    Range = 2,
+    Access = 3,
+    Validation = 4,
+    Busy = 5,
+    Limit = 6,
+    PredecessorSilent = 7,
+    Hardware = 8,
+}
+
+impl ResultCode {
+    /// `b` is the already-extracted 5-bit field; `9..=31` reject.
+    #[inline]
+    pub const fn from_bits(b: u8) -> Option<ResultCode> {
+        match b {
+            0 => Some(ResultCode::Ok),
+            1 => Some(ResultCode::Instruction),
+            2 => Some(ResultCode::Range),
+            3 => Some(ResultCode::Access),
+            4 => Some(ResultCode::Validation),
+            5 => Some(ResultCode::Busy),
+            6 => Some(ResultCode::Limit),
+            7 => Some(ResultCode::PredecessorSilent),
+            8 => Some(ResultCode::Hardware),
+            _ => None,
+        }
+    }
+}
+
+/// MGMT sub-op, payload byte 0 (sec 9).
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MgmtOp {
+    Enum = 0x01,
+    Assign = 0x02,
+    Save = 0x03,
+    Reboot = 0x04,
+    Factory = 0x05,
+    Cal = 0x06,
+}
+
+impl MgmtOp {
+    #[inline]
+    pub const fn from_byte(b: u8) -> Option<MgmtOp> {
+        match b {
+            0x01 => Some(MgmtOp::Enum),
+            0x02 => Some(MgmtOp::Assign),
+            0x03 => Some(MgmtOp::Save),
+            0x04 => Some(MgmtOp::Reboot),
+            0x05 => Some(MgmtOp::Factory),
+            0x06 => Some(MgmtOp::Cal),
+            _ => None,
+        }
+    }
+}
+
+/// Packed `INST` byte. Bit 7 selects the layout: instruction (opcode [6:4] +
+/// flags [3:0]) or status (result [6:2] + bit 1 reserved + ALERT bit 0).
+/// Every bit pattern is representable; validity comes from the typed
+/// accessors.
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Inst(pub u8);
+
+impl Inst {
+    pub const FLAG_HOLD: u8 = 1 << 0;
+    /// Bit 0 on READ/GREAD: the payload names a profile slot (sec 5.2).
+    pub const FLAG_PROFILE: u8 = Self::FLAG_HOLD;
+    // Bit 1 is reserved (0) in both layouts -- freed by the pad deletion,
+    // kept for future extensions (sec 3.1, sec 5).
+    pub const FLAG_NOREPLY: u8 = 1 << 2;
+    pub const FLAG_PER_TARGET: u8 = 1 << 3;
+
+    const STATUS_BIT: u8 = 0x80;
+    const ALERT_BIT: u8 = 1 << 0;
+
+    #[inline]
+    pub const fn instruction(op: Opcode, flags: u8) -> Self {
+        Self(((op as u8) << 4) | (flags & 0x0F))
+    }
+
+    #[inline]
+    pub const fn status(result: ResultCode, alert: bool) -> Self {
+        let mut b = Self::STATUS_BIT | ((result as u8) << 2);
+        if alert {
+            b |= Self::ALERT_BIT;
+        }
+        Self(b)
+    }
+
+    #[inline]
+    pub const fn is_status(self) -> bool {
+        self.0 & Self::STATUS_BIT != 0
+    }
+
+    /// Opcode of an instruction frame; `None` for status frames or opcode `0`.
+    #[inline]
+    pub const fn opcode(self) -> Option<Opcode> {
+        if self.is_status() {
+            return None;
+        }
+        Opcode::from_bits((self.0 >> 4) & 0x07)
+    }
+
+    #[inline]
+    pub const fn hold(self) -> bool {
+        self.0 & Self::FLAG_HOLD != 0
+    }
+
+    /// Bit 0's read-side meaning (sec 5): on READ/GREAD the payload names a
+    /// profile slot instead of addr+count (sec 5.2). Same bit as HOLD.
+    #[inline]
+    pub const fn profile(self) -> bool {
+        self.hold()
+    }
+
+    #[inline]
+    pub const fn noreply(self) -> bool {
+        self.0 & Self::FLAG_NOREPLY != 0
+    }
+
+    #[inline]
+    pub const fn per_target(self) -> bool {
+        self.0 & Self::FLAG_PER_TARGET != 0
+    }
+
+    /// Result code of a status frame; `None` for instruction frames or a
+    /// reserved code.
+    #[inline]
+    pub const fn result(self) -> Option<ResultCode> {
+        if !self.is_status() {
+            return None;
+        }
+        ResultCode::from_bits((self.0 >> 2) & 0x1F)
+    }
+
+    #[inline]
+    pub const fn alert(self) -> bool {
+        self.0 & Self::ALERT_BIT != 0
+    }
+}
+
+/// Max payload bytes; sized so the largest frame fits whole in the ring (sec 3.1).
+pub const MAX_PAYLOAD: u8 = 252;
+
+/// UID field width in bytes (sec 9.2): UUID-width, fixed. A chip fills it
+/// LSB-first from its silicon ID and zero-pads the tail (the V006's 96-bit
+/// ESIG leaves the top four bytes zero); no catalog MCU exceeds 128 bits.
+pub const UID_LEN: usize = 16;
+
+/// sec 9.2 ENUM reply slots: a broadcast-ENUM reply delays its trigger by
+/// `0..ENUM_REPLY_SLOTS` byte-times, drawn from the responder's UID CRC
+/// XOR its free-running tick. Same-die matchers run cycle-identical
+/// firmware and otherwise answer in unison -- and two near-equal frames
+/// superimposed sub-bit-aligned read back as ONE clean frame instead of
+/// the collision garble the walk descends on.
+pub const ENUM_REPLY_SLOTS: u8 = 16;
+
+/// TX-buffer alignment byte at offset 0 (sec 3.2): keeps the hardware CRC feed
+/// halfword-aligned and even; a CRC no-op (leading zero, init = 0). Not part
+/// of the wire checksum definition.
+pub const ALIGN_BYTE: u8 = 0x00;
+
+/// `LEN` for a `p`-byte payload: `INST + payload + CRC` = `3 + p`.
+/// Caller keeps `p <= MAX_PAYLOAD`.
+#[inline]
+pub const fn len_for(p: u8) -> u8 {
+    3 + p
+}
+
+/// Payload length recovered from `LEN`: `len - 3` (validate guarantees
+/// `LEN >= 3`).
+#[inline]
+pub const fn payload_len(len: u8) -> u8 {
+    len - 3
+}
+
+/// Ring bytes for a frame including the break byte: `3 + len` (max 258).
+#[inline]
+pub const fn footprint(len: u8) -> usize {
+    3 + len as usize
+}
+
+/// Anchor-inclusive feed-span length (`1 + len`): the wire checksum covers
+/// `ID .. payload` (sec 3.2), but a span counted from the anchor includes the
+/// break's `0x00` no-op byte -- the form receivers and buffers use.
+#[inline]
+pub const fn covered_len(len: u8) -> usize {
+    1 + len as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_classification() {
+        assert!(Id::BROADCAST.is_broadcast());
+        assert!(Id::BROADCAST.is_valid());
+        assert!(!Id::BROADCAST.is_unicast());
+        assert!(Id::new(0x01).is_unicast());
+        assert!(Id::new(0xF9).is_unicast());
+        assert!(!Id::new(0x00).is_valid());
+        assert!(!Id::new(0xFF).is_valid());
+        assert!(!Id::new(0xFA).is_valid());
+    }
+
+    #[test]
+    fn id_try_unicast() {
+        assert_eq!(Id::try_unicast(0x00), None);
+        assert_eq!(Id::try_unicast(0x01), Some(Id::new(0x01)));
+        assert_eq!(Id::try_unicast(0xF9), Some(Id::new(0xF9)));
+        assert_eq!(Id::try_unicast(0xFA), None);
+        assert_eq!(Id::try_unicast(0xFE), None);
+    }
+
+    #[test]
+    fn id_addresses() {
+        assert!(Id::BROADCAST.addresses(Id::new(0x05)));
+        assert!(Id::new(0x05).addresses(Id::new(0x05)));
+        assert!(!Id::new(0x05).addresses(Id::new(0x06)));
+    }
+
+    #[test]
+    fn opcode_from_bits() {
+        assert_eq!(Opcode::from_bits(0x0), None);
+        assert_eq!(Opcode::from_bits(0x1), Some(Opcode::Ping));
+        assert_eq!(Opcode::from_bits(0x7), Some(Opcode::Mgmt));
+    }
+
+    #[test]
+    fn result_from_bits() {
+        assert_eq!(ResultCode::from_bits(0), Some(ResultCode::Ok));
+        assert_eq!(
+            ResultCode::from_bits(7),
+            Some(ResultCode::PredecessorSilent)
+        );
+        assert_eq!(ResultCode::from_bits(8), Some(ResultCode::Hardware));
+        assert_eq!(ResultCode::from_bits(9), None);
+        assert_eq!(ResultCode::from_bits(31), None);
+    }
+
+    #[test]
+    fn mgmt_from_byte() {
+        assert_eq!(MgmtOp::from_byte(0x00), None);
+        assert_eq!(MgmtOp::from_byte(0x01), Some(MgmtOp::Enum));
+        assert_eq!(MgmtOp::from_byte(0x05), Some(MgmtOp::Factory));
+        assert_eq!(MgmtOp::from_byte(0x06), Some(MgmtOp::Cal));
+        assert_eq!(MgmtOp::from_byte(0x07), None);
+    }
+
+    #[test]
+    fn inst_instruction_roundtrip() {
+        let i = Inst::instruction(Opcode::Write, Inst::FLAG_HOLD | Inst::FLAG_NOREPLY);
+        assert!(!i.is_status());
+        assert_eq!(i.opcode(), Some(Opcode::Write));
+        assert!(i.hold());
+        assert!(i.noreply());
+        assert!(!i.per_target());
+        assert_eq!(i.result(), None);
+    }
+
+    #[test]
+    fn inst_profile_is_bit0_read_side() {
+        let r = Inst::instruction(Opcode::Read, Inst::FLAG_PROFILE);
+        assert!(r.profile());
+        assert!(r.hold());
+        let plain = Inst::instruction(Opcode::Read, 0);
+        assert!(!plain.profile());
+    }
+
+    #[test]
+    fn inst_status_roundtrip() {
+        let s = Inst::status(ResultCode::Range, true);
+        assert!(s.is_status());
+        assert_eq!(s.result(), Some(ResultCode::Range));
+        assert!(s.alert());
+        assert_eq!(s.opcode(), None);
+    }
+
+    #[test]
+    fn inst_status_no_flags() {
+        let s = Inst::status(ResultCode::Ok, false);
+        assert_eq!(s.0, 0x80);
+        assert!(!s.alert());
+        assert_eq!(s.result(), Some(ResultCode::Ok));
+    }
+
+    #[test]
+    fn span_math() {
+        assert_eq!(len_for(2), 5);
+        assert_eq!(payload_len(5), 2);
+        // Odd payload: no pad, LEN even-legal (sec 3.1).
+        assert_eq!(len_for(3), 6);
+        assert_eq!(payload_len(6), 3);
+        // PING: empty payload.
+        assert_eq!(len_for(0), 3);
+        // Largest frame.
+        assert_eq!(len_for(MAX_PAYLOAD), 255);
+        assert_eq!(footprint(255), 258);
+        assert_eq!(covered_len(255), 256);
+    }
+
+    #[test]
+    fn span_covered_matches_vectors() {
+        // "00 05 07 30 80 01 2C 01" -- WRITE id 5, p=4 payload, LEN 7.
+        assert_eq!(len_for(4), 7);
+        assert_eq!(covered_len(7), 8);
+        assert_eq!(footprint(7), 10);
+    }
+}

--- a/firmware/lib/rust-toolchain.toml
+++ b/firmware/lib/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel    = "nightly"
+components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]

--- a/firmware/lib/units/Cargo.toml
+++ b/firmware/lib/units/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name    = "osc-units"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true

--- a/firmware/lib/units/src/lib.rs
+++ b/firmware/lib/units/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Microrads(pub i32);
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct MilliradsPerSec(pub i32);
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Milliamps(pub i16);
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Millivolts(pub i16);
+
+/// 0.01 degC; e.g. 2500 = 25.0 degC.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct CentiCelsius(pub i16);
+
+/// Normalized actuator command. Range is symmetric (`-i16::MAX..=i16::MAX`) so `-x` can't overflow.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Effort(pub i16);
+
+impl Effort {
+    pub const ZERO: Self = Self(0);
+    pub const FULL: Self = Self(i16::MAX);
+    pub const MIN: Self = Self(-i16::MAX);
+}


### PR DESCRIPTION
Construction starts. Everything here is transplanted verbatim from #20's tip; the only edit is the workspace members list, which grows rung by rung.

Three foundation crates for the firmware/lib workspace:

- **osc-protocol** — the osc-native wire format as a chip-free library: framing, CRC-16/ARC with test vectors, instruction/status encoding, group ops. 52 unit tests, most of them straight from the spec's tables.
- **osc-units** / **osc-log** — the small stuff everything else leans on.

Plus a fresh CI workflow with the lib job (fmt, clippy `-D warnings`, build, test). CI grows a job per rung as the ladder climbs.

