### PR TITLE
firmware: control table + derive macro

### DIFF
--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["log", "osc-protocol", "units"]
+members = ["control-table", "control-table-derive", "log", "osc-protocol", "units"]
 
 [workspace.package]
 edition = "2024"

--- a/firmware/lib/control-table-derive/Cargo.toml
+++ b/firmware/lib/control-table-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name    = "control-table-derive"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote       = "1"
+syn         = { version = "2", features = ["full", "extra-traits"] }

--- a/firmware/lib/control-table-derive/src/block.rs
+++ b/firmware/lib/control-table-derive/src/block.rs
@@ -1,0 +1,477 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::token::PathSep;
+use syn::{Attribute, Data, DeriveInput, Expr, Fields, Ident, Path, PathSegment, Type};
+
+#[derive(Copy, Clone)]
+enum AccessMode {
+    Ro,
+    Rw,
+}
+
+#[derive(Copy, Clone)]
+enum CmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+impl CmpOp {
+    /// The matching `control_table::rules::OP_*` const, as a path token.
+    fn const_tokens(self) -> TokenStream2 {
+        match self {
+            CmpOp::Lt => quote!(::control_table::rules::OP_LT),
+            CmpOp::Le => quote!(::control_table::rules::OP_LE),
+            CmpOp::Gt => quote!(::control_table::rules::OP_GT),
+            CmpOp::Ge => quote!(::control_table::rules::OP_GE),
+            CmpOp::Eq => quote!(::control_table::rules::OP_EQ),
+            CmpOp::Ne => quote!(::control_table::rules::OP_NE),
+        }
+    }
+}
+
+struct FieldAttrs {
+    skip: bool,
+    access: AccessMode,
+    compares: Vec<(CmpOp, Expr)>,
+    abs: bool,
+    hook: Option<Path>,
+}
+
+impl Default for FieldAttrs {
+    fn default() -> Self {
+        Self {
+            skip: false,
+            access: AccessMode::Rw,
+            compares: Vec::new(),
+            abs: false,
+            hook: None,
+        }
+    }
+}
+
+struct HookBinding<'a> {
+    field_ident: &'a Ident,
+    field_ty: &'a Type,
+    trait_path: Path,
+    method_ident: Ident,
+}
+
+pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let struct_ty = &input.ident;
+
+    crate::common::check_repr(&input.attrs, struct_ty.span(), "Block")?;
+
+    let Data::Struct(s) = &input.data else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Block can only be derived for structs",
+        ));
+    };
+
+    let Fields::Named(fields) = &s.fields else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Block requires a struct with named fields",
+        ));
+    };
+
+    let hooks_trait = parse_block_attrs(&input.attrs)?;
+
+    let mut cmp_rules: Vec<TokenStream2> = Vec::new();
+    let mut allowed_rules: Vec<TokenStream2> = Vec::new();
+    let mut writable: Vec<TokenStream2> = Vec::new();
+    let mut size_terms: Vec<TokenStream2> = Vec::new();
+    let mut new_inits: Vec<TokenStream2> = Vec::new();
+    let mut kept_idents: Vec<&Ident> = Vec::new();
+    let mut kept_upper: Vec<Ident> = Vec::new();
+    let mut hook_bindings: Vec<HookBinding> = Vec::new();
+
+    for field in &fields.named {
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        let attrs = parse_field_attrs(&field.attrs)?;
+
+        if let Some(hook_path) = &attrs.hook {
+            let resolved = resolve_hook_path(hook_path, hooks_trait.as_ref())?;
+            hook_bindings.push(HookBinding {
+                field_ident: name,
+                field_ty: ty,
+                trait_path: resolved.0,
+                method_ident: resolved.1,
+            });
+        }
+
+        let init = crate::block::default_init_for_type(ty);
+        new_inits.push(quote!(#name: #init));
+        size_terms.push(quote!(::core::mem::size_of::<#ty>()));
+
+        let is_ro = matches!(attrs.access, AccessMode::Ro);
+        if !attrs.compares.is_empty() && (attrs.skip || is_ro) {
+            return Err(syn::Error::new(
+                name.span(),
+                "compare clause on a skipped or read-only field never runs (drop the compare or make the field rw)",
+            ));
+        }
+
+        if attrs.skip {
+            continue;
+        }
+
+        let rel_addr = quote!(::core::mem::offset_of!(#struct_ty, #name) as u16);
+
+        if !is_ro {
+            if let Some(allowed) = auto_enum_allowed(ty) {
+                allowed_rules.push(quote! {
+                    ::control_table::rules::AllowedRule { addr: #rel_addr, allowed: #allowed }
+                });
+            }
+
+            if !attrs.compares.is_empty() {
+                let (width, signed) = cmp_width_signed(ty)?;
+                let abs = attrs.abs && signed;
+                for (op, expr) in &attrs.compares {
+                    let op_const = op.const_tokens();
+                    let (is_reg, val) = build_rule_val(expr);
+                    let spec = if is_reg {
+                        quote!(::control_table::rules::spec(#width, #signed, #abs, #op_const)
+                            | ::control_table::rules::SPEC_RHS_REG)
+                    } else {
+                        quote!(::control_table::rules::spec(#width, #signed, #abs, #op_const))
+                    };
+                    cmp_rules.push(quote! {
+                        ::control_table::rules::CmpRule { addr: #rel_addr, spec: #spec, val: #val }
+                    });
+                }
+            }
+
+            writable.push(quote!((#rel_addr, ::core::mem::size_of::<#ty>() as u16)));
+        }
+
+        kept_upper.push(Ident::new(&name.to_string().to_uppercase(), name.span()));
+        kept_idents.push(name);
+    }
+
+    let n_writable = writable.len();
+    let n_cmp = cmp_rules.len();
+    let n_allowed = allowed_rules.len();
+    let meta_macro = Ident::new(
+        &crate::common::flat_meta_macro_name(struct_ty),
+        struct_ty.span(),
+    );
+    let hooks_emit = build_hooks_emit(struct_ty, &hook_bindings);
+
+    Ok(quote! {
+        impl #struct_ty {
+            pub const CT_SIZE: u16 = ::core::mem::size_of::<Self>() as u16;
+            pub const CT_WRITABLE: [(u16, u16); #n_writable] = [#(#writable),*];
+
+            // Block-relative rule descriptors; the Section derive rebases `addr`
+            // into table-absolute form (register RHS addrs are already absolute).
+            pub const CT_CMP_RULES: [::control_table::rules::CmpRule; #n_cmp] =
+                [#(#cmp_rules),*];
+            pub const CT_ALLOWED_RULES: [::control_table::rules::AllowedRule; #n_allowed] =
+                [#(#allowed_rules),*];
+        }
+
+        #[allow(clippy::new_without_default)]
+        impl #struct_ty {
+            pub const fn new() -> Self {
+                Self { #(#new_inits),* }
+            }
+        }
+
+        #hooks_emit
+
+        const _: () = {
+            assert!(
+                0 #(+ #size_terms)* == ::core::mem::size_of::<#struct_ty>(),
+                "Block struct has repr(C) padding; add explicit `_rsvd` fields so the flat read path never exposes uninitialized bytes",
+            );
+        };
+
+        #[doc(hidden)]
+        #[macro_export]
+        macro_rules! #meta_macro {
+            (@addr_consts base = $base:expr, block_ty = $bty:path) => {
+                #(
+                    pub const #kept_upper: u16 =
+                        $base + ::core::mem::offset_of!($bty, #kept_idents) as u16;
+                )*
+            };
+        }
+    })
+}
+
+fn build_hooks_emit(struct_ty: &Ident, bindings: &[HookBinding<'_>]) -> TokenStream2 {
+    let unique_traits = unique_trait_paths(bindings);
+    let body: Vec<TokenStream2> = bindings
+        .iter()
+        .map(|b| {
+            let field_ident = b.field_ident;
+            let field_ty = b.field_ty;
+            let trait_path = &b.trait_path;
+            let method_ident = &b.method_ident;
+            quote! {
+                {
+                    let __f_lo = block_base as u32
+                        + ::core::mem::offset_of!(#struct_ty, #field_ident) as u32;
+                    let __f_hi = __f_lo + ::core::mem::size_of::<#field_ty>() as u32;
+                    let __w_lo = abs_addr as u32;
+                    let __w_hi = __w_lo + len as u32;
+                    if __w_lo < __f_hi && __f_lo < __w_hi {
+                        <H as #trait_path>::#method_ident(hooks, self.#field_ident);
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let where_clause = if unique_traits.is_empty() {
+        quote!()
+    } else {
+        quote!(where H: #(#unique_traits)+*)
+    };
+
+    let dispatch_args = if bindings.is_empty() {
+        quote!(_abs_addr: u16, _len: u16, _block_base: u16, _hooks: &mut H)
+    } else {
+        quote!(abs_addr: u16, len: u16, block_base: u16, hooks: &mut H)
+    };
+
+    quote! {
+        impl #struct_ty {
+            pub fn dispatch_events<H>(
+                &self,
+                #dispatch_args,
+            ) #where_clause {
+                #(#body)*
+            }
+        }
+    }
+}
+
+fn unique_trait_paths<'a>(bindings: &'a [HookBinding<'_>]) -> Vec<&'a Path> {
+    let mut out: Vec<&Path> = Vec::new();
+    for b in bindings {
+        if !out.iter().any(|p| path_eq(p, &b.trait_path)) {
+            out.push(&b.trait_path);
+        }
+    }
+    out
+}
+
+fn path_eq(a: &Path, b: &Path) -> bool {
+    use quote::ToTokens;
+    a.to_token_stream().to_string() == b.to_token_stream().to_string()
+}
+
+/// Splits `Trait::method` into (Trait, method). If `hook` is a single ident
+/// and the block declared `#[ct_block(hooks = ...)]`, that trait is used as
+/// the prefix.
+fn resolve_hook_path(hook: &Path, block_trait: Option<&Path>) -> syn::Result<(Path, Ident)> {
+    let total = hook.segments.len();
+    if total >= 2 {
+        let mut trait_path = Path {
+            leading_colon: hook.leading_colon,
+            segments: Punctuated::<PathSegment, PathSep>::new(),
+        };
+        for (i, seg) in hook.segments.iter().enumerate() {
+            if i == total - 1 {
+                break;
+            }
+            trait_path.segments.push(seg.clone());
+        }
+        let method_ident = hook.segments.last().unwrap().ident.clone();
+        Ok((trait_path, method_ident))
+    } else {
+        let method_ident = hook
+            .segments
+            .last()
+            .map(|s| s.ident.clone())
+            .ok_or_else(|| syn::Error::new(hook.span(), "empty hook path"))?;
+        let trait_path = block_trait.ok_or_else(|| {
+            syn::Error::new(
+                hook.span(),
+                "single-ident `hook = name` requires `#[ct_block(hooks = TraitPath)]` on the block",
+            )
+        })?;
+        Ok((trait_path.clone(), method_ident))
+    }
+}
+
+fn parse_block_attrs(attrs: &[Attribute]) -> syn::Result<Option<Path>> {
+    let mut hooks_trait = None;
+    for attr in attrs {
+        if !attr.path().is_ident("ct_block") {
+            continue;
+        }
+        attr.parse_nested_meta(|m| {
+            if m.path.is_ident("hooks") {
+                hooks_trait = Some(m.value()?.parse()?);
+                Ok(())
+            } else if m.path.is_ident("validators") {
+                Err(m.error("block validators are gone in Block; move the check to a field rule"))
+            } else {
+                Err(m.error("unknown ct_block key (expected `hooks = TraitPath`)"))
+            }
+        })?;
+    }
+    Ok(hooks_trait)
+}
+
+fn parse_field_attrs(attrs: &[Attribute]) -> syn::Result<FieldAttrs> {
+    let mut out = FieldAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("ct_field") {
+            continue;
+        }
+        attr.parse_nested_meta(|m| {
+            if m.path.is_ident("skip") {
+                out.skip = true;
+                Ok(())
+            } else if m.path.is_ident("abs") {
+                out.abs = true;
+                Ok(())
+            } else if m.path.is_ident("access") {
+                let val = m.value()?;
+                let ident: Ident = val.parse()?;
+                out.access = match ident.to_string().as_str() {
+                    "ro" => AccessMode::Ro,
+                    "rw" => AccessMode::Rw,
+                    "reserved" => {
+                        return Err(syn::Error::new(
+                            ident.span(),
+                            "`access = reserved` is gone; use `skip` for padding fields",
+                        ));
+                    }
+                    other => {
+                        return Err(syn::Error::new(
+                            ident.span(),
+                            format!("unknown access `{other}` (expected ro|rw)"),
+                        ));
+                    }
+                };
+                Ok(())
+            } else if m.path.is_ident("hook") {
+                let val = m.value()?;
+                out.hook = Some(val.parse()?);
+                Ok(())
+            } else if let Some(op) = cmp_op_for_path(&m.path) {
+                let val = m.value()?;
+                let expr: Expr = val.parse()?;
+                out.compares.push((op, expr));
+                Ok(())
+            } else {
+                Err(m.error("unknown ct_field key"))
+            }
+        })?;
+    }
+    Ok(out)
+}
+
+fn cmp_op_for_path(path: &Path) -> Option<CmpOp> {
+    let ident = path.get_ident()?;
+    Some(match ident.to_string().as_str() {
+        "lt" => CmpOp::Lt,
+        "le" => CmpOp::Le,
+        "gt" => CmpOp::Gt,
+        "ge" => CmpOp::Ge,
+        "eq" => CmpOp::Eq,
+        "ne" => CmpOp::Ne,
+        _ => return None,
+    })
+}
+
+/// Auto enum rule source: `bool` -> `BOOL_ALLOWED`; any non-primitive, non-array
+/// path type -> `<Ty as HasAllowed>::ALLOWED`; primitives and arrays -> none.
+fn auto_enum_allowed(ty: &Type) -> Option<TokenStream2> {
+    let Type::Path(tp) = ty else { return None };
+    let path = &tp.path;
+    if let Some(ident) = path.get_ident() {
+        let name = ident.to_string();
+        if name == "bool" {
+            return Some(quote!(::control_table::BOOL_ALLOWED));
+        }
+        if is_primitive(&name) {
+            return None;
+        }
+    }
+    Some(quote!(<#path as ::control_table::HasAllowed>::ALLOWED))
+}
+
+/// The integer primitives the derive recognizes: zero-initialized in the
+/// generated `new()` ([`default_init_for_type`]) and, with f32/f64, the set that
+/// carries no auto-enum rule ([`is_primitive`]). One list so a new width can't be
+/// added to one consumer and forgotten in the other.
+const PRIMITIVE_INTS: &[&str] = &[
+    "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128", "usize", "isize",
+];
+
+fn is_primitive(name: &str) -> bool {
+    PRIMITIVE_INTS.contains(&name) || matches!(name, "f32" | "f64")
+}
+
+/// `(width, signed)` for a Cmp rule; errors on u32/arrays/other (no wider Cmp).
+fn cmp_width_signed(ty: &Type) -> syn::Result<(u8, bool)> {
+    if let Type::Path(tp) = ty
+        && let Some(ident) = tp.path.get_ident()
+    {
+        match ident.to_string().as_str() {
+            "u8" => return Ok((1, false)),
+            "i8" => return Ok((1, true)),
+            "u16" => return Ok((2, false)),
+            "i16" => return Ok((2, true)),
+            "i32" => return Ok((4, true)),
+            _ => {}
+        }
+    }
+    Err(syn::Error::new(
+        ty.span(),
+        "compare clauses require a primitive integer (u8/u16/i8/i16/i32)",
+    ))
+}
+
+/// RHS of a compare as `(is_reg, val_bits)` for a `CmpRule`: a `&path`
+/// reference names another register (its addr const is already table-absolute,
+/// widened by the helper to the LHS width+signedness -- pinned); any other
+/// expression is the immediate's `i32` bits.
+fn build_rule_val(expr: &Expr) -> (bool, TokenStream2) {
+    if let Expr::Reference(r) = expr {
+        let inner = &r.expr;
+        (true, quote!((#inner) as u32))
+    } else {
+        (false, quote!(((#expr) as i32) as u32))
+    }
+}
+
+/// Type-driven default for the auto-emitted `new()`. Primitives get their
+/// zero value; arrays recurse; anything else falls through to `<Ty>::new()`,
+/// which requires the field type to expose a `const fn new`.
+pub(crate) fn default_init_for_type(ty: &Type) -> TokenStream2 {
+    if let Type::Array(arr) = ty {
+        let inner = default_init_for_type(&arr.elem);
+        let len = &arr.len;
+        return quote!([#inner; #len]);
+    }
+    if let Type::Path(tp) = ty
+        && let Some(ident) = tp.path.get_ident()
+    {
+        let name = ident.to_string();
+        if name == "bool" {
+            return quote!(false);
+        }
+        if PRIMITIVE_INTS.contains(&name.as_str()) {
+            return quote!(0);
+        }
+        if matches!(name.as_str(), "f32" | "f64") {
+            return quote!(0.0);
+        }
+    }
+    quote!(<#ty>::new())
+}

--- a/firmware/lib/control-table-derive/src/common.rs
+++ b/firmware/lib/control-table-derive/src/common.rs
@@ -1,0 +1,113 @@
+//! Helpers shared by the `Block`/`Section`/`Table` derives. Each derive used to
+//! carry its own copy of these; the derive name (for error text) and the attr
+//! ident are the only things that vary, so they pass as parameters.
+
+use proc_macro2::{Group, Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{Attribute, Ident, Meta, Path};
+
+/// Enforce `#[repr(C)]` and reject `packed`/alternate reprs. `derive` names the
+/// deriving macro for the error text (`"Block"`/`"Section"`/`"Table"`).
+pub(crate) fn check_repr(attrs: &[Attribute], struct_span: Span, derive: &str) -> syn::Result<()> {
+    let mut has_c = false;
+    for a in attrs {
+        if !a.path().is_ident("repr") {
+            continue;
+        }
+        a.parse_nested_meta(|m| {
+            if m.path.is_ident("C") {
+                has_c = true;
+                Ok(())
+            } else if m.path.is_ident("packed") {
+                if m.input.peek(syn::token::Paren) {
+                    let _: Group = m.input.parse()?;
+                }
+                Err(m.error(format!(
+                    "{derive} derive forbids #[repr(packed)] (unaligned reads + offset_of are unsound)"
+                )))
+            } else if m.path.is_ident("align") {
+                if m.input.peek(syn::token::Paren) {
+                    let _: Group = m.input.parse()?;
+                }
+                Ok(())
+            } else {
+                Err(m.error(format!(
+                    "{derive} derive requires #[repr(C)] and forbids alternate reprs"
+                )))
+            }
+        })?;
+    }
+    if !has_c {
+        return Err(syn::Error::new(
+            struct_span,
+            format!("{derive} derive requires #[repr(C)]"),
+        ));
+    }
+    Ok(())
+}
+
+/// `#[ct_*(skip)]` on a field. `attr_ident` is the deriving macro's attribute
+/// (`"ct_table"`/`"ct_section"`).
+pub(crate) fn parse_field_skip(attrs: &[Attribute], attr_ident: &str) -> syn::Result<bool> {
+    let mut skip = false;
+    for attr in attrs {
+        if !attr.path().is_ident(attr_ident) {
+            continue;
+        }
+        if matches!(attr.meta, Meta::Path(_)) {
+            continue;
+        }
+        attr.parse_nested_meta(|m| {
+            if m.path.is_ident("skip") {
+                skip = true;
+                Ok(())
+            } else {
+                Err(m.error(format!("unknown {attr_ident} field key (expected `skip`)")))
+            }
+        })?;
+    }
+    Ok(skip)
+}
+
+/// `__flat_meta_<crate>_<Block>` -- the `<crate>` prefix prevents name collisions
+/// at the consumer's crate root when two crates each derive a block with the
+/// same name. Section and Block must compute the same name for the macro the
+/// Block defines and the Section invokes; both run in the consumer's
+/// compilation, so `CARGO_CRATE_NAME` matches.
+pub(crate) fn flat_meta_macro_name(struct_ty: &Ident) -> String {
+    let crate_name = std::env::var("CARGO_CRATE_NAME").unwrap_or_default();
+    let crate_part = crate_name.replace('-', "_");
+    format!("__flat_meta_{crate_part}_{struct_ty}")
+}
+
+/// Optional `where H: <trait>` clause from a single hooks-bound path (the
+/// `dispatch_events` generic bound on Table and Section).
+pub(crate) fn hooks_where_clause(bound: &Option<Path>) -> TokenStream2 {
+    match bound {
+        Some(path) => quote!(where H: #path),
+        None => quote!(),
+    }
+}
+
+/// One block of the const-array concat: walk `src`, run `assign` per element,
+/// and bump the shared `__n`/`i` counters. `prologue` runs once before the loop
+/// (e.g. a `let base = ...;` binding the assignment reads). The enclosing
+/// `const {}` owns `out` and `__n`; this only appends.
+pub(crate) fn fill_loop(
+    src: TokenStream2,
+    prologue: TokenStream2,
+    assign: TokenStream2,
+) -> TokenStream2 {
+    quote! {
+        {
+            let src = #src;
+            #prologue
+            let mut i = 0;
+            while i < src.len() {
+                #assign
+                __n += 1;
+                i += 1;
+            }
+        }
+    }
+}

--- a/firmware/lib/control-table-derive/src/enums.rs
+++ b/firmware/lib/control-table-derive/src/enums.rs
@@ -1,0 +1,82 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Attribute, Data, DeriveInput, Fields, Ident};
+
+pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let enum_ty = &input.ident;
+
+    check_repr_u8(&input.attrs, enum_ty.span())?;
+
+    let Data::Enum(e) = &input.data else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Enum can only be derived for enums",
+        ));
+    };
+
+    let mut variant_idents: Vec<&Ident> = Vec::new();
+    let mut default_variant: Option<&Ident> = None;
+    for v in &e.variants {
+        if !matches!(v.fields, Fields::Unit) {
+            return Err(syn::Error::new(
+                v.span(),
+                "Enum derive requires unit variants only",
+            ));
+        }
+        if v.attrs.iter().any(|a| a.path().is_ident("default")) {
+            default_variant = Some(&v.ident);
+        }
+        variant_idents.push(&v.ident);
+    }
+
+    let new_variant = default_variant.or_else(|| variant_idents.first().copied());
+    let new_impl = new_variant.map(|v| {
+        quote! {
+            #[allow(clippy::new_without_default)]
+            impl #enum_ty {
+                pub const fn new() -> Self {
+                    Self::#v
+                }
+            }
+        }
+    });
+
+    Ok(quote! {
+        impl #enum_ty {
+            pub const ALLOWED: &'static [u8] = &[
+                #(Self::#variant_idents as u8),*
+            ];
+        }
+
+        impl ::control_table::HasAllowed for #enum_ty {
+            const ALLOWED: &'static [u8] = <Self>::ALLOWED;
+        }
+
+        #new_impl
+    })
+}
+
+fn check_repr_u8(attrs: &[Attribute], enum_span: proc_macro2::Span) -> syn::Result<()> {
+    let mut has_u8 = false;
+    for a in attrs {
+        if !a.path().is_ident("repr") {
+            continue;
+        }
+        a.parse_nested_meta(|m| {
+            if m.path.is_ident("u8") {
+                has_u8 = true;
+                Ok(())
+            } else {
+                Err(m.error("Enum derive requires #[repr(u8)]"))
+            }
+        })?;
+    }
+    if !has_u8 {
+        return Err(syn::Error::new(
+            enum_span,
+            "Enum derive requires #[repr(u8)]",
+        ));
+    }
+    Ok(())
+}

--- a/firmware/lib/control-table-derive/src/lib.rs
+++ b/firmware/lib/control-table-derive/src/lib.rs
@@ -1,0 +1,40 @@
+use proc_macro::TokenStream;
+use syn::{DeriveInput, parse_macro_input};
+
+mod block;
+mod common;
+mod enums;
+mod section;
+mod table;
+
+#[proc_macro_derive(Block, attributes(ct_field, ct_block))]
+pub fn derive_block(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    block::expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(Enum, attributes(ct_enum))]
+pub fn derive_enum(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    enums::expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(Section, attributes(ct_section))]
+pub fn derive_section(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    section::expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(Table, attributes(ct_table))]
+pub fn derive_table(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    table::expand(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}

--- a/firmware/lib/control-table-derive/src/section.rs
+++ b/firmware/lib/control-table-derive/src/section.rs
@@ -1,0 +1,248 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Attribute, Data, DeriveInput, Expr, Fields, Ident, Path, Type, TypePath};
+
+#[derive(Default)]
+struct SectionAttrs {
+    base: Option<Expr>,
+    size: Option<Expr>,
+    hooks: Option<Path>,
+}
+
+pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let struct_ty = &input.ident;
+
+    crate::common::check_repr(&input.attrs, struct_ty.span(), "Section")?;
+
+    let Data::Struct(s) = &input.data else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Section can only be derived for structs",
+        ));
+    };
+    let Fields::Named(fields) = &s.fields else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Section requires a struct with named fields",
+        ));
+    };
+
+    let attrs = parse_section_attrs(&input.attrs)?;
+    let base = attrs.base.ok_or_else(|| {
+        syn::Error::new(
+            struct_ty.span(),
+            "Section requires `#[ct_section(base = ...)]`",
+        )
+    })?;
+    let size = attrs.size.ok_or_else(|| {
+        syn::Error::new(
+            struct_ty.span(),
+            "Section requires `#[ct_section(size = ...)]`",
+        )
+    })?;
+    let hooks_bound = attrs.hooks;
+
+    let mut size_terms: Vec<TokenStream2> = Vec::new();
+    let mut new_inits: Vec<TokenStream2> = Vec::new();
+
+    let mut block_tys: Vec<&Type> = Vec::new();
+    let mut block_idents: Vec<&Ident> = Vec::new();
+    let mut block_ty_idents: Vec<&Ident> = Vec::new();
+
+    for field in &fields.named {
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+
+        let init = crate::block::default_init_for_type(ty);
+        new_inits.push(quote!(#name: #init));
+        size_terms.push(quote!(::core::mem::size_of::<#ty>()));
+
+        if crate::common::parse_field_skip(&field.attrs, "ct_section")? {
+            continue;
+        }
+        block_ty_idents.push(block_type_ident(ty)?);
+        block_tys.push(ty);
+        block_idents.push(name);
+    }
+
+    let base_exprs: Vec<TokenStream2> = block_idents
+        .iter()
+        .map(|name| quote!(#struct_ty::BASE + ::core::mem::offset_of!(#struct_ty, #name) as u16))
+        .collect();
+
+    let n_writable = quote!(0 #(+ <#block_tys>::CT_WRITABLE.len())*);
+    let n_cmp = quote!(0 #(+ <#block_tys>::CT_CMP_RULES.len())*);
+    let n_allowed = quote!(0 #(+ <#block_tys>::CT_ALLOWED_RULES.len())*);
+
+    // Blocks in declaration order (= address order): preserves the old
+    // sorted-by-offset first-failure precedence. Only `addr` is rebased into
+    // table-absolute form; register-RHS `val` addrs are already absolute.
+    let rebase_rule = |src: TokenStream2, base_expr: &TokenStream2| {
+        crate::common::fill_loop(
+            src,
+            quote!(let base = #base_expr;),
+            quote!(let mut r = src[i]; r.addr += base; out[__n] = r;),
+        )
+    };
+    let cmp_copy: Vec<TokenStream2> = block_tys
+        .iter()
+        .zip(&base_exprs)
+        .map(|(ty, base_expr)| rebase_rule(quote!(<#ty>::CT_CMP_RULES), base_expr))
+        .collect();
+
+    let allowed_copy: Vec<TokenStream2> = block_tys
+        .iter()
+        .zip(&base_exprs)
+        .map(|(ty, base_expr)| rebase_rule(quote!(<#ty>::CT_ALLOWED_RULES), base_expr))
+        .collect();
+
+    let writable_copy: Vec<TokenStream2> = block_tys
+        .iter()
+        .zip(&base_exprs)
+        .map(|(ty, base_expr)| {
+            crate::common::fill_loop(
+                quote!(<#ty>::CT_WRITABLE),
+                quote!(let base = #base_expr;),
+                quote!(out[__n] = (src[i].0 + base, src[i].1);),
+            )
+        })
+        .collect();
+
+    let addr_mods: Vec<TokenStream2> = block_idents
+        .iter()
+        .zip(&block_ty_idents)
+        .map(|(name, block_ty_ident)| {
+            let meta_macro = Ident::new(
+                &crate::common::flat_meta_macro_name(block_ty_ident),
+                block_ty_ident.span(),
+            );
+            quote! {
+                #[allow(dead_code)]
+                pub mod #name {
+                    use super::super::{#struct_ty, #block_ty_ident};
+                    #meta_macro!(@addr_consts
+                        base = (#struct_ty::BASE
+                            + ::core::mem::offset_of!(#struct_ty, #name) as u16),
+                        block_ty = #block_ty_ident);
+                }
+            }
+        })
+        .collect();
+
+    let dispatch_calls: Vec<TokenStream2> = block_idents
+        .iter()
+        .zip(&base_exprs)
+        .map(|(name, base_expr)| {
+            quote! {
+                self.#name.dispatch_events(abs_addr, len, #base_expr, hooks);
+            }
+        })
+        .collect();
+
+    let where_clause = crate::common::hooks_where_clause(&hooks_bound);
+    let dispatch_args = if dispatch_calls.is_empty() {
+        quote!(_abs_addr: u16, _len: u16, _hooks: &mut H)
+    } else {
+        quote!(abs_addr: u16, len: u16, hooks: &mut H)
+    };
+
+    Ok(quote! {
+        impl #struct_ty {
+            pub const BASE: u16 = #base;
+            pub const SECTION_SIZE: u16 = #size;
+
+            pub const CT_WRITABLE_ABS: [(u16, u16); #n_writable] = {
+                let mut out = [(0u16, 0u16); #n_writable];
+                let mut __n = 0;
+                #(#writable_copy)*
+                out
+            };
+
+            pub const CT_CMP_RULES_ABS: [::control_table::rules::CmpRule; #n_cmp] = {
+                let mut out = [::control_table::rules::CmpRule { addr: 0, spec: 0, val: 0 }; #n_cmp];
+                let mut __n = 0;
+                #(#cmp_copy)*
+                out
+            };
+
+            pub const CT_ALLOWED_RULES_ABS: [::control_table::rules::AllowedRule; #n_allowed] = {
+                let mut out =
+                    [::control_table::rules::AllowedRule { addr: 0, allowed: &[] }; #n_allowed];
+                let mut __n = 0;
+                #(#allowed_copy)*
+                out
+            };
+
+        }
+
+        #[allow(clippy::new_without_default)]
+        impl #struct_ty {
+            pub const fn new() -> Self {
+                Self { #(#new_inits),* }
+            }
+        }
+
+        impl #struct_ty {
+            pub fn dispatch_events<H>(
+                &self,
+                #dispatch_args,
+            ) #where_clause {
+                #(#dispatch_calls)*
+            }
+        }
+
+        pub mod addr {
+            #(#addr_mods)*
+        }
+
+        const _: () = {
+            assert!(
+                ::core::mem::size_of::<#struct_ty>() == (#size as usize),
+                "Section struct size does not equal its declared section budget; add an explicit `_rsvd` tail array to fill the section budget",
+            );
+            assert!(
+                0 #(+ #size_terms)* == ::core::mem::size_of::<#struct_ty>(),
+                "Section struct has repr(C) padding; add explicit `_rsvd` fields so the flat read path never exposes uninitialized bytes",
+            );
+        };
+    })
+}
+
+fn parse_section_attrs(attrs: &[Attribute]) -> syn::Result<SectionAttrs> {
+    let mut out = SectionAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("ct_section") {
+            continue;
+        }
+        attr.parse_nested_meta(|m| {
+            if m.path.is_ident("base") {
+                out.base = Some(m.value()?.parse()?);
+                Ok(())
+            } else if m.path.is_ident("size") {
+                out.size = Some(m.value()?.parse()?);
+                Ok(())
+            } else if m.path.is_ident("hooks") {
+                out.hooks = Some(m.value()?.parse()?);
+                Ok(())
+            } else {
+                Err(m.error("unknown ct_section key (expected base|size|hooks)"))
+            }
+        })?;
+    }
+    Ok(out)
+}
+
+fn block_type_ident(ty: &Type) -> syn::Result<&Ident> {
+    let Type::Path(TypePath { qself: None, path }) = ty else {
+        return Err(syn::Error::new(
+            ty.span(),
+            "Section field type must be a simple path to a Block-derived struct",
+        ));
+    };
+    let last = path
+        .segments
+        .last()
+        .ok_or_else(|| syn::Error::new(ty.span(), "Section field type has empty path"))?;
+    Ok(&last.ident)
+}

--- a/firmware/lib/control-table-derive/src/table.rs
+++ b/firmware/lib/control-table-derive/src/table.rs
@@ -1,0 +1,331 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+use syn::{Attribute, Data, DeriveInput, Expr, Fields, Ident, Path, Type};
+
+#[derive(Default)]
+struct TableAttrs {
+    size: Option<Expr>,
+    hooks: Option<Path>,
+}
+
+pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
+    let table_ty = &input.ident;
+
+    crate::common::check_repr(&input.attrs, table_ty.span(), "Table")?;
+
+    let Data::Struct(s) = &input.data else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Table can only be derived for structs",
+        ));
+    };
+    let Fields::Named(fields) = &s.fields else {
+        return Err(syn::Error::new(
+            input.span(),
+            "Table requires a struct with named fields",
+        ));
+    };
+
+    let attrs = parse_table_attrs(&input.attrs)?;
+    let size = attrs.size.ok_or_else(|| {
+        syn::Error::new(table_ty.span(), "Table requires `#[ct_table(size = ...)]`")
+    })?;
+    let hooks_bound = attrs.hooks;
+
+    let mut size_terms: Vec<TokenStream2> = Vec::new();
+    let mut new_inits: Vec<TokenStream2> = Vec::new();
+
+    let mut sec_tys: Vec<&Type> = Vec::new();
+    let mut sec_idents: Vec<&Ident> = Vec::new();
+
+    for field in &fields.named {
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+
+        let init = crate::block::default_init_for_type(ty);
+        new_inits.push(quote!(#name: #init));
+        size_terms.push(quote!(::core::mem::size_of::<#ty>()));
+
+        if crate::common::parse_field_skip(&field.attrs, "ct_table")? {
+            continue;
+        }
+        sec_tys.push(ty);
+        sec_idents.push(name);
+    }
+
+    let words = quote!((#size as usize).div_ceil(32));
+
+    let writable_fill: Vec<TokenStream2> = sec_tys
+        .iter()
+        .map(|ty| {
+            quote! {
+                {
+                    let spans = <#ty>::CT_WRITABLE_ABS;
+                    let mut si = 0;
+                    while si < spans.len() {
+                        let (off, len) = spans[si];
+                        let mut b = off as usize;
+                        let end = off as usize + len as usize;
+                        while b < end {
+                            w[b / 32] |= 1u32 << (b % 32);
+                            b += 1;
+                        }
+                        si += 1;
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // Per-section index range into the table-level rule arrays: start is the
+    // cumulative rule count of preceding sections (section declaration order).
+    let section_metas: Vec<TokenStream2> = sec_tys
+        .iter()
+        .enumerate()
+        .map(|(i, ty)| {
+            let cmp_pre = &sec_tys[..i];
+            let allowed_pre = &sec_tys[..i];
+            quote! {
+                ::control_table::map::SectionMeta {
+                    base: <#ty>::BASE,
+                    size: <#ty>::SECTION_SIZE,
+                    cmp_rules: {
+                        let start = 0u16 #(+ <#cmp_pre>::CT_CMP_RULES_ABS.len() as u16)*;
+                        (start, start + <#ty>::CT_CMP_RULES_ABS.len() as u16)
+                    },
+                    allowed_rules: {
+                        let start = 0u16 #(+ <#allowed_pre>::CT_ALLOWED_RULES_ABS.len() as u16)*;
+                        (start, start + <#ty>::CT_ALLOWED_RULES_ABS.len() as u16)
+                    },
+                }
+            }
+        })
+        .collect();
+
+    let n_cmp = quote!(0 #(+ <#sec_tys>::CT_CMP_RULES_ABS.len())*);
+    let n_allowed = quote!(0 #(+ <#sec_tys>::CT_ALLOWED_RULES_ABS.len())*);
+
+    let cmp_fill: Vec<TokenStream2> = sec_tys
+        .iter()
+        .map(|ty| {
+            crate::common::fill_loop(
+                quote!(<#ty>::CT_CMP_RULES_ABS),
+                quote!(),
+                quote!(out[__n] = src[i];),
+            )
+        })
+        .collect();
+
+    let allowed_fill: Vec<TokenStream2> = sec_tys
+        .iter()
+        .map(|ty| {
+            crate::common::fill_loop(
+                quote!(<#ty>::CT_ALLOWED_RULES_ABS),
+                quote!(),
+                quote!(out[__n] = src[i];),
+            )
+        })
+        .collect();
+
+    let dispatch_calls: Vec<TokenStream2> = sec_idents
+        .iter()
+        .map(|name| quote!(self.#name.dispatch_events(abs_addr, len, hooks);))
+        .collect();
+
+    let addr_reexports: Vec<TokenStream2> = sec_idents
+        .iter()
+        .map(|name| quote!(pub use super::#name::addr as #name;))
+        .collect();
+
+    let base_offset_asserts: Vec<TokenStream2> = sec_idents
+        .iter()
+        .zip(&sec_tys)
+        .map(|(name, ty)| {
+            quote! {
+                assert!(
+                    ::core::mem::offset_of!(#table_ty, #name) as u16 == <#ty>::BASE,
+                    "section base must equal its byte offset in the table (address IS offset)",
+                );
+            }
+        })
+        .collect();
+
+    let extents: Vec<TokenStream2> = sec_tys
+        .iter()
+        .map(|ty| quote!((<#ty>::BASE, <#ty>::SECTION_SIZE)))
+        .collect();
+
+    let where_clause = crate::common::hooks_where_clause(&hooks_bound);
+    let dispatch_args = if dispatch_calls.is_empty() {
+        quote!(_abs_addr: u16, _len: u16, _hooks: &mut H)
+    } else {
+        quote!(abs_addr: u16, len: u16, hooks: &mut H)
+    };
+
+    // Orphan rules forbid `impl RegisterMap for SyncUnsafeCell<#table_ty>` in the
+    // consumer crate (foreign trait, non-fundamental foreign wrapper). A local
+    // #[repr(transparent)] newtype is orphan-legal, and its interior UnsafeCell
+    // keeps `base()`'s pointer mutably-provenanced (writes through a `&#table_ty`
+    // would be UB).
+    let cell_ty = format_ident!("{table_ty}Cell");
+
+    Ok(quote! {
+        impl #table_ty {
+            pub const WRITABLE_WORDS: [u32; #words] = {
+                let mut w = [0u32; #words];
+                #(#writable_fill)*
+                w
+            };
+
+            pub const CMP_RULES: [::control_table::rules::CmpRule; #n_cmp] = {
+                let mut out =
+                    [::control_table::rules::CmpRule { addr: 0, spec: 0, val: 0 }; #n_cmp];
+                let mut __n = 0;
+                #(#cmp_fill)*
+                out
+            };
+
+            pub const ALLOWED_RULES: [::control_table::rules::AllowedRule; #n_allowed] = {
+                let mut out =
+                    [::control_table::rules::AllowedRule { addr: 0, allowed: &[] }; #n_allowed];
+                let mut __n = 0;
+                #(#allowed_fill)*
+                out
+            };
+        }
+
+        #[allow(clippy::new_without_default)]
+        impl #table_ty {
+            pub const fn new() -> Self {
+                Self { #(#new_inits),* }
+            }
+        }
+
+        #[repr(transparent)]
+        pub struct #cell_ty(::core::cell::SyncUnsafeCell<#table_ty>);
+
+        #[allow(clippy::new_without_default)]
+        impl #cell_ty {
+            pub const fn new() -> Self {
+                Self(::core::cell::SyncUnsafeCell::new(#table_ty::new()))
+            }
+
+            /// Shared view of the underlying table (e.g. for `dispatch_events`).
+            ///
+            /// # Safety
+            /// Caller upholds the single-writer contract: no `&mut` to the table
+            /// may be live for the borrow.
+            pub unsafe fn table(&self) -> &#table_ty {
+                unsafe { &*self.0.get() }
+            }
+        }
+
+        impl ::control_table::Region for #table_ty {}
+
+        impl ::control_table::RegionStorage<#table_ty> for #cell_ty {
+            fn with<T>(&self, f: impl FnOnce(&#table_ty) -> T) -> T {
+                // SAFETY: caller upholds RegionStorage's single-writer contract.
+                unsafe { f(&*self.0.get()) }
+            }
+            fn with_mut<T>(&self, f: impl FnOnce(&mut #table_ty) -> T) -> T {
+                // SAFETY: caller upholds RegionStorage's single-writer contract.
+                unsafe { f(&mut *self.0.get()) }
+            }
+        }
+
+        // SAFETY: the interior `SyncUnsafeCell::get` returns a valid aligned
+        // pointer to the table, valid for the cell's lifetime.
+        unsafe impl ::control_table::RegionStorageRaw<#table_ty> for #cell_ty {
+            fn region_ptr(&self) -> *mut #table_ty {
+                self.0.get()
+            }
+        }
+
+        impl ::control_table::map::RegisterMap for #cell_ty {
+            const SIZE: usize = #size as usize;
+            const WRITABLE: &'static [u32] = &#table_ty::WRITABLE_WORDS;
+            const SECTIONS: &'static [::control_table::map::SectionMeta] =
+                &[#(#section_metas),*];
+            const CMP_RULES: &'static [::control_table::rules::CmpRule] =
+                &#table_ty::CMP_RULES;
+            const ALLOWED_RULES: &'static [::control_table::rules::AllowedRule] =
+                &#table_ty::ALLOWED_RULES;
+            fn base(&self) -> *mut u8 {
+                self.0.get() as *mut u8
+            }
+        }
+
+        impl #table_ty {
+            pub fn dispatch_events<H>(
+                &self,
+                #dispatch_args,
+            ) #where_clause {
+                #(#dispatch_calls)*
+            }
+        }
+
+        pub mod addr {
+            #(#addr_reexports)*
+        }
+
+        const _: () = {
+            assert!(
+                ::core::mem::size_of::<#table_ty>() == (#size as usize),
+                "Table struct size does not equal its declared size; add an explicit `_rsvd` tail array to fill the table budget",
+            );
+            assert!(
+                0 #(+ #size_terms)* == ::core::mem::size_of::<#table_ty>(),
+                "Table struct has repr(C) padding; add explicit `_rsvd` fields so the flat read path never exposes uninitialized bytes",
+            );
+
+            #(#base_offset_asserts)*
+
+            const EXTENTS: &[(u16, u16)] = &[#(#extents),*];
+            let mut i = 0;
+            while i < EXTENTS.len() {
+                let (ai, si) = EXTENTS[i];
+                assert!(
+                    (ai as u32) + (si as u32) <= (#size as u32),
+                    "section extends past the table end",
+                );
+                let mut j = i + 1;
+                while j < EXTENTS.len() {
+                    let (aj, sj) = EXTENTS[j];
+                    let i_end = (ai as u32) + (si as u32);
+                    let j_end = (aj as u32) + (sj as u32);
+                    assert!(
+                        (ai as u32) >= j_end || (aj as u32) >= i_end,
+                        "sections overlap within the table",
+                    );
+                    j += 1;
+                }
+                i += 1;
+            }
+        };
+    })
+}
+
+fn parse_table_attrs(attrs: &[Attribute]) -> syn::Result<TableAttrs> {
+    let mut out = TableAttrs::default();
+    for attr in attrs {
+        if !attr.path().is_ident("ct_table") {
+            continue;
+        }
+        if matches!(attr.meta, syn::Meta::Path(_)) {
+            continue;
+        }
+        attr.parse_nested_meta(|m| {
+            if m.path.is_ident("size") {
+                out.size = Some(m.value()?.parse()?);
+                Ok(())
+            } else if m.path.is_ident("hooks") {
+                out.hooks = Some(m.value()?.parse()?);
+                Ok(())
+            } else {
+                Err(m.error("unknown ct_table key (expected `size` or `hooks`)"))
+            }
+        })?;
+    }
+    Ok(out)
+}

--- a/firmware/lib/control-table/Cargo.toml
+++ b/firmware/lib/control-table/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name    = "control-table"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+heapless.workspace             = true
+control-table-derive.workspace = true
+defmt                          = { version = "1", optional = true }
+
+[dev-dependencies]
+trybuild = "1"
+
+[features]
+default          = ["sync-unsafe-cell"]
+defmt            = ["dep:defmt"]
+sync-unsafe-cell = []

--- a/firmware/lib/control-table/src/lib.rs
+++ b/firmware/lib/control-table/src/lib.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![cfg_attr(feature = "sync-unsafe-cell", feature(sync_unsafe_cell))]
+
+pub mod map;
+mod region;
+pub mod rules;
+mod stage;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    OutOfRange,
+    AccessError,
+    StagingFull,
+    ValidationError(ValidationKind),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ValidationKind {
+    Enum,
+    Compare,
+}
+
+/// `bool` is `u8` 0/1; any other byte yields UB on later access.
+pub const BOOL_ALLOWED: &[u8] = &[0, 1];
+
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not expose an `ALLOWED` discriminant slice",
+    label = "missing `#[derive(control_table::Enum)]`",
+    note = "add `#[derive(Enum)]` and `#[repr(u8)]` to `{Self}` to generate `ALLOWED`"
+)]
+pub trait HasAllowed {
+    const ALLOWED: &'static [u8];
+}
+
+pub use region::{Region, RegionStorage, RegionStorageRaw};
+pub use stage::{STAGE_DATA_CAP, STAGE_ENTRY_CAP, Snapshot, StagedWrites};
+
+pub use control_table_derive::{Block, Enum, Section, Table};
+
+pub use map::{RegisterFile, RegisterMap, SectionMeta, View};

--- a/firmware/lib/control-table/src/map.rs
+++ b/firmware/lib/control-table/src/map.rs
@@ -1,0 +1,354 @@
+use crate::Error;
+use crate::rules;
+use crate::stage::{Snapshot, StagedWrites};
+
+/// Compile-time description of a flat register map. Implemented by the Table
+/// derive; hand-implemented in tests.
+///
+/// # Safety
+/// `base` must return a valid, non-null, aligned pointer to `SIZE` bytes that
+/// stays valid for the lifetime of `&self`; callers uphold a single-writer
+/// contract like `RegionStorageRaw`.
+pub trait RegisterMap {
+    const SIZE: usize;
+    /// Writable-byte bitmask, bit `i % 32` of word `i / 32` set = byte `i`
+    /// host-writable. `len == SIZE.div_ceil(32)`.
+    const WRITABLE: &'static [u32];
+    /// Sorted by `base`, non-overlapping.
+    const SECTIONS: &'static [SectionMeta];
+    /// All sections' compare rules concatenated in section order (table-absolute
+    /// addresses); each section owns the `cmp_rules` sub-slice of this array.
+    const CMP_RULES: &'static [rules::CmpRule] = &[];
+    /// All sections' enum/bool rules concatenated in section order; each section
+    /// owns the `allowed_rules` sub-slice of this array.
+    const ALLOWED_RULES: &'static [rules::AllowedRule] = &[];
+    fn base(&self) -> *mut u8;
+}
+
+pub struct SectionMeta {
+    pub base: u16,
+    pub size: u16,
+    /// `[start, end)` range into `RegisterMap::CMP_RULES` for this section.
+    pub cmp_rules: (u16, u16),
+    /// `[start, end)` range into `RegisterMap::ALLOWED_RULES` for this section.
+    pub allowed_rules: (u16, u16),
+}
+
+/// Live base pointer + size plus one pending overlay, so a check sees the value
+/// about to be committed on top of live storage. The overlay is up to two
+/// contiguous ranges -- `o2` logically follows `o1` at `overlay_addr + o1.len()`
+/// -- because a ring-seam write arrives as head + tail (`o2` empty otherwise).
+pub struct View<'a> {
+    base: *const u8,
+    size: usize,
+    overlay_addr: u16,
+    o1: &'a [u8],
+    o2: &'a [u8],
+}
+
+impl<'a> View<'a> {
+    /// Build a view over `[base, base+size)` with one pending overlay of
+    /// `overlay` bytes starting at `overlay_addr`.
+    ///
+    /// # Safety
+    /// `base` must point to `size` valid bytes that outlive the view; the caller
+    /// upholds `RegisterMap`'s single-writer contract for shared reads.
+    pub fn new(base: *const u8, size: usize, overlay_addr: u16, overlay: &'a [u8]) -> View<'a> {
+        View::new_split(base, size, overlay_addr, overlay, &[])
+    }
+
+    /// As [`View::new`] but with the overlay split across the ring seam: `o1`
+    /// starts at `overlay_addr`, `o2` continues at `overlay_addr + o1.len()`.
+    ///
+    /// # Safety
+    /// Same contract as [`View::new`].
+    pub fn new_split(
+        base: *const u8,
+        size: usize,
+        overlay_addr: u16,
+        o1: &'a [u8],
+        o2: &'a [u8],
+    ) -> View<'a> {
+        View {
+            base,
+            size,
+            overlay_addr,
+            o1,
+            o2,
+        }
+    }
+
+    /// Load `[addr, addr+len)` (`len <= 4`) into a `[u8; 4]` as little-endian
+    /// bytes, taking each byte from the pending overlay where it lands inside
+    /// `[overlay_addr, overlay_addr+o1.len()+o2.len())` and from live storage
+    /// otherwise. Returns `OutOfRange` when `[addr, addr+len)` leaves the map.
+    /// Bounds-checked once up front; the per-byte picks then need no further
+    /// checks. Bytes past `len` in the returned array are zero.
+    ///
+    /// Rule reads are almost always fully outside the overlay (a compare's
+    /// RHS register, a lock byte) or fully inside `o1` (the field being
+    /// written) -- those take straight byte loads; the per-byte pick pays
+    /// only on seam splits and overlay-edge straddles (bench: the pick chain
+    /// ran ~6.8 us per load on flash-resident code, the write path's
+    /// hottest function). Outlined: inlining at the (deduped) rule-body
+    /// sites measured zero gain for +146 B -- the cost is the loads, not the
+    /// call.
+    #[inline(never)]
+    pub fn read_fixed(&self, addr: u16, len: usize) -> Result<[u8; 4], Error> {
+        let lo = addr as usize;
+        let hi = match lo.checked_add(len) {
+            Some(h) => h,
+            None => return Err(Error::OutOfRange),
+        };
+        if hi > self.size {
+            return Err(Error::OutOfRange);
+        }
+        let o_lo = self.overlay_addr as usize;
+        let split = o_lo + self.o1.len();
+        let o_hi = split + self.o2.len();
+        if hi <= o_lo || lo >= o_hi {
+            // SAFETY: `hi <= size` bytes of live storage; the caller upholds
+            // RegisterMap's single-writer contract, so this shared read does
+            // not race a commit.
+            return Ok(unsafe { load_le4(self.base.add(lo), len) });
+        }
+        if lo >= o_lo && hi <= split {
+            // SAFETY: `[lo, hi)` lies inside `[o_lo, split)`, so the offset
+            // span is in `o1`.
+            return Ok(unsafe { load_le4(self.o1.as_ptr().add(lo - o_lo), len) });
+        }
+        Ok(self.read_mixed(lo, len, o_lo, split, o_hi))
+    }
+
+    /// Overlay-edge straddles and seam splits: pick each byte from live
+    /// storage, `o1`, or `o2`. Bounds pre-checked by [`Self::read_fixed`].
+    #[cold]
+    fn read_mixed(&self, lo: usize, len: usize, o_lo: usize, split: usize, o_hi: usize) -> [u8; 4] {
+        let mut out = [0u8; 4];
+        for (i, slot) in out.iter_mut().take(len).enumerate() {
+            let a = lo + i;
+            *slot = if a >= o_lo && a < split {
+                // Bounds guaranteed by `a < split = o_lo + o1.len()`; get keeps
+                // the never-panic contract regardless.
+                self.o1.get(a - o_lo).copied().unwrap_or(0)
+            } else if a >= split && a < o_hi {
+                self.o2.get(a - split).copied().unwrap_or(0)
+            } else {
+                // SAFETY: `a < hi <= size` bytes of live storage; the caller
+                // upholds RegisterMap's single-writer contract, so this shared
+                // read does not race a commit.
+                unsafe { *self.base.add(a) }
+            };
+        }
+        out
+    }
+}
+
+/// Load `len` bytes (capped at 4) from `p` into a zero-padded `[u8; 4]` with
+/// unrolled byte loads -- no per-byte range compares.
+///
+/// # Safety
+/// `p` must be valid for `len.min(4)` byte reads.
+unsafe fn load_le4(p: *const u8, len: usize) -> [u8; 4] {
+    let mut out = [0u8; 4];
+    // SAFETY: caller guarantees `len.min(4)` readable bytes at `p`.
+    unsafe {
+        match len {
+            4.. => out = p.cast::<[u8; 4]>().read_unaligned(),
+            2 => out[..2].copy_from_slice(&p.cast::<[u8; 2]>().read_unaligned()),
+            1 => out[0] = p.read(),
+            3 => {
+                out[..2].copy_from_slice(&p.cast::<[u8; 2]>().read_unaligned());
+                out[2] = p.add(2).read();
+            }
+            0 => {}
+        }
+    }
+    out
+}
+
+/// Validate `[addr, addr+o1.len()+o2.len())` against the flat map: bounds ->
+/// writable mask -> rules, in that precedence. The view is live storage
+/// plus this op's `o1`/`o2` overlay only (previously staged entries are not
+/// visible). `o2` continues after `o1` at the ring seam; it is empty for a
+/// contiguous write.
+fn validate<M: RegisterMap + ?Sized>(m: &M, addr: u16, o1: &[u8], o2: &[u8]) -> Result<(), Error> {
+    let total = o1.len() + o2.len();
+    if total == 0 {
+        return Ok(());
+    }
+    let lo = addr as usize;
+    let hi = match lo.checked_add(total) {
+        Some(h) => h,
+        None => return Err(Error::OutOfRange),
+    };
+    if hi > M::SIZE {
+        return Err(Error::OutOfRange);
+    }
+    // Writable-mask check a word at a time: interior words must equal `!0`; the
+    // (up to two) edge words test only their covered bit-spans. `src` is non-
+    // empty here, so `hi - 1` never underflows.
+    let first = lo / 32;
+    let last = (hi - 1) / 32;
+    for wi in first..=last {
+        let word_lo = wi * 32;
+        let start_bit = lo.saturating_sub(word_lo);
+        let end_bit = (hi - word_lo).min(32);
+        // u32 shifts only -- a runtime u64 shift is an __ashldi3 libcall on
+        // RV32E. `start_bit < 32` always; branch on the one amount that would
+        // overflow a u32 shift.
+        let covered = if end_bit == 32 {
+            !0u32
+        } else {
+            (1u32 << end_bit) - 1
+        };
+        let mask = covered & !((1u32 << start_bit) - 1);
+        let w = M::WRITABLE.get(wi).copied().unwrap_or(0);
+        if (w & mask) != mask {
+            return Err(Error::AccessError);
+        }
+    }
+
+    let view = View::new_split(m.base() as *const u8, M::SIZE, addr, o1, o2);
+
+    // Within a section allowed rules run before compare rules (previously
+    // interleaved in field order -- only observable when one write spans
+    // multiple invalid fields of different kinds; not spec-pinned).
+    for sec in M::SECTIONS {
+        if !overlaps(sec.base as usize, sec.size as usize, lo, hi) {
+            continue;
+        }
+        // Both stripes are address-ordered (blocks and fields emit in
+        // declaration = address order), so the scan ends at the first rule
+        // past the write.
+        let (a0, a1) = sec.allowed_rules;
+        if let Some(rs) = M::ALLOWED_RULES.get(a0 as usize..a1 as usize) {
+            for r in rs {
+                if r.addr as usize >= hi {
+                    break;
+                }
+                if overlaps(r.addr as usize, 1, lo, hi) {
+                    rules::check_allowed(&view, r.addr, r.allowed)?;
+                }
+            }
+        }
+        let (c0, c1) = sec.cmp_rules;
+        if let Some(rs) = M::CMP_RULES.get(c0 as usize..c1 as usize) {
+            for r in rs {
+                if r.addr as usize >= hi {
+                    break;
+                }
+                let width = (r.spec & 0xF) as usize;
+                if overlaps(r.addr as usize, width, lo, hi) {
+                    let rhs = if r.spec & rules::SPEC_RHS_REG != 0 {
+                        rules::Rhs::Reg(r.val as u16)
+                    } else {
+                        rules::Rhs::Imm(r.val as i32)
+                    };
+                    rules::check_cmp(&view, r.addr, r.spec, rhs)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `[a_lo, a_lo+a_len)` overlaps `[lo, hi)` at all.
+fn overlaps(a_lo: usize, a_len: usize, lo: usize, hi: usize) -> bool {
+    a_lo < hi && a_lo + a_len > lo
+}
+
+/// Copy every staged entry pushed since `snap` into live storage (out-of-bounds
+/// entries skipped). The caller truncates the buffer afterward per its commit
+/// semantics (`clear` for a full COMMIT, `revert_to(snap)` for a verdict).
+fn apply_from<M: RegisterMap + ?Sized>(m: &M, staged: &StagedWrites, snap: &Snapshot) {
+    let base = m.base();
+    for (addr, data) in staged.iter_from(snap) {
+        let end = addr as usize + data.len();
+        if end > M::SIZE {
+            continue;
+        }
+        // SAFETY: bounds guarded above; the caller upholds RegisterMap's
+        // single-writer contract.
+        unsafe {
+            core::ptr::copy_nonoverlapping(data.as_ptr(), base.add(addr as usize), data.len());
+        }
+    }
+}
+
+/// Extension surface over a `RegisterMap`: memory-like `read`/`write` plus the
+/// staged (RegWrite) flow. Blanket-implemented for every map.
+pub trait RegisterFile: RegisterMap {
+    fn read(&self, addr: u16, len: u16) -> Result<&[u8], Error> {
+        let hi = addr as u32 + len as u32;
+        if hi > Self::SIZE as u32 {
+            return Err(Error::OutOfRange);
+        }
+        if len == 0 {
+            return Ok(&[]);
+        }
+        // SAFETY: `[addr, addr+len)` lies in `SIZE` bytes; the caller upholds
+        // RegisterMap's single-writer contract, so this borrow does not race a
+        // commit for its lifetime.
+        let slice =
+            unsafe { core::slice::from_raw_parts(self.base().add(addr as usize), len as usize) };
+        Ok(slice)
+    }
+
+    fn write(&self, addr: u16, src: &[u8]) -> Result<(), Error> {
+        self.write_split(addr, src, &[])
+    }
+
+    /// As [`write`](RegisterFile::write) but with the source split across the
+    /// ring seam: `head` at `addr`, `tail` continuing after it.
+    fn write_split(&self, addr: u16, head: &[u8], tail: &[u8]) -> Result<(), Error> {
+        validate(self, addr, head, tail)?;
+        // SAFETY: validate confirmed `[addr, addr+head.len()+tail.len())` is in
+        // bounds; the caller upholds RegisterMap's single-writer contract.
+        unsafe {
+            let base = self.base();
+            core::ptr::copy_nonoverlapping(head.as_ptr(), base.add(addr as usize), head.len());
+            core::ptr::copy_nonoverlapping(
+                tail.as_ptr(),
+                base.add(addr as usize + head.len()),
+                tail.len(),
+            );
+        }
+        Ok(())
+    }
+
+    fn stage(&self, addr: u16, src: &[u8], staged: &mut StagedWrites) -> Result<(), Error> {
+        self.stage_split(addr, src, &[], staged)
+    }
+
+    /// As [`stage`](RegisterFile::stage) but with the source split across the
+    /// ring seam.
+    fn stage_split(
+        &self,
+        addr: u16,
+        head: &[u8],
+        tail: &[u8],
+        staged: &mut StagedWrites,
+    ) -> Result<(), Error> {
+        validate(self, addr, head, tail)?;
+        staged.push_split(addr, head, tail)
+    }
+
+    fn commit_staged(&self, staged: &mut StagedWrites) {
+        apply_from(self, staged, &Snapshot::ZERO);
+        staged.clear();
+    }
+
+    /// Apply only the entries pushed since `snap`, then truncate the buffer back
+    /// to it -- a pending write's verdict commit, leaving any pre-`snap` HOLD
+    /// entries intact for a later real COMMIT.
+    fn commit_from(&self, staged: &mut StagedWrites, snap: &Snapshot) {
+        apply_from(self, staged, snap);
+        staged.revert_to(snap);
+    }
+}
+
+impl<M: RegisterMap> RegisterFile for M {}
+
+#[cfg(test)]
+mod tests;

--- a/firmware/lib/control-table/src/map/tests.rs
+++ b/firmware/lib/control-table/src/map/tests.rs
@@ -1,0 +1,403 @@
+use super::*;
+use crate::ValidationKind;
+use core::cell::UnsafeCell;
+
+// --- Basic fixture: checks + a read-only byte, no lock. Hand-written to mirror
+// what the derive emits: enum [0,1]@0, i16 >= 0 @4, u16 < reg(8) @6, i8 |x| <= 5
+// @10, i32 <= 100_000 @12 -- each overlap-guarded against the pending range. ---
+
+const BASIC_SIZE: usize = 16;
+
+// The same five rules the old `basic_check` encoded, now as flash descriptors:
+// enum [0,1]@0, i16 >= 0 @4, u16 < reg(8) @6, i8 |x| <= 5 @10, i32 <= 100_000 @12.
+const BASIC_ALLOWED_RULES: &[crate::rules::AllowedRule] = &[crate::rules::AllowedRule {
+    addr: 0,
+    allowed: &[0, 1],
+}];
+const BASIC_CMP_RULES: &[crate::rules::CmpRule] = &[
+    crate::rules::CmpRule {
+        addr: 4,
+        spec: crate::rules::spec(2, true, false, crate::rules::OP_GE),
+        val: 0,
+    },
+    crate::rules::CmpRule {
+        addr: 6,
+        spec: crate::rules::spec(2, false, false, crate::rules::OP_LT) | crate::rules::SPEC_RHS_REG,
+        val: 8,
+    },
+    crate::rules::CmpRule {
+        addr: 10,
+        spec: crate::rules::spec(1, true, true, crate::rules::OP_LE),
+        val: 5,
+    },
+    crate::rules::CmpRule {
+        addr: 12,
+        spec: crate::rules::spec(4, true, false, crate::rules::OP_LE),
+        val: 100_000,
+    },
+];
+
+static BASIC_SECTIONS: &[SectionMeta] = &[SectionMeta {
+    base: 0,
+    size: BASIC_SIZE as u16,
+    cmp_rules: (0, 4),
+    allowed_rules: (0, 1),
+}];
+
+// Every byte writable except byte 3 (read-only, mid-range).
+const BASIC_WRITABLE: &[u32] = &[!(1u32 << 3)];
+
+struct Basic {
+    store: UnsafeCell<[u8; BASIC_SIZE]>,
+}
+
+// SAFETY: tests are single-threaded.
+unsafe impl Sync for Basic {}
+
+impl Basic {
+    fn new(init: [u8; BASIC_SIZE]) -> Self {
+        Self {
+            store: UnsafeCell::new(init),
+        }
+    }
+}
+
+impl RegisterMap for Basic {
+    const SIZE: usize = BASIC_SIZE;
+    const WRITABLE: &'static [u32] = BASIC_WRITABLE;
+    const SECTIONS: &'static [SectionMeta] = BASIC_SECTIONS;
+    const CMP_RULES: &'static [crate::rules::CmpRule] = BASIC_CMP_RULES;
+    const ALLOWED_RULES: &'static [crate::rules::AllowedRule] = BASIC_ALLOWED_RULES;
+    fn base(&self) -> *mut u8 {
+        self.store.get() as *mut u8
+    }
+}
+
+#[test]
+fn read_bounds() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    assert_eq!(m.read(14, 3), Err(Error::OutOfRange));
+    assert_eq!(m.read(16, 1), Err(Error::OutOfRange));
+    assert!(m.read(0, 16).is_ok());
+    assert_eq!(m.read(4, 0), Ok(&[][..]));
+}
+
+#[test]
+fn write_bounds() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    assert_eq!(m.write(14, &[0, 0, 0]), Err(Error::OutOfRange));
+    assert_eq!(m.write(16, &[0]), Err(Error::OutOfRange));
+}
+
+#[test]
+fn read_returns_live_bytes() {
+    let mut init = [0u8; BASIC_SIZE];
+    init[3] = 0xAB;
+    init[9] = 0xCD;
+    let m = Basic::new(init);
+    assert_eq!(m.read(3, 1), Ok(&[0xAB][..]));
+    assert_eq!(m.read(9, 1), Ok(&[0xCD][..]));
+}
+
+#[test]
+fn mask_rejects_readonly_byte() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    // Byte 3 is RO: a write spanning it fails even if the rest is fine.
+    assert_eq!(m.write(2, &[0, 0, 0]), Err(Error::AccessError));
+    // A write that avoids byte 3 succeeds.
+    assert!(m.write(4, &[0, 0]).is_ok());
+}
+
+#[test]
+fn enum_rule() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    assert!(m.write(0, &[1]).is_ok());
+    assert_eq!(
+        m.write(0, &[2]),
+        Err(Error::ValidationError(ValidationKind::Enum))
+    );
+}
+
+#[test]
+fn cmp_imm_signed_i16() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    // -1 as i16 LE = 0xFF 0xFF, must be >= 0 -> reject.
+    assert_eq!(
+        m.write(4, &[0xFF, 0xFF]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+    // +1 passes.
+    assert!(m.write(4, &[1, 0]).is_ok());
+}
+
+#[test]
+fn cmp_reg_cross_field_u16() {
+    // field6 < field8 (both u16). Seed field8 = 100.
+    let mut init = [0u8; BASIC_SIZE];
+    init[8] = 100;
+    let m = Basic::new(init);
+    assert!(m.write(6, &[50, 0]).is_ok());
+    assert_eq!(
+        m.write(6, &[200, 0]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+}
+
+#[test]
+fn cmp_abs_i8() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    // |x| <= 5. -5 (0xFB) passes, -6 (0xFA) fails.
+    assert!(m.write(10, &[0xFB]).is_ok());
+    assert_eq!(
+        m.write(10, &[0xFA]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+}
+
+#[test]
+fn cmp_signed_i32_width4() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    // <= 100_000. 50_000 passes.
+    assert!(m.write(12, &50_000i32.to_le_bytes()).is_ok());
+    // 200_000 fails.
+    assert_eq!(
+        m.write(12, &200_000i32.to_le_bytes()),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+    // A negative value passes (signed read).
+    assert!(m.write(12, &(-1i32).to_le_bytes()).is_ok());
+}
+
+#[test]
+fn partial_field_overwrite_revalidates_whole_field() {
+    // Seed field4 (i16) = 0x0001 (valid, >= 0). Overwrite only the high byte
+    // with 0xFF -> field becomes 0xFF01 = -255, which must re-validate and fail.
+    let mut init = [0u8; BASIC_SIZE];
+    init[4] = 0x01;
+    init[5] = 0x00;
+    let m = Basic::new(init);
+    assert_eq!(
+        m.write(5, &[0xFF]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+}
+
+#[test]
+fn straddle_low_pending_high_live() {
+    // field12 (i32, <= 100_000): low bytes pending, high bytes live. Live high
+    // byte 14 = 0x01 contributes 0x00010000 = 65536, so the rule must see both
+    // the overlay low half and the live high half to reach the right verdict.
+    let mut init = [0u8; BASIC_SIZE];
+    init[14] = 0x01;
+    // overlay low = 0x86A0 -> total 100_000, passes.
+    let m = Basic::new(init);
+    assert!(m.write(12, &[0xA0, 0x86]).is_ok());
+    // overlay low = 0x86A1 -> total 100_001, fails (proves live-high seen too).
+    let m = Basic::new(init);
+    assert_eq!(
+        m.write(12, &[0xA1, 0x86]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+}
+
+#[test]
+fn straddle_high_pending_low_live() {
+    // field12 (i32, <= 100_000): high bytes pending, low bytes live. Live low
+    // half = 0x86A0 = 34464.
+    let mut init = [0u8; BASIC_SIZE];
+    init[12] = 0xA0;
+    init[13] = 0x86;
+    // overlay high = 0x0001 -> total 100_000, passes.
+    let m = Basic::new(init);
+    assert!(m.write(14, &[0x01, 0x00]).is_ok());
+    // overlay high = 0x0002 -> total 165_536, fails (proves live-low seen too).
+    let m = Basic::new(init);
+    assert_eq!(
+        m.write(14, &[0x02, 0x00]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+}
+
+#[test]
+fn read_fixed_picks_per_path() {
+    // Live 0..8 with the overlay covering 2..6: o1 at 2..4, o2 at 4..6. Spans
+    // chosen to hit each read_fixed path: fully live (both sides), fully
+    // inside o1, inside o2, and every straddle shape.
+    let live: [u8; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
+    let o1 = [0xA0, 0xA1];
+    let o2 = [0xB0, 0xB1];
+    let v = View::new_split(live.as_ptr(), live.len(), 2, &o1, &o2);
+    assert_eq!(v.read_fixed(0, 2), Ok([10, 11, 0, 0]));
+    assert_eq!(v.read_fixed(6, 2), Ok([16, 17, 0, 0]));
+    assert_eq!(v.read_fixed(2, 2), Ok([0xA0, 0xA1, 0, 0]));
+    assert_eq!(v.read_fixed(4, 2), Ok([0xB0, 0xB1, 0, 0]));
+    assert_eq!(v.read_fixed(1, 4), Ok([11, 0xA0, 0xA1, 0xB0]));
+    assert_eq!(v.read_fixed(3, 2), Ok([0xA1, 0xB0, 0, 0]));
+    assert_eq!(v.read_fixed(5, 3), Ok([0xB1, 16, 17, 0]));
+    assert_eq!(v.read_fixed(0, 1), Ok([10, 0, 0, 0]));
+    assert_eq!(v.read_fixed(0, 0), Ok([0, 0, 0, 0]));
+    assert_eq!(v.read_fixed(6, 4), Err(Error::OutOfRange));
+    // Empty overlay degenerates to all-live.
+    let v = View::new_split(live.as_ptr(), live.len(), 3, &[], &[]);
+    assert_eq!(v.read_fixed(2, 4), Ok([12, 13, 14, 15]));
+}
+
+#[test]
+fn stage_validates_then_pushes() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    let mut staged = StagedWrites::new();
+    // Bad enum: rejected, nothing staged.
+    assert_eq!(
+        m.stage(0, &[2], &mut staged),
+        Err(Error::ValidationError(ValidationKind::Enum))
+    );
+    assert!(staged.is_empty());
+    // Good: staged.
+    assert!(m.stage(0, &[1], &mut staged).is_ok());
+    assert!(!staged.is_empty());
+    // Not committed to live storage yet.
+    assert_eq!(m.read(0, 1), Ok(&[0][..]));
+}
+
+#[test]
+fn commit_staged_order_later_wins_no_revalidation() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    let mut staged = StagedWrites::new();
+    // Push directly (bypassing validate) an out-of-enum value: commit must not
+    // re-validate it, and the later push at the same addr wins.
+    staged.push(0, &[9]).unwrap();
+    staged.push(0, &[1]).unwrap();
+    staged.push(4, &[0xFF, 0xFF]).unwrap(); // would fail the i16 rule if checked
+    m.commit_staged(&mut staged);
+    assert_eq!(m.read(0, 1), Ok(&[1][..]));
+    assert_eq!(m.read(4, 2), Ok(&[0xFF, 0xFF][..]));
+    assert!(staged.is_empty());
+}
+
+// --- Mask fixture: 3 words (96 B), no rules, so only the writable-mask
+// scan runs. Two read-only holes: byte 50 (mid word 1) and byte 64 (start of
+// word 2, a word boundary). Ranges are positioned so a hole falls just inside
+// vs just outside each edge shape. ---
+
+const MASK_SIZE: usize = 96;
+
+// word0 all writable; word1 hole at bit 18 (byte 50); word2 hole at bit 0 (byte 64).
+const MASK_WRITABLE: &[u32] = &[0xFFFF_FFFF, !(1u32 << 18), !(1u32 << 0)];
+
+static MASK_SECTIONS: &[SectionMeta] = &[SectionMeta {
+    base: 0,
+    size: MASK_SIZE as u16,
+    cmp_rules: (0, 0),
+    allowed_rules: (0, 0),
+}];
+
+struct MaskFix {
+    store: UnsafeCell<[u8; MASK_SIZE]>,
+}
+
+// SAFETY: tests are single-threaded.
+unsafe impl Sync for MaskFix {}
+
+impl MaskFix {
+    fn new() -> Self {
+        Self {
+            store: UnsafeCell::new([0; MASK_SIZE]),
+        }
+    }
+}
+
+impl RegisterMap for MaskFix {
+    const SIZE: usize = MASK_SIZE;
+    const WRITABLE: &'static [u32] = MASK_WRITABLE;
+    const SECTIONS: &'static [SectionMeta] = MASK_SECTIONS;
+    fn base(&self) -> *mut u8 {
+        self.store.get() as *mut u8
+    }
+}
+
+#[test]
+fn mask_word_at_a_time_edges() {
+    let z = [0u8; MASK_SIZE];
+    let m = MaskFix::new();
+
+    // start mid-word: [51,56) excludes hole@50 -> ok; [50,56) includes -> Access.
+    assert!(m.write(51, &z[..5]).is_ok());
+    assert_eq!(m.write(50, &z[..6]), Err(Error::AccessError));
+
+    // end mid-word: [46,50) excludes hole@50 -> ok; [46,51) includes -> Access.
+    assert!(m.write(46, &z[..4]).is_ok());
+    assert_eq!(m.write(46, &z[..5]), Err(Error::AccessError));
+
+    // span exactly one word: [0,32) no hole -> ok; [32,64) has hole@50 -> Access.
+    assert!(m.write(0, &z[..32]).is_ok());
+    assert_eq!(m.write(32, &z[..32]), Err(Error::AccessError));
+
+    // span multiple words: [10,48) excludes hole@50 -> ok; [10,51) includes -> Access.
+    assert!(m.write(10, &z[..38]).is_ok());
+    assert_eq!(m.write(10, &z[..41]), Err(Error::AccessError));
+
+    // 1-byte range at a word boundary: [63,64) excludes hole@64 -> ok;
+    // [64,65) is the boundary hole -> Access.
+    assert!(m.write(63, &z[..1]).is_ok());
+    assert_eq!(m.write(64, &z[..1]), Err(Error::AccessError));
+}
+
+// --- Split (ring-seam) write/stage: the source arrives as head + tail, the
+// split landing MID a multi-byte field. Behaviour must match the equivalent
+// contiguous write. Field12 (i32 <= 100_000) spans bytes 12..16 on Basic. ---
+
+#[test]
+fn write_split_mid_field_accepts_valid_value() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    // 50_000 across bytes 12..16, split after byte 13 (mid-field).
+    let v = 50_000i32.to_le_bytes();
+    assert!(m.write_split(12, &v[..2], &v[2..]).is_ok());
+    assert_eq!(m.read(12, 4), Ok(&v[..]));
+}
+
+#[test]
+fn write_split_mid_field_rejects_and_leaves_table_untouched() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    // 200_000 fails the <= 100_000 rule; the split must not mutate the table.
+    let v = 200_000i32.to_le_bytes();
+    assert_eq!(
+        m.write_split(12, &v[..2], &v[2..]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+    assert_eq!(m.read(12, 4), Ok(&[0, 0, 0, 0][..]));
+}
+
+#[test]
+fn write_split_matches_contiguous_at_every_split_point() {
+    let v = 50_000i32.to_le_bytes();
+    for k in 0..=v.len() {
+        let m = Basic::new([0; BASIC_SIZE]);
+        assert!(m.write_split(12, &v[..k], &v[k..]).is_ok());
+        assert_eq!(m.read(12, 4), Ok(&v[..]));
+    }
+}
+
+#[test]
+fn stage_split_validates_then_pushes_contiguously() {
+    let m = Basic::new([0; BASIC_SIZE]);
+    let mut staged = StagedWrites::new();
+    let v = 50_000i32.to_le_bytes();
+    // Bad value rejected, nothing staged.
+    let bad = 200_000i32.to_le_bytes();
+    assert_eq!(
+        m.stage_split(12, &bad[..2], &bad[2..], &mut staged),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+    assert!(staged.is_empty());
+    // Good split stages one contiguous 4-byte entry; commit lands it.
+    assert!(m.stage_split(12, &v[..1], &v[1..], &mut staged).is_ok());
+    let mut count = 0;
+    for (a, d) in staged.iter_from(&crate::stage::Snapshot::ZERO) {
+        assert_eq!(a, 12);
+        assert_eq!(d, &v[..]);
+        count += 1;
+    }
+    assert_eq!(count, 1);
+    m.commit_staged(&mut staged);
+    assert_eq!(m.read(12, 4), Ok(&v[..]));
+}

--- a/firmware/lib/control-table/src/region.rs
+++ b/firmware/lib/control-table/src/region.rs
@@ -1,0 +1,38 @@
+pub trait Region {}
+
+/// Impls may rely on the caller holding the region's single-writer guarantee.
+pub trait RegionStorage<R: Region> {
+    fn with<T>(&self, f: impl FnOnce(&R) -> T) -> T;
+    fn with_mut<T>(&self, f: impl FnOnce(&mut R) -> T) -> T;
+}
+
+/// Raw-pointer access for Router's memcpy dispatch path.
+///
+/// # Safety
+/// Impls must return a valid, non-null, aligned pointer to `R` that remains
+/// valid for the lifetime of `&self`. Lock-based wrappers must not impl this
+/// trait -- the pointer would outlive any lock scope.
+pub unsafe trait RegionStorageRaw<R: Region>: RegionStorage<R> {
+    fn region_ptr(&self) -> *mut R;
+}
+
+#[cfg(feature = "sync-unsafe-cell")]
+impl<R: Region> RegionStorage<R> for core::cell::SyncUnsafeCell<R> {
+    fn with<T>(&self, f: impl FnOnce(&R) -> T) -> T {
+        // SAFETY: caller upholds RegionStorage's single-writer contract.
+        unsafe { f(&*self.get()) }
+    }
+    fn with_mut<T>(&self, f: impl FnOnce(&mut R) -> T) -> T {
+        // SAFETY: caller upholds RegionStorage's single-writer contract.
+        unsafe { f(&mut *self.get()) }
+    }
+}
+
+// SAFETY: `SyncUnsafeCell::get` returns a valid aligned pointer to its inner
+// `R`, valid for the cell's lifetime.
+#[cfg(feature = "sync-unsafe-cell")]
+unsafe impl<R: Region> RegionStorageRaw<R> for core::cell::SyncUnsafeCell<R> {
+    fn region_ptr(&self) -> *mut R {
+        self.get()
+    }
+}

--- a/firmware/lib/control-table/src/rules.rs
+++ b/firmware/lib/control-table/src/rules.rs
@@ -1,0 +1,194 @@
+//! Shared field-rule bodies. The Block derive emits one call per rule instead
+//! of expanding the load/widen/compare sequence at every field site -- the
+//! per-site cost is a handful of argument moves, and exactly one compare body
+//! exists no matter how many rules or shapes the table grows (width, sign,
+//! abs, and op arrive packed in a const-folded [`spec`] word; the runtime
+//! dispatch is a couple of compares on the us-budget write path). Widening and
+//! saturating-abs semantics are pinned here (carried over from the deleted
+//! rule interpreter) and unit-tested directly instead of per generated copy.
+
+use crate::map::View;
+use crate::{Error, ValidationKind};
+
+pub const OP_LT: u8 = 0;
+pub const OP_LE: u8 = 1;
+pub const OP_GT: u8 = 2;
+pub const OP_GE: u8 = 3;
+pub const OP_EQ: u8 = 4;
+pub const OP_NE: u8 = 5;
+
+const SPEC_SIGNED: u16 = 1 << 4;
+const SPEC_ABS: u16 = 1 << 5;
+
+/// Rhs flavor bit in a spec word: set = `val` names another register.
+pub const SPEC_RHS_REG: u16 = 1 << 6; // must not collide: width [3:0], signed 4, abs 5, op [15:8]
+
+/// One compare rule as flash data: `addr` is table-absolute after section
+/// concat, `spec` is `spec(..)` (possibly | SPEC_RHS_REG), `val` is the
+/// immediate's i32 bits or the RHS register's table-absolute address.
+#[derive(Copy, Clone)]
+pub struct CmpRule {
+    pub addr: u16,
+    pub spec: u16,
+    pub val: u32,
+}
+
+/// One enum/bool rule as flash data (field width is always 1).
+#[derive(Copy, Clone)]
+pub struct AllowedRule {
+    pub addr: u16,
+    pub allowed: &'static [u8],
+}
+
+/// Pack a compare rule's shape into one word: width in bits [3:0], signed at
+/// bit 4, abs at bit 5, op in bits [15:8]. Const-folded at every call site.
+pub const fn spec(width: u8, signed: bool, abs: bool, op: u8) -> u16 {
+    width as u16
+        | if signed { SPEC_SIGNED } else { 0 }
+        | if abs { SPEC_ABS } else { 0 }
+        | (op as u16) << 8
+}
+
+/// Compare right-hand side: an immediate from the rule expression, or another
+/// register loaded with the SAME width + signedness as the field (pinned).
+#[derive(Copy, Clone)]
+pub enum Rhs {
+    Imm(i32),
+    Reg(u16),
+}
+
+/// Enum/bool rule: the candidate byte must be one of `allowed`.
+#[inline(never)]
+pub fn check_allowed(view: &View, addr: u16, allowed: &[u8]) -> Result<(), Error> {
+    let b = view.read_fixed(addr, 1)?;
+    if allowed.contains(&b[0]) {
+        Ok(())
+    } else {
+        Err(Error::ValidationError(ValidationKind::Enum))
+    }
+}
+
+/// Load `[addr, addr+width)` widened to `i32` with per-width sign extension.
+fn widen(view: &View, addr: u16, width: u8, signed: bool) -> Result<i32, Error> {
+    let b = view.read_fixed(addr, width as usize)?;
+    Ok(match (width, signed) {
+        (1, false) => b[0] as i32,
+        (1, true) => b[0] as i8 as i32,
+        (2, false) => u16::from_le_bytes([b[0], b[1]]) as i32,
+        (2, true) => i16::from_le_bytes([b[0], b[1]]) as i32,
+        _ => i32::from_le_bytes(b),
+    })
+}
+
+/// Compare rule; `spec` comes from [`spec`]. With abs, both sides take a
+/// saturating absolute value clamped to the field width's positive max.
+#[inline(never)]
+pub fn check_cmp(view: &View, addr: u16, spec: u16, rhs: Rhs) -> Result<(), Error> {
+    let width = (spec & 0xF) as u8;
+    let signed = spec & SPEC_SIGNED != 0;
+    let mut a = widen(view, addr, width, signed)?;
+    let mut r = match rhs {
+        Rhs::Imm(v) => v,
+        Rhs::Reg(reg) => widen(view, reg, width, signed)?,
+    };
+    if spec & SPEC_ABS != 0 {
+        let sat_max = match width {
+            1 => i8::MAX as i32,
+            2 => i16::MAX as i32,
+            _ => i32::MAX,
+        };
+        a = a.saturating_abs().min(sat_max);
+        r = r.saturating_abs().min(sat_max);
+    }
+    let ok = match (spec >> 8) as u8 {
+        OP_LT => a < r,
+        OP_LE => a <= r,
+        OP_GT => a > r,
+        OP_GE => a >= r,
+        OP_EQ => a == r,
+        _ => a != r,
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(Error::ValidationError(ValidationKind::Compare))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view_over(storage: &[u8]) -> View<'_> {
+        View::new(storage.as_ptr(), storage.len(), 0, &[])
+    }
+
+    fn cmp(v: &View, width: u8, signed: bool, abs: bool, op: u8, rhs: Rhs) -> Result<(), Error> {
+        check_cmp(v, 0, spec(width, signed, abs, op), rhs)
+    }
+
+    #[test]
+    fn allowed_accepts_and_rejects() {
+        let s = [1u8, 7];
+        let v = view_over(&s);
+        assert!(check_allowed(&v, 0, &[0, 1]).is_ok());
+        assert!(matches!(
+            check_allowed(&v, 1, &[0, 1]),
+            Err(Error::ValidationError(ValidationKind::Enum))
+        ));
+    }
+
+    #[test]
+    fn widen_signs_per_width() {
+        let s = [0xFFu8, 0xFF, 0xFF, 0xFF];
+        let v = view_over(&s);
+        assert_eq!(widen(&v, 0, 1, false), Ok(255));
+        assert_eq!(widen(&v, 0, 1, true), Ok(-1));
+        assert_eq!(widen(&v, 0, 2, false), Ok(65535));
+        assert_eq!(widen(&v, 0, 2, true), Ok(-1));
+        assert_eq!(widen(&v, 0, 4, true), Ok(-1));
+    }
+
+    #[test]
+    fn cmp_ops_fold_correctly() {
+        let s = 5i16.to_le_bytes();
+        let v = view_over(&s);
+        assert!(cmp(&v, 2, true, false, OP_LE, Rhs::Imm(5)).is_ok());
+        assert!(cmp(&v, 2, true, false, OP_LT, Rhs::Imm(5)).is_err());
+        assert!(cmp(&v, 2, true, false, OP_GE, Rhs::Imm(5)).is_ok());
+        assert!(cmp(&v, 2, true, false, OP_NE, Rhs::Imm(4)).is_ok());
+        assert!(cmp(&v, 2, true, false, OP_EQ, Rhs::Imm(4)).is_err());
+    }
+
+    #[test]
+    fn cmp_reg_rhs_loads_same_width() {
+        let mut s = [0u8; 4];
+        s[..2].copy_from_slice(&10i16.to_le_bytes());
+        s[2..].copy_from_slice(&20i16.to_le_bytes());
+        let v = view_over(&s);
+        assert!(cmp(&v, 2, true, false, OP_LE, Rhs::Reg(2)).is_ok());
+        assert!(cmp(&v, 2, true, false, OP_GT, Rhs::Reg(2)).is_err());
+    }
+
+    #[test]
+    fn abs_saturates_at_width_max() {
+        // i8::MIN's plain abs would overflow; the pinned semantics saturate,
+        // then clamp to the width's positive max.
+        let s = [0x80u8]; // -128
+        let v = view_over(&s);
+        assert!(cmp(&v, 1, true, true, OP_LE, Rhs::Imm(127)).is_ok());
+        assert!(cmp(&v, 1, true, true, OP_GT, Rhs::Imm(126)).is_ok());
+        // i16::MIN likewise clamps to i16::MAX.
+        let s = i16::MIN.to_le_bytes();
+        let v = view_over(&s);
+        assert!(cmp(&v, 2, true, true, OP_EQ, Rhs::Imm(i16::MAX as i32)).is_ok());
+    }
+
+    #[test]
+    fn overlay_is_visible_to_rules() {
+        let s = [0u8, 0];
+        let pending = [0xFFu8, 0x7F]; // i16::MAX about to be committed
+        let v = View::new(s.as_ptr(), s.len(), 0, &pending);
+        assert!(cmp(&v, 2, true, false, OP_GE, Rhs::Imm(1000)).is_ok());
+    }
+}

--- a/firmware/lib/control-table/src/stage.rs
+++ b/firmware/lib/control-table/src/stage.rs
@@ -1,0 +1,148 @@
+use crate::Error;
+
+/// Total staging buffer for pending write data, in bytes. Every write stages
+/// here ahead of its CRC verdict (the dispatch spine), so the cap must fit
+/// the largest legal single write -- 250 B of data under the 252 B payload
+/// ceiling (osc-native sec 5.1: LEN is the only size limit) -- plus whatever
+/// HOLD writes are pending. Override with `OSC_STAGE_DATA_CAP`.
+pub const STAGE_DATA_CAP: usize = env_usize(option_env!("OSC_STAGE_DATA_CAP"), 256);
+
+/// Max number of pending RegWrite entries before Action commits. Override
+/// with `OSC_STAGE_ENTRY_CAP`.
+pub const STAGE_ENTRY_CAP: usize = env_usize(option_env!("OSC_STAGE_ENTRY_CAP"), 16);
+
+const fn env_usize(value: Option<&'static str>, default: usize) -> usize {
+    match value {
+        Some(s) => parse_usize(s),
+        None => default,
+    }
+}
+
+const fn parse_usize(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut n: usize = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        assert!(
+            b >= b'0' && b <= b'9',
+            "OSC_STAGE_* must be a decimal integer",
+        );
+        n = n * 10 + (b - b'0') as usize;
+        i += 1;
+    }
+    n
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct StagedEntry {
+    addr: u16,
+    len: u16,
+    data_off: u16,
+}
+
+/// Caller-held transaction handle. Hand to `revert_to` to discard pushes
+/// since capture, or to `iter_from` to walk them. Nesting is free -- each
+/// caller holds its own.
+#[derive(Copy, Clone)]
+pub struct Snapshot {
+    pub(crate) data: u16,
+    pub(crate) entries: u16,
+}
+
+impl Snapshot {
+    /// Start-of-buffer snapshot: `iter_from(&ZERO)` walks every staged entry.
+    /// Used by `commit_staged` to flush the full buffer through the same
+    /// path as range commits.
+    pub(crate) const ZERO: Snapshot = Snapshot {
+        data: 0,
+        entries: 0,
+    };
+}
+
+pub struct StagedWrites {
+    pub(crate) data: heapless::Vec<u8, STAGE_DATA_CAP>,
+    pub(crate) entries: heapless::Vec<StagedEntry, STAGE_ENTRY_CAP>,
+}
+
+impl StagedWrites {
+    pub const fn new() -> Self {
+        Self {
+            data: heapless::Vec::new(),
+            entries: heapless::Vec::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.entries.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            data: self.data.len() as u16,
+            entries: self.entries.len() as u16,
+        }
+    }
+
+    /// Discard everything pushed since `snap`. Infallible: truncation only.
+    pub fn revert_to(&mut self, snap: &Snapshot) {
+        self.data.truncate(snap.data as usize);
+        self.entries.truncate(snap.entries as usize);
+    }
+
+    pub fn push(&mut self, addr: u16, src: &[u8]) -> Result<(), Error> {
+        self.push_split(addr, src, &[])
+    }
+
+    /// As [`push`](Self::push) but with the source split across the ring seam:
+    /// `head` then `tail` land contiguously in one staged entry.
+    pub fn push_split(&mut self, addr: u16, head: &[u8], tail: &[u8]) -> Result<(), Error> {
+        let data_off = self.data.len();
+        let total = head.len() + tail.len();
+        if data_off + total > STAGE_DATA_CAP {
+            return Err(Error::StagingFull);
+        }
+        self.data
+            .extend_from_slice(head)
+            .map_err(|_| Error::StagingFull)?;
+        self.data.extend_from_slice(tail).map_err(|_| {
+            self.data.truncate(data_off);
+            Error::StagingFull
+        })?;
+        self.entries
+            .push(StagedEntry {
+                addr,
+                len: total as u16,
+                data_off: data_off as u16,
+            })
+            .map_err(|_| {
+                self.data.truncate(data_off);
+                Error::StagingFull
+            })?;
+        Ok(())
+    }
+
+    /// Walk every staged entry, oldest first.
+    pub fn iter_all(&self) -> impl Iterator<Item = (u16, &[u8])> + '_ {
+        self.iter_from(&Snapshot::ZERO)
+    }
+
+    pub fn iter_from(&self, snap: &Snapshot) -> impl Iterator<Item = (u16, &[u8])> + '_ {
+        self.entries[snap.entries as usize..].iter().map(|e| {
+            let lo = e.data_off as usize;
+            let hi = lo + e.len as usize;
+            (e.addr, &self.data[lo..hi])
+        })
+    }
+}
+
+impl Default for StagedWrites {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/firmware/lib/control-table/tests/derive_block.rs
+++ b/firmware/lib/control-table/tests/derive_block.rs
@@ -1,0 +1,223 @@
+#![feature(sync_unsafe_cell)]
+
+use control_table::{Block, Enum, Error, RegisterFile, Table, ValidationKind};
+use core::mem::{offset_of, size_of};
+
+#[repr(u8)]
+#[derive(Copy, Clone, Enum)]
+enum Mode {
+    Stop = 0,
+    Go = 1,
+}
+
+// Field order keeps the struct dense (no repr(C) padding) so the derive's
+// zero-padding const assert accepts it.
+#[repr(C)]
+#[derive(Block)]
+struct Basic {
+    b: u16,
+    a: u8,
+    c: bool,
+    mode: Mode,
+    d: u8,
+}
+
+#[test]
+fn ct_size_tracks_struct_size() {
+    assert_eq!(Basic::CT_SIZE, size_of::<Basic>() as u16);
+    assert_eq!(Basic::CT_SIZE, 6);
+}
+
+#[test]
+fn writable_covers_every_rw_field() {
+    let w = Basic::CT_WRITABLE;
+    assert_eq!(
+        w,
+        [
+            (offset_of!(Basic, b) as u16, 2),
+            (offset_of!(Basic, a) as u16, 1),
+            (offset_of!(Basic, c) as u16, 1),
+            (offset_of!(Basic, mode) as u16, 1),
+            (offset_of!(Basic, d) as u16, 1),
+        ]
+    );
+}
+
+// Behavioral coverage of the generated `ct_check`: enum, an immediate compare, a
+// signed abs compare, a cross-field register compare, and mask-driven ro
+// rejection -- the write-outcome facts the old structural `CT_RULES` assertions
+// encoded. `target < &checks::CEILING` is an in-table register reference (same
+// shape the derive emits) so `read_fixed` stays in bounds.
+#[repr(C)]
+#[derive(Block)]
+struct Checks {
+    #[ct_field(le = 100u8)]
+    ratio: u8,
+    #[ct_field(ge = -5i8, le = 5i8, abs)]
+    trim: i8,
+    ceiling: u8,
+    #[ct_field(lt = &bt::addr::checks::CEILING)]
+    target: u8,
+    flag: bool,
+    #[ct_field(access = ro)]
+    ro: u8,
+}
+
+mod bt {
+    use super::Checks;
+    use control_table::Section;
+
+    #[repr(C)]
+    #[derive(Section)]
+    #[ct_section(base = 0, size = 6)]
+    pub struct Sect {
+        pub checks: Checks,
+    }
+}
+
+#[repr(C)]
+#[derive(Table)]
+#[ct_table(size = 6)]
+struct Bt {
+    pub bt: bt::Sect,
+}
+
+#[test]
+fn ct_check_write_outcomes() {
+    use bt::addr::checks as a;
+
+    let t = BtCell::new();
+    // Seed the ceiling used by the register compare.
+    t.write(a::CEILING, &[50]).unwrap();
+
+    // enum: good then bad.
+    assert!(t.write(a::FLAG, &[1]).is_ok());
+    assert_eq!(
+        t.write(a::FLAG, &[2]),
+        Err(Error::ValidationError(ValidationKind::Enum))
+    );
+
+    // immediate compare: ratio <= 100.
+    assert!(t.write(a::RATIO, &[100]).is_ok());
+    assert_eq!(
+        t.write(a::RATIO, &[101]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+
+    // signed abs compare: |trim| <= 5. -5 (0xFB) passes, -6 (0xFA) fails.
+    assert!(t.write(a::TRIM, &[0xFB]).is_ok());
+    assert_eq!(
+        t.write(a::TRIM, &[0xFA]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+
+    // register compare: target < ceiling (50).
+    assert!(t.write(a::TARGET, &[49]).is_ok());
+    assert_eq!(
+        t.write(a::TARGET, &[50]),
+        Err(Error::ValidationError(ValidationKind::Compare))
+    );
+
+    // ro field rejected by the writable mask.
+    assert_eq!(t.write(a::RO, &[0]), Err(Error::AccessError));
+}
+
+#[repr(C)]
+#[derive(Block)]
+struct Access {
+    #[ct_field(access = ro)]
+    ro_field: u16,
+    rw_field: u16,
+    #[ct_field(skip)]
+    _rsvd: [u8; 2],
+    #[ct_field(access = ro)]
+    ro_bool: bool,
+    tail: u8,
+}
+
+#[test]
+fn ro_and_skip_excluded_from_writable_and_rules() {
+    // ro (incl. ro bool) and skip fields never enter the writable mask.
+    assert_eq!(
+        Access::CT_WRITABLE,
+        [
+            (offset_of!(Access, rw_field) as u16, 2),
+            (offset_of!(Access, tail) as u16, 1),
+        ]
+    );
+    // skip field still counts toward layout size.
+    assert_eq!(Access::CT_SIZE, size_of::<Access>() as u16);
+    assert_eq!(Access::CT_SIZE, 8);
+}
+
+trait MyHooks {
+    fn on_a(&mut self, v: u8);
+}
+
+struct HookRec {
+    last: Option<u8>,
+}
+
+impl MyHooks for HookRec {
+    fn on_a(&mut self, v: u8) {
+        self.last = Some(v);
+    }
+}
+
+#[repr(C)]
+#[derive(Block)]
+#[ct_block(hooks = MyHooks)]
+struct Hooked {
+    #[ct_field(hook = on_a)]
+    pub a: u8,
+    pub b: u8,
+}
+
+#[test]
+fn hook_fires_only_when_write_window_overlaps_field() {
+    let h = Hooked { a: 7, b: 0 };
+
+    let mut hit = HookRec { last: None };
+    h.dispatch_events(0, 1, 0, &mut hit);
+    assert_eq!(hit.last, Some(7));
+
+    // window on field `b` (offset 1) must not fire `a`'s hook.
+    let mut miss = HookRec { last: None };
+    h.dispatch_events(1, 1, 0, &mut miss);
+    assert_eq!(miss.last, None);
+
+    // block rebased by base: field `a` now lives at abs 10.
+    let mut rebased = HookRec { last: None };
+    h.dispatch_events(10, 1, 10, &mut rebased);
+    assert_eq!(rebased.last, Some(7));
+}
+
+#[repr(C)]
+#[derive(Block)]
+struct Dense {
+    w: u32,
+    h: u16,
+    a: u8,
+    b: u8,
+}
+
+#[test]
+fn zero_padding_assert_accepts_dense_struct() {
+    // Compiling this struct at all proves the const assert passed.
+    assert_eq!(Dense::CT_SIZE, size_of::<Dense>() as u16);
+    assert_eq!(Dense::CT_SIZE, 8);
+    let sum: u16 = Dense::CT_WRITABLE.iter().map(|(_, len)| len).sum();
+    assert_eq!(sum, Dense::CT_SIZE);
+}
+
+// `new()` zero-initializes every field (enum/bool included) in const context.
+const _: Basic = Basic::new();
+
+#[test]
+fn new_zero_initializes() {
+    let v = Basic::new();
+    assert_eq!(v.a, 0);
+    assert_eq!(v.b, 0);
+    assert!(!v.c);
+    assert_eq!(v.d, 0);
+}

--- a/firmware/lib/control-table/tests/derive_enum.rs
+++ b/firmware/lib/control-table/tests/derive_enum.rs
@@ -1,0 +1,37 @@
+use control_table::Enum;
+
+#[derive(Copy, Clone, Enum)]
+#[repr(u8)]
+enum Mode {
+    OpenLoop = 0,
+    PositionPid = 1,
+}
+
+#[derive(Copy, Clone, Enum)]
+#[repr(u8)]
+enum DefaultNumbered {
+    A,
+    B,
+    C,
+}
+
+#[derive(Copy, Clone, Enum)]
+#[repr(u8)]
+enum Single {
+    Only = 7,
+}
+
+#[test]
+fn explicit_discriminants_produce_allowed_in_source_order() {
+    assert_eq!(Mode::ALLOWED, &[0u8, 1]);
+}
+
+#[test]
+fn default_numbered_variants_produce_sequential_allowed() {
+    assert_eq!(DefaultNumbered::ALLOWED, &[0u8, 1, 2]);
+}
+
+#[test]
+fn single_variant_is_a_one_element_slice() {
+    assert_eq!(Single::ALLOWED, &[7u8]);
+}

--- a/firmware/lib/control-table/tests/derive_table.rs
+++ b/firmware/lib/control-table/tests/derive_table.rs
@@ -1,0 +1,246 @@
+#![feature(sync_unsafe_cell)]
+
+use control_table::{Block, Enum, Error, RegisterFile, RegisterMap, Table, ValidationKind};
+use core::mem::{offset_of, size_of};
+
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Debug, Enum)]
+pub enum Mode {
+    Idle = 0,
+    Run = 1,
+}
+
+// --- Blocks --------------------------------------------------------------
+
+#[repr(C)]
+#[derive(Block)]
+pub struct Ident {
+    #[ct_field(access = ro)]
+    pub model: u16,
+    pub id: u8,
+    pub spare: u8,
+}
+
+#[repr(C)]
+#[derive(Block)]
+pub struct Limits {
+    #[ct_field(le = 100u8)]
+    pub max_ratio: u8,
+    pub mode: Mode,
+    pub enabled: bool,
+    pub _rsvd: u8,
+}
+
+#[repr(C)]
+#[derive(Block)]
+#[ct_block(hooks = GoalHooks)]
+pub struct Goal {
+    // Cross-section compare: goal stays <= the config ceiling byte.
+    #[ct_field(le = &config::addr::limits::MAX_RATIO)]
+    pub target: u8,
+    #[ct_field(hook = on_target)]
+    pub commit: u8,
+}
+
+pub trait GoalHooks {
+    fn on_target(&mut self, v: u8);
+}
+
+// --- Sections ------------------------------------------------------------
+
+mod config {
+    use super::{Ident, Limits};
+    use control_table::Section;
+
+    #[repr(C)]
+    #[derive(Section)]
+    #[ct_section(base = 0x0000, size = 12)]
+    pub struct Config {
+        pub ident: Ident,
+        pub limits: Limits,
+        #[ct_section(skip)]
+        pub _rsvd: [u8; 4],
+    }
+}
+
+mod control {
+    use super::Goal;
+    use control_table::Section;
+
+    #[repr(C)]
+    #[derive(Section)]
+    #[ct_section(
+        base = 0x000C,
+        size = 4,
+        hooks = super::GoalHooks,
+    )]
+    pub struct Control {
+        pub goal: Goal,
+        #[ct_section(skip)]
+        pub _rsvd: [u8; 2],
+    }
+}
+
+use config::Config;
+use control::Control;
+
+#[repr(C)]
+#[derive(Table)]
+#[ct_table(size = 24, hooks = GoalHooks)]
+struct Table {
+    pub config: Config,
+    pub control: Control,
+    #[ct_table(skip)]
+    pub _rsvd: [u8; 8],
+}
+
+// -------------------------------------------------------------------------
+
+#[test]
+fn addr_consts_are_base_plus_offset() {
+    assert_eq!(
+        addr::config::ident::MODEL,
+        Config::BASE + offset_of!(Config, ident) as u16 + offset_of!(Ident, model) as u16
+    );
+    assert_eq!(
+        addr::config::ident::SPARE,
+        Config::BASE + offset_of!(Config, ident) as u16 + offset_of!(Ident, spare) as u16
+    );
+    assert_eq!(
+        addr::config::limits::MAX_RATIO,
+        Config::BASE + offset_of!(Config, limits) as u16 + offset_of!(Limits, max_ratio) as u16
+    );
+    assert_eq!(
+        addr::control::goal::TARGET,
+        Control::BASE + offset_of!(Control, goal) as u16 + offset_of!(Goal, target) as u16
+    );
+}
+
+#[test]
+fn section_base_and_size_consts() {
+    assert_eq!(Config::BASE, 0x0000);
+    assert_eq!(Config::SECTION_SIZE, 12);
+    assert_eq!(Control::BASE, 0x000C);
+    assert_eq!(Control::SECTION_SIZE, 4);
+}
+
+#[test]
+fn writable_words_track_ro_rw_and_reserved() {
+    let words = Table::WRITABLE_WORDS;
+    assert_eq!(words.len(), 24usize.div_ceil(32));
+
+    let bit = |a: u16| (words[a as usize / 32] >> (a as usize % 32)) & 1 == 1;
+
+    // ro model bytes clear.
+    assert!(!bit(addr::config::ident::MODEL));
+    assert!(!bit(addr::config::ident::MODEL + 1));
+    // rw bytes set.
+    assert!(bit(addr::config::ident::ID));
+    assert!(bit(addr::config::ident::SPARE));
+    assert!(bit(addr::config::limits::MAX_RATIO));
+    assert!(bit(addr::control::goal::TARGET));
+    // reserved / skip tails clear.
+    assert!(!bit(8)); // config._rsvd tail
+    assert!(!bit(14)); // control._rsvd tail
+    assert!(!bit(20)); // table-level _rsvd
+}
+
+#[test]
+fn sections_metadata_exposed_through_register_map() {
+    let secs = <TableCell as RegisterMap>::SECTIONS;
+    assert_eq!(secs.len(), 2);
+
+    assert_eq!(secs[0].base, Config::BASE);
+    assert_eq!(secs[0].size, Config::SECTION_SIZE);
+
+    assert_eq!(secs[1].base, Control::BASE);
+    assert_eq!(secs[1].size, Control::SECTION_SIZE);
+
+    assert_eq!(<TableCell as RegisterMap>::SIZE, 24);
+}
+
+fn fresh() -> TableCell {
+    TableCell::new()
+}
+
+#[test]
+fn read_round_trips_written_bytes() {
+    let t = fresh();
+    t.write(addr::config::ident::ID, &[0x42]).unwrap();
+    assert_eq!(t.read(addr::config::ident::ID, 1).unwrap(), &[0x42]);
+}
+
+#[test]
+fn write_to_ro_byte_rejected_by_mask() {
+    let t = fresh();
+    let err = t.write(addr::config::ident::MODEL, &[1, 2]).unwrap_err();
+    assert_eq!(err, Error::AccessError);
+}
+
+#[test]
+fn write_rejected_by_enum_rule() {
+    let t = fresh();
+    let err = t.write(addr::config::limits::MODE, &[9]).unwrap_err();
+    assert_eq!(err, Error::ValidationError(ValidationKind::Enum));
+    t.write(addr::config::limits::MODE, &[Mode::Run as u8])
+        .unwrap();
+}
+
+#[test]
+fn write_rejected_by_compare_rule() {
+    let t = fresh();
+    let err = t
+        .write(addr::config::limits::MAX_RATIO, &[200])
+        .unwrap_err();
+    assert_eq!(err, Error::ValidationError(ValidationKind::Compare));
+    t.write(addr::config::limits::MAX_RATIO, &[100]).unwrap();
+}
+
+#[test]
+fn cross_section_compare_reads_config_ceiling() {
+    let t = fresh();
+    t.write(addr::config::limits::MAX_RATIO, &[50]).unwrap();
+    assert_eq!(
+        t.write(addr::control::goal::TARGET, &[80]).unwrap_err(),
+        Error::ValidationError(ValidationKind::Compare)
+    );
+    t.write(addr::control::goal::TARGET, &[40]).unwrap();
+    assert_eq!(t.read(addr::control::goal::TARGET, 1).unwrap(), &[40]);
+}
+
+struct Rec {
+    hit: Option<u8>,
+}
+
+impl GoalHooks for Rec {
+    fn on_target(&mut self, v: u8) {
+        self.hit = Some(v);
+    }
+}
+
+#[test]
+fn hook_dispatches_through_table_for_hooked_field() {
+    let mut tbl = Table::new();
+    tbl.control.goal.commit = 0xAB;
+
+    let mut rec = Rec { hit: None };
+    tbl.dispatch_events(addr::control::goal::COMMIT, 1, &mut rec);
+    assert_eq!(rec.hit, Some(0xAB));
+
+    // A window entirely inside config must not fire the control hook.
+    let mut miss = Rec { hit: None };
+    tbl.dispatch_events(addr::config::ident::ID, 1, &mut miss);
+    assert_eq!(miss.hit, None);
+}
+
+#[test]
+fn new_zero_initializes_including_skips() {
+    let t = Table::new();
+    assert_eq!(t.config.ident.model, 0);
+    assert_eq!(t.config.limits.max_ratio, 0);
+    assert_eq!(t.config.limits.mode, Mode::Idle);
+    assert!(!t.config.limits.enabled);
+    assert_eq!(t.control.goal.target, 0);
+    assert_eq!(t._rsvd, [0u8; 8]);
+    assert_eq!(size_of::<Table>(), 24);
+}

--- a/firmware/lib/control-table/tests/derive_ui.rs
+++ b/firmware/lib/control-table/tests/derive_ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn derive_compile_fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/firmware/lib/control-table/tests/ui/access_reserved.rs
+++ b/firmware/lib/control-table/tests/ui/access_reserved.rs
@@ -1,0 +1,10 @@
+use control_table::Block;
+
+#[repr(C)]
+#[derive(Block)]
+struct BadReserved {
+    #[ct_field(access = reserved)]
+    x: u8,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/access_reserved.stderr
+++ b/firmware/lib/control-table/tests/ui/access_reserved.stderr
@@ -1,0 +1,5 @@
+error: `access = reserved` is gone; use `skip` for padding fields
+ --> tests/ui/access_reserved.rs:6:25
+  |
+6 |     #[ct_field(access = reserved)]
+  |                         ^^^^^^^^

--- a/firmware/lib/control-table/tests/ui/compare_on_ro.rs
+++ b/firmware/lib/control-table/tests/ui/compare_on_ro.rs
@@ -1,0 +1,10 @@
+use control_table::Block;
+
+#[repr(C)]
+#[derive(Block)]
+struct CompareOnRo {
+    #[ct_field(access = ro, le = 10u8)]
+    x: u8,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/compare_on_ro.stderr
+++ b/firmware/lib/control-table/tests/ui/compare_on_ro.stderr
@@ -1,0 +1,5 @@
+error: compare clause on a skipped or read-only field never runs (drop the compare or make the field rw)
+ --> tests/ui/compare_on_ro.rs:7:5
+  |
+7 |     x: u8,
+  |     ^

--- a/firmware/lib/control-table/tests/ui/compare_on_u32.rs
+++ b/firmware/lib/control-table/tests/ui/compare_on_u32.rs
@@ -1,0 +1,10 @@
+use control_table::Block;
+
+#[repr(C)]
+#[derive(Block)]
+struct WideCompare {
+    #[ct_field(le = 10u32)]
+    x: u32,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/compare_on_u32.stderr
+++ b/firmware/lib/control-table/tests/ui/compare_on_u32.stderr
@@ -1,0 +1,5 @@
+error: compare clauses require a primitive integer (u8/u16/i8/i16/i32)
+ --> tests/ui/compare_on_u32.rs:7:8
+  |
+7 |     x: u32,
+  |        ^^^

--- a/firmware/lib/control-table/tests/ui/enum_missing_repr.rs
+++ b/firmware/lib/control-table/tests/ui/enum_missing_repr.rs
@@ -1,0 +1,9 @@
+use control_table::Enum;
+
+#[derive(Enum)]
+enum MissingRepr {
+    A = 0,
+    B = 1,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/enum_missing_repr.stderr
+++ b/firmware/lib/control-table/tests/ui/enum_missing_repr.stderr
@@ -1,0 +1,5 @@
+error: Enum derive requires #[repr(u8)]
+ --> tests/ui/enum_missing_repr.rs:4:6
+  |
+4 | enum MissingRepr {
+  |      ^^^^^^^^^^^

--- a/firmware/lib/control-table/tests/ui/enum_on_struct.rs
+++ b/firmware/lib/control-table/tests/ui/enum_on_struct.rs
@@ -1,0 +1,9 @@
+use control_table::Enum;
+
+#[derive(Enum)]
+#[repr(u8)]
+struct NotAnEnum {
+    x: u8,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/enum_on_struct.stderr
+++ b/firmware/lib/control-table/tests/ui/enum_on_struct.stderr
@@ -1,0 +1,16 @@
+error: Enum can only be derived for enums
+ --> tests/ui/enum_on_struct.rs:4:1
+  |
+4 | / #[repr(u8)]
+5 | | struct NotAnEnum {
+6 | |     x: u8,
+7 | | }
+  | |_^
+
+error: `#[repr(u8)]` attribute cannot be used on structs
+ --> tests/ui/enum_on_struct.rs:4:1
+  |
+4 | #[repr(u8)]
+  | ^^^^^^^^^^^
+  |
+  = help: `#[repr(u8)]` can only be applied to enums

--- a/firmware/lib/control-table/tests/ui/enum_repr_i8.rs
+++ b/firmware/lib/control-table/tests/ui/enum_repr_i8.rs
@@ -1,0 +1,10 @@
+use control_table::Enum;
+
+#[derive(Enum)]
+#[repr(i8)]
+enum ReprI8 {
+    A = 0,
+    B = 1,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/enum_repr_i8.stderr
+++ b/firmware/lib/control-table/tests/ui/enum_repr_i8.stderr
@@ -1,0 +1,5 @@
+error: Enum derive requires #[repr(u8)]
+ --> tests/ui/enum_repr_i8.rs:4:8
+  |
+4 | #[repr(i8)]
+  |        ^^

--- a/firmware/lib/control-table/tests/ui/enum_repr_u16.rs
+++ b/firmware/lib/control-table/tests/ui/enum_repr_u16.rs
@@ -1,0 +1,10 @@
+use control_table::Enum;
+
+#[derive(Enum)]
+#[repr(u16)]
+enum ReprU16 {
+    A = 0,
+    B = 1,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/enum_repr_u16.stderr
+++ b/firmware/lib/control-table/tests/ui/enum_repr_u16.stderr
@@ -1,0 +1,5 @@
+error: Enum derive requires #[repr(u8)]
+ --> tests/ui/enum_repr_u16.rs:4:8
+  |
+4 | #[repr(u16)]
+  |        ^^^

--- a/firmware/lib/control-table/tests/ui/enum_variant_with_fields.rs
+++ b/firmware/lib/control-table/tests/ui/enum_variant_with_fields.rs
@@ -1,0 +1,10 @@
+use control_table::Enum;
+
+#[derive(Enum)]
+#[repr(u8)]
+enum HasPayload {
+    A,
+    B(u8),
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/enum_variant_with_fields.stderr
+++ b/firmware/lib/control-table/tests/ui/enum_variant_with_fields.stderr
@@ -1,0 +1,5 @@
+error: Enum derive requires unit variants only
+ --> tests/ui/enum_variant_with_fields.rs:7:5
+  |
+7 |     B(u8),
+  |     ^^^^^

--- a/firmware/lib/control-table/tests/ui/padding_violation.rs
+++ b/firmware/lib/control-table/tests/ui/padding_violation.rs
@@ -1,0 +1,10 @@
+use control_table::Block;
+
+#[repr(C)]
+#[derive(Block)]
+struct Padded {
+    a: u8,
+    b: u16,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/padding_violation.stderr
+++ b/firmware/lib/control-table/tests/ui/padding_violation.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: Block struct has repr(C) padding; add explicit `_rsvd` fields so the flat read path never exposes uninitialized bytes
+ --> tests/ui/padding_violation.rs:4:10
+  |
+4 | #[derive(Block)]
+  |          ^^^^^ evaluation of `_` failed here

--- a/firmware/lib/control-table/tests/ui/section_size_mismatch.rs
+++ b/firmware/lib/control-table/tests/ui/section_size_mismatch.rs
@@ -1,0 +1,16 @@
+use control_table::{Block, Section};
+
+#[repr(C)]
+#[derive(Block)]
+struct Blk {
+    a: u16,
+}
+
+#[repr(C)]
+#[derive(Section)]
+#[ct_section(base = 0, size = 4)]
+struct Sec {
+    blk: Blk,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/section_size_mismatch.stderr
+++ b/firmware/lib/control-table/tests/ui/section_size_mismatch.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: Section struct size does not equal its declared section budget; add an explicit `_rsvd` tail array to fill the section budget
+  --> tests/ui/section_size_mismatch.rs:10:10
+   |
+10 | #[derive(Section)]
+   |          ^^^^^^^ evaluation of `_` failed here

--- a/firmware/lib/control-table/tests/ui/table_base_offset_mismatch.rs
+++ b/firmware/lib/control-table/tests/ui/table_base_offset_mismatch.rs
@@ -1,0 +1,44 @@
+#![feature(sync_unsafe_cell)]
+
+use control_table::{Block, Table};
+
+#[repr(C)]
+#[derive(Block)]
+struct Blk {
+    a: u16,
+}
+
+mod a {
+    use super::Blk;
+    use control_table::Section;
+
+    #[repr(C)]
+    #[derive(Section)]
+    #[ct_section(base = 0, size = 2)]
+    pub struct SecA {
+        pub blk: Blk,
+    }
+}
+
+mod b {
+    use super::Blk;
+    use control_table::Section;
+
+    // Declared base 0, but the field below sits at byte offset 2.
+    #[repr(C)]
+    #[derive(Section)]
+    #[ct_section(base = 0, size = 2)]
+    pub struct SecB {
+        pub blk: Blk,
+    }
+}
+
+#[repr(C)]
+#[derive(Table)]
+#[ct_table(size = 4)]
+struct Tbl {
+    a: a::SecA,
+    b: b::SecB,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/table_base_offset_mismatch.stderr
+++ b/firmware/lib/control-table/tests/ui/table_base_offset_mismatch.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: section base must equal its byte offset in the table (address IS offset)
+  --> tests/ui/table_base_offset_mismatch.rs:37:10
+   |
+37 | #[derive(Table)]
+   |          ^^^^^ evaluation of `_` failed here


### PR DESCRIPTION
The control table, from #20's tip, as a pair of crates.

`control-table` is the flat register map — 1024 bytes, address equals offset, no indirect registers — with staged writes (HOLD/COMMIT) and per-field validation rules. `control-table-derive` is the proc macro that generates the map from a declarative table definition, including emit bitmasks and rule dispatch. Rules-as-code instead of a rule interpreter took the hot goal_position write from 45 to 17 µs when it landed on #20.

48 tests, including trybuild cases that pin the macro's compile errors.
