### PR TITLE
firmware: osc-core (regions, services, persistence)

### DIFF
--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["control-table", "control-table-derive", "log", "osc-protocol", "units"]
+members = ["control-table", "control-table-derive", "core", "log", "osc-protocol", "units"]
 
 [workspace.package]
 edition = "2024"

--- a/firmware/lib/core/Cargo.toml
+++ b/firmware/lib/core/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name    = "osc-core"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+heapless.workspace         = true
+bbqueue.workspace          = true
+portable-atomic.workspace  = true
+critical-section.workspace = true
+bitflags.workspace         = true
+# defmt's macros expand to absolute `::defmt::` paths, so a crate that *invokes*
+# a defmt log macro needs its own dep (osc-log re-exports, but the expansion is
+# resolved here). See osc-log.
+defmt = { version = "1", optional = true }
+
+osc-units.workspace     = true
+osc-log.workspace       = true
+osc-protocol.workspace  = true
+control-table.workspace = true
+
+[dev-dependencies]
+crc = { workspace = true }
+
+[features]
+default = []
+defmt   = ["dep:defmt", "osc-log/defmt", "control-table/defmt"]
+log     = ["osc-log/log"]

--- a/firmware/lib/core/src/debug.rs
+++ b/firmware/lib/core/src/debug.rs
@@ -1,0 +1,18 @@
+/// Software breakpoint. Emits `ebreak` on riscv32; no-op elsewhere.
+///
+/// On QingKe V2 (CH32V006), `dcsr.ebreakm` (QingKeV2 Manual sec 6.1) gates
+/// behaviour: 0 = exception #3 via `mtvec` (hang), 1 = enter Debug mode.
+/// Debuggers (probe-rs, wlink, OpenOCD) set this on attach.
+///
+/// To inspect locals at the breakpoint: build with `debug = 2`; note
+/// `opt-level = "z"` may show vars as `<optimized out>` -- wrap in
+/// `core::hint::black_box` or log explicitly.
+#[macro_export]
+macro_rules! bp {
+    () => {
+        #[cfg(target_arch = "riscv32")]
+        unsafe {
+            ::core::arch::asm!("ebreak")
+        }
+    };
+}

--- a/firmware/lib/core/src/kernel.rs
+++ b/firmware/lib/core/src/kernel.rs
@@ -1,0 +1,32 @@
+use crate::traits::ControlIo;
+use crate::{Sample, Shared};
+
+/// Runs in the PWM ISR; one `on_tick` per period.
+pub struct Kernel<I: ControlIo> {
+    pub io: I,
+    pub state: KernelState,
+    pub stream_decimation_counter: u8,
+    pub stream_duration_remaining_ticks: u32,
+}
+
+#[derive(Default)]
+pub struct KernelState {
+    pub pid_integrator: i32,
+    pub pid_prev_error: i32,
+}
+
+impl<I: ControlIo> Kernel<I> {
+    pub fn new(io: I) -> Self {
+        Self {
+            io,
+            state: KernelState::default(),
+            stream_decimation_counter: 1,
+            stream_duration_remaining_ticks: 0,
+        }
+    }
+
+    /// Must complete well inside the kernel period (~50 us at 20 kHz).
+    pub fn on_tick(&mut self, _sample: Sample, _shared: &Shared) {
+        // TODO: PID + mode dispatch + motor.write once the control loop lands.
+    }
+}

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+#![feature(sync_unsafe_cell)]
+
+pub mod debug;
+pub mod kernel;
+pub mod log;
+pub mod persist;
+pub mod regions;
+pub mod sample;
+pub mod services;
+pub mod shared;
+pub mod traits;
+
+pub use control_table::{
+    Error, Region, RegionStorage, RegionStorageRaw, StagedWrites, ValidationKind,
+};
+pub use kernel::{Kernel, KernelState};
+pub use persist::{ConfigStore, StoreError};
+pub use regions::config::{BaudRate, ConfigDefaults};
+pub use regions::{
+    BemfCalibBlock, BootMode, CalibRegs, ConfigCalibration, ConfigComms, ConfigControlPosition,
+    ConfigIdentity, ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal, ControlLifecycle,
+    ControlRegs, ControlStreaming, ControlSystem, ControlTable, ControlTableCell, Mode,
+    PotLutBlock, StallResponse, TelemetryBusLink, TelemetryConverted, TelemetryFault,
+    TelemetryIntermediaries, TelemetryRaw, TelemetryRegs,
+};
+pub use sample::{ConversionVariables, RawSamples, Sample};
+pub use services::bus::{Dispatcher, Session};
+pub use shared::Shared;
+pub use traits::{
+    Capabilities, ControlIo, DecayMode, Dispatch, Dispatched, Motor, MotorCmd, Reply, Request,
+    RequestCtx, SendError, Sensors, Status,
+};

--- a/firmware/lib/core/src/log.rs
+++ b/firmware/lib/core/src/log.rs
@@ -1,0 +1,4 @@
+//! Logging facade -- forwards to `defmt`/`log`/no-op via the shared `osc-log`
+//! crate; re-exported here so call sites keep using `crate::log::*`.
+
+pub use osc_log::{debug, error, info, trace, warn};

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -1,0 +1,374 @@
+//! Config persistence (osc-native sec 9.4/sec 9.5): the saved-image codec, the
+//! boot-time A/B pick + overlay, and the [`ConfigStore`] port the chip's
+//! flash provider (or the sim's RAM fake) implements.
+//!
+//! One image fits a single 256 B fast-erase page:
+//!
+//!   [0]    magic
+//!   [1]    layout version
+//!   [2..4] seq u16 LE -- A/B alternation picks the wrapping-newest
+//!   [4..6] body len u16 LE (= config + profile)
+//!   [6..8] CRC-16/ARC u16 LE over bytes 0..6 ++ 8..IMAGE_LEN
+//!   [8..]  config region (128 B) ++ profile region (64 B), raw table bytes
+//!
+//! The CRC sits in the header (not the tail) so every segment is a whole
+//! number of words -- the flash provider streams header/config/profile
+//! straight into the page buffer with no byte packing and no staging copy.
+
+use control_table::RegisterMap;
+use osc_protocol::crc::{osc_crc, osc_crc_continue};
+
+use crate::ControlTableCell;
+use crate::regions::{
+    CONFIG_BASE_ADDR, CONFIG_REGION_SIZE, PROFILE_BASE_ADDR, PROFILE_REGION_SIZE, config,
+};
+
+pub const CONFIG_LEN: usize = CONFIG_REGION_SIZE as usize;
+pub const PROFILE_LEN: usize = PROFILE_REGION_SIZE as usize;
+pub const HEADER_LEN: usize = 8;
+pub const IMAGE_LEN: usize = HEADER_LEN + CONFIG_LEN + PROFILE_LEN;
+
+pub const IMAGE_MAGIC: u8 = b'C';
+/// Bump on any CONFIG/PROFILE layout change; a mismatched image is ignored
+/// (boot keeps board defaults) rather than migrated.
+pub const IMAGE_VERSION: u8 = 1;
+
+/// Store failure (erase/program/verify); dispatch answers `hardware` (sec 5.3).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct StoreError;
+
+/// sec 9.4 persistence port. Both methods are cold and blocking: on flash,
+/// `save` stalls the caller for the erase + program time (ms-scale) -- the
+/// torque gate in dispatch is what makes that stall safe.
+pub trait ConfigStore: Sync {
+    fn save(
+        &self,
+        config: &[u8; CONFIG_LEN],
+        profile: &[u8; PROFILE_LEN],
+    ) -> Result<(), StoreError>;
+    /// FACTORY (sec 9.5): invalidate both slots -- the erased store IS the
+    /// factory state; the follow-up reboot re-seeds board defaults.
+    fn wipe(&self) -> Result<(), StoreError>;
+}
+
+/// A/B slot names; the store impl maps them to its two pages.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Slot {
+    A,
+    B,
+}
+
+impl Slot {
+    pub fn other(self) -> Slot {
+        match self {
+            Slot::A => Slot::B,
+            Slot::B => Slot::A,
+        }
+    }
+}
+
+/// Boot-time store state handed to the [`ConfigStore`] impl: the slot the
+/// next SAVE programs (the older or invalid one) and the seq it carries.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BootPick {
+    pub next_slot: Slot,
+    pub next_seq: u16,
+    /// A valid image was found and overlaid (false = board defaults stand).
+    pub loaded: bool,
+}
+
+/// Build the 8-byte header for an image whose body is `config ++ profile`.
+pub fn header(
+    seq: u16,
+    config: &[u8; CONFIG_LEN],
+    profile: &[u8; PROFILE_LEN],
+) -> [u8; HEADER_LEN] {
+    let body_len = (CONFIG_LEN + PROFILE_LEN) as u16;
+    let mut h = [0u8; HEADER_LEN];
+    h[0] = IMAGE_MAGIC;
+    h[1] = IMAGE_VERSION;
+    h[2..4].copy_from_slice(&seq.to_le_bytes());
+    h[4..6].copy_from_slice(&body_len.to_le_bytes());
+    let crc = osc_crc_continue(osc_crc_continue(osc_crc(&h[..6]), config), profile);
+    h[6..8].copy_from_slice(&crc.to_le_bytes());
+    h
+}
+
+/// Assemble a whole image in RAM -- for hosts, fakes, and tests; the chip
+/// provider streams the three segments instead (no staging buffer).
+pub fn assemble(
+    out: &mut [u8; IMAGE_LEN],
+    seq: u16,
+    config: &[u8; CONFIG_LEN],
+    profile: &[u8; PROFILE_LEN],
+) {
+    out[..HEADER_LEN].copy_from_slice(&header(seq, config, profile));
+    out[HEADER_LEN..HEADER_LEN + CONFIG_LEN].copy_from_slice(config);
+    out[HEADER_LEN + CONFIG_LEN..].copy_from_slice(profile);
+}
+
+/// A validated stored image; region refs borrow the slot bytes in place.
+pub struct Image<'a> {
+    pub seq: u16,
+    pub config: &'a [u8; CONFIG_LEN],
+    pub profile: &'a [u8; PROFILE_LEN],
+}
+
+impl<'a> Image<'a> {
+    /// Validate a slot (extra bytes past `IMAGE_LEN` -- the rest of the page --
+    /// are ignored). Magic, version, len, and CRC gate integrity; the
+    /// allowed-rules pass gates safety: overlay writes raw bytes into
+    /// enum/bool-typed table fields, and an out-of-range discriminant there
+    /// is UB, so a CRC-valid image must still never carry one.
+    pub fn parse(slot: &'a [u8]) -> Option<Image<'a>> {
+        let bytes = slot.get(..IMAGE_LEN)?;
+        if bytes[0] != IMAGE_MAGIC || bytes[1] != IMAGE_VERSION {
+            return None;
+        }
+        let seq = u16::from_le_bytes([bytes[2], bytes[3]]);
+        if u16::from_le_bytes([bytes[4], bytes[5]]) != (CONFIG_LEN + PROFILE_LEN) as u16 {
+            return None;
+        }
+        let crc = u16::from_le_bytes([bytes[6], bytes[7]]);
+        if osc_crc_continue(osc_crc(&bytes[..6]), &bytes[HEADER_LEN..]) != crc {
+            return None;
+        }
+        let img = Image {
+            seq,
+            config: bytes[HEADER_LEN..HEADER_LEN + CONFIG_LEN].try_into().ok()?,
+            profile: bytes[HEADER_LEN + CONFIG_LEN..].try_into().ok()?,
+        };
+        img.fields_allowed().then_some(img)
+    }
+
+    /// Every enum/bool rule whose field lies in a persisted region must hold
+    /// an allowed byte. Driven by the table's generated rule data, so new
+    /// enum fields are covered without touching this code.
+    fn fields_allowed(&self) -> bool {
+        <ControlTableCell as RegisterMap>::ALLOWED_RULES
+            .iter()
+            .all(|r| match self.persisted_byte(r.addr) {
+                Some(b) => r.allowed.contains(&b),
+                None => true,
+            })
+    }
+
+    fn persisted_byte(&self, addr: u16) -> Option<u8> {
+        if (CONFIG_BASE_ADDR..CONFIG_BASE_ADDR + CONFIG_REGION_SIZE).contains(&addr) {
+            Some(self.config[(addr - CONFIG_BASE_ADDR) as usize])
+        } else if (PROFILE_BASE_ADDR..PROFILE_BASE_ADDR + PROFILE_REGION_SIZE).contains(&addr) {
+            Some(self.profile[(addr - PROFILE_BASE_ADDR) as usize])
+        } else {
+            None
+        }
+    }
+}
+
+impl ControlTableCell {
+    /// Overlay a validated image onto the live table -- raw byte copy,
+    /// deliberately bypassing ro masks and field rules (`Image::parse`
+    /// already gated the UB-critical bytes; everything else was rule-valid
+    /// when saved). The identity block is skipped: model/fw must reflect the
+    /// flashed firmware, never a stale saved image. Bringup-only, pre-IRQ;
+    /// sole writer (the `seed_config_defaults` contract).
+    pub fn overlay_persistent(&self, config: &[u8; CONFIG_LEN], profile: &[u8; PROFILE_LEN]) {
+        let skip = config::addr::comms::ID as usize;
+        let base = RegisterMap::base(self);
+        // SAFETY: base points at the flat map (RegisterMap contract), both
+        // regions lie inside it, and the fn doc pins the sole-writer window.
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                config.as_ptr().add(skip),
+                base.add(CONFIG_BASE_ADDR as usize + skip),
+                CONFIG_LEN - skip,
+            );
+            core::ptr::copy_nonoverlapping(
+                profile.as_ptr(),
+                base.add(PROFILE_BASE_ADDR as usize),
+                PROFILE_LEN,
+            );
+        }
+    }
+}
+
+/// Boot-time load: parse both slots, overlay the wrapping-newest valid image
+/// (board defaults, already seeded, stand when neither validates), and hand
+/// back the store state for the impl. Bringup-only, pre-IRQ.
+pub fn boot_overlay(table: &ControlTableCell, slot_a: &[u8], slot_b: &[u8]) -> BootPick {
+    let a = Image::parse(slot_a);
+    let b = Image::parse(slot_b);
+    let (img, next_slot) = match (a, b) {
+        (Some(a), Some(b)) => {
+            if (a.seq.wrapping_sub(b.seq) as i16) > 0 {
+                (Some(a), Slot::B)
+            } else {
+                (Some(b), Slot::A)
+            }
+        }
+        (Some(a), None) => (Some(a), Slot::B),
+        (None, b) => (b, Slot::A),
+    };
+    match img {
+        Some(img) => {
+            table.overlay_persistent(img.config, img.profile);
+            BootPick {
+                next_slot,
+                next_seq: img.seq.wrapping_add(1),
+                loaded: true,
+            }
+        }
+        None => BootPick {
+            next_slot: Slot::A,
+            next_seq: 1,
+            loaded: false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regions::config::addr;
+    use crate::{ConfigDefaults, RegionStorage};
+
+    /// A plausible table snapshot: pattern data in rule-free fields, valid
+    /// (zero) bytes in every enum/bool field.
+    fn body() -> ([u8; CONFIG_LEN], [u8; PROFILE_LEN]) {
+        let mut config = [0u8; CONFIG_LEN];
+        config[addr::comms::ID as usize] = 7;
+        config[addr::comms::RESPONSE_DEADLINE_US as usize] = 99;
+        config[addr::identity::MODEL_NUMBER as usize] = 0xEE;
+        let mut profile = [0u8; PROFILE_LEN];
+        profile[0] = 0xAA;
+        profile[PROFILE_LEN - 1] = 0x55;
+        (config, profile)
+    }
+
+    fn image_of(seq: u16) -> [u8; IMAGE_LEN] {
+        let (config, profile) = body();
+        let mut img = [0u8; IMAGE_LEN];
+        assemble(&mut img, seq, &config, &profile);
+        img
+    }
+
+    #[test]
+    fn image_round_trips() {
+        let (config, profile) = body();
+        let img = image_of(9);
+        let parsed = Image::parse(&img).expect("valid image");
+        assert_eq!(parsed.seq, 9);
+        assert_eq!(parsed.config, &config);
+        assert_eq!(parsed.profile, &profile);
+    }
+
+    #[test]
+    fn parse_rejects_each_gate() {
+        let img = image_of(1);
+        assert!(Image::parse(&img[..IMAGE_LEN - 1]).is_none(), "short slot");
+        for (i, name) in [(0, "magic"), (1, "version"), (4, "len"), (6, "crc")] {
+            let mut bad = img;
+            bad[i] ^= 0x01;
+            assert!(Image::parse(&bad).is_none(), "{name} must gate");
+        }
+        // Erased flash (all 0xFF) is the common invalid slot.
+        assert!(Image::parse(&[0xFF; IMAGE_LEN]).is_none());
+        // Extra bytes past IMAGE_LEN (the rest of the page) are ignored.
+        let mut page = [0xFF; 256];
+        page[..IMAGE_LEN].copy_from_slice(&img);
+        assert!(Image::parse(&page).is_some());
+    }
+
+    #[test]
+    fn parse_rejects_disallowed_enum_byte() {
+        // A CRC-valid image planting an out-of-range discriminant must not
+        // parse -- overlay would construct an invalid enum (UB).
+        let (mut config, profile) = body();
+        config[addr::comms::BAUD_RATE_IDX as usize] = 4;
+        let mut img = [0u8; IMAGE_LEN];
+        assemble(&mut img, 1, &config, &profile);
+        assert!(Image::parse(&img).is_none());
+    }
+
+    fn seeded_table() -> crate::ControlTableCell {
+        let table = crate::ControlTableCell::new();
+        table.seed_config_defaults(&ConfigDefaults {
+            id: 1,
+            ..Default::default()
+        });
+        table
+    }
+
+    #[test]
+    fn boot_overlay_picks_the_newest_and_programs_the_other() {
+        let table = seeded_table();
+        let newer = {
+            let (mut config, profile) = body();
+            config[addr::comms::ID as usize] = 8;
+            let mut img = [0u8; IMAGE_LEN];
+            assemble(&mut img, 6, &config, &profile);
+            img
+        };
+        let pick = boot_overlay(&table, &image_of(5), &newer);
+        assert_eq!(
+            pick,
+            BootPick {
+                next_slot: Slot::A,
+                next_seq: 7,
+                loaded: true
+            }
+        );
+        assert_eq!(table.with(|t| t.config.comms.id), 8);
+        assert_eq!(table.with(|t| t.profile.slots.words[0]), 0x00AA);
+    }
+
+    #[test]
+    fn boot_overlay_seq_compare_wraps() {
+        let table = seeded_table();
+        let pick = boot_overlay(&table, &image_of(0xFFFF), &image_of(0));
+        // 0 is wrapping-newer than 0xFFFF: slot B wins, A is next.
+        assert_eq!(pick.next_slot, Slot::A);
+        assert_eq!(pick.next_seq, 1);
+    }
+
+    #[test]
+    fn boot_overlay_single_valid_slot_wins_either_side() {
+        for (a, b, next) in [
+            (&image_of(3)[..], &[0xFF; IMAGE_LEN][..], Slot::B),
+            (&[0xFF; IMAGE_LEN][..], &image_of(3)[..], Slot::A),
+        ] {
+            let table = seeded_table();
+            let pick = boot_overlay(&table, a, b);
+            assert_eq!(
+                (pick.next_slot, pick.next_seq, pick.loaded),
+                (next, 4, true)
+            );
+            assert_eq!(table.with(|t| t.config.comms.id), 7);
+        }
+    }
+
+    #[test]
+    fn boot_overlay_without_valid_image_keeps_defaults() {
+        let table = seeded_table();
+        let pick = boot_overlay(&table, &[0xFF; IMAGE_LEN], &[0u8; IMAGE_LEN]);
+        assert_eq!(
+            pick,
+            BootPick {
+                next_slot: Slot::A,
+                next_seq: 1,
+                loaded: false
+            }
+        );
+        assert_eq!(table.with(|t| t.config.comms.id), 1);
+    }
+
+    #[test]
+    fn overlay_skips_the_identity_block() {
+        let table = seeded_table();
+        table.with_mut(|t| t.config.identity.model_number = 0x1234);
+        boot_overlay(&table, &image_of(1), &[0xFF; IMAGE_LEN]);
+        // The image carried 0x00EE at MODEL_NUMBER; the flashed firmware's
+        // identity stands.
+        assert_eq!(table.with(|t| t.config.identity.model_number), 0x1234);
+        assert_eq!(table.with(|t| t.config.comms.id), 7, "comms overlaid");
+    }
+}

--- a/firmware/lib/core/src/regions/calib.rs
+++ b/firmware/lib/core/src/regions/calib.rs
@@ -1,0 +1,33 @@
+use control_table::{Block, Section};
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct PotLutBlock {
+    pub raw_min: u16,
+    pub raw_max: u16,
+    pub lut: [i32; 55],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct BemfCalibBlock {
+    pub ke_uvs_per_rad: u16,
+    pub r_motor_mohm: u16,
+    pub calib_v_bus_mv: u16,
+    pub calib_i_ma: u16,
+}
+
+/// Calibration section: always writable (normal field validation applies),
+/// volatile until persisted -- persistence is SAVE's job, not a write gate.
+#[repr(C)]
+#[derive(Section)]
+#[ct_section(
+    base = crate::regions::CALIB_BASE_ADDR,
+    size = crate::regions::CALIB_REGION_SIZE,
+)]
+pub struct CalibRegs {
+    pub pot_lut: PotLutBlock,
+    pub bemf: BemfCalibBlock,
+    #[ct_section(skip)]
+    pub _rsvd_tail: [u8; 24],
+}

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -1,0 +1,191 @@
+use control_table::{Block, Enum, Section};
+
+/// osc-native operational baud (sec 2). Recovery is the rescue break's job, not a
+/// crawl-speed fallback, so only the four operational rates exist.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
+#[repr(u8)]
+pub enum BaudRate {
+    // Default = the sec 9.1 rescue floor, the always-reachable rate -- and the
+    // zero value, which keeps the table's const image all-zero so SHARED
+    // lands in .bss (no 1 KB flash init image). The operational default is
+    // the board's `ConfigDefaults.baud`, seeded at boot before the bus runs.
+    #[default]
+    B500000 = 0,
+    B1000000 = 1,
+    B2000000 = 2,
+    B3000000 = 3,
+}
+
+/// osc-native sec 7 default: chain reclaim + host timeout, not a reply-time floor.
+pub const DEFAULT_RESPONSE_DEADLINE_US: u16 = 60;
+
+impl BaudRate {
+    pub const fn as_idx(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn as_hz(self) -> u32 {
+        match self {
+            BaudRate::B500000 => 500_000,
+            BaudRate::B1000000 => 1_000_000,
+            BaudRate::B2000000 => 2_000_000,
+            BaudRate::B3000000 => 3_000_000,
+        }
+    }
+
+    pub const fn from_idx(idx: u8) -> Option<Self> {
+        match idx {
+            0 => Some(BaudRate::B500000),
+            1 => Some(BaudRate::B1000000),
+            2 => Some(BaudRate::B2000000),
+            3 => Some(BaudRate::B3000000),
+            _ => None,
+        }
+    }
+}
+
+/// Stall detector policy. `repr(u8)`; constructing from an unlisted discriminant is UB,
+/// so validators MUST gate writes to `StallResponse::ALLOWED`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
+#[repr(u8)]
+pub enum StallResponse {
+    #[default]
+    Disable = 0,
+    Comply = 1,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigIdentity {
+    #[ct_field(access = ro)]
+    pub model_number: u16,
+    #[ct_field(access = ro)]
+    pub firmware_version: u8,
+    #[ct_field(skip)]
+    pub _rsvd_align: u8,
+    #[ct_field(access = ro)]
+    pub hardware_revision: u32,
+    #[ct_field(access = ro)]
+    pub capability_flags: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+#[ct_block(hooks = crate::regions::hooks::ControlTableHookEvents)]
+pub struct ConfigComms {
+    #[ct_field(ge = 1u8, le = 249u8, hook = on_id_write)]
+    pub id: u8,
+    #[ct_field(hook = on_baud_rate_idx_write)]
+    pub baud_rate_idx: BaudRate,
+    #[ct_field(hook = on_response_deadline_us_write)]
+    pub response_deadline_us: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigPosLimits {
+    #[ct_field(lt = &addr::pos_limits::POS_MAX_PHYS_URAD)]
+    pub pos_min_phys_urad: i32,
+    #[ct_field(gt = &addr::pos_limits::POS_MIN_PHYS_URAD)]
+    pub pos_max_phys_urad: i32,
+    #[ct_field(
+        ge = &addr::pos_limits::POS_MIN_PHYS_URAD,
+        le = &addr::pos_limits::POS_MAX_PHYS_URAD,
+        lt = &addr::pos_limits::POS_MAX_SOFT_URAD,
+    )]
+    pub pos_min_soft_urad: i32,
+    #[ct_field(
+        ge = &addr::pos_limits::POS_MIN_PHYS_URAD,
+        le = &addr::pos_limits::POS_MAX_PHYS_URAD,
+        gt = &addr::pos_limits::POS_MIN_SOFT_URAD,
+    )]
+    pub pos_max_soft_urad: i32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigStall {
+    pub stall_response: StallResponse,
+    #[ct_field(skip)]
+    pub _rsvd_align: u8,
+    pub stall_effort_threshold: i16,
+    pub stall_motion_threshold_urad: u32,
+    pub stall_time_threshold_ms: u16,
+    pub comply_release_window_ms: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigThermal {
+    pub motor_thermal_k_q88: u16,
+    pub motor_thermal_tau_ms: u16,
+    #[ct_field(gt = &addr::thermal::WINDING_RECOVER_CC)]
+    pub winding_cutoff_cc: i16,
+    #[ct_field(lt = &addr::thermal::WINDING_CUTOFF_CC)]
+    pub winding_recover_cc: i16,
+    pub v_undervolt_mv: u16,
+    #[ct_field(skip)]
+    pub _rsvd_tail: u16,
+}
+
+/// `vdd_mv` is the DMM-measured VDD-at-chip-pin baked in per board.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigCalibration {
+    pub vdd_mv: u16,
+    #[ct_field(skip)]
+    pub _rsvd_align: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ConfigControlPosition {
+    pub pid_kp_q88: u16,
+    pub pid_ki_q88: u16,
+    pub pid_kd_q88: u16,
+    #[ct_field(skip)]
+    pub _rsvd_align: u16,
+    pub pid_i_limit: i32,
+    pub pos_deadband_urad: u32,
+    #[ct_field(le = 50u8)]
+    pub pwm_deadband_pct: u8,
+    pub v_comp_enable: bool,
+    pub max_effort: i16,
+    pub v_nominal_mv: u16,
+    #[ct_field(skip)]
+    pub _rsvd_tail: u16,
+}
+
+/// Config section: always writable (normal field validation applies), volatile
+/// until `MGMT SAVE` persists it -- SAVE is the only torque-gated operation
+/// (osc-native sec 9.4 separates write from persistence).
+#[repr(C)]
+#[derive(Section)]
+#[ct_section(
+    base = crate::regions::CONFIG_BASE_ADDR,
+    size = crate::regions::CONFIG_REGION_SIZE,
+    hooks = crate::regions::hooks::ControlTableHookEvents,
+)]
+pub struct ConfigRegs {
+    pub identity: ConfigIdentity,
+    pub comms: ConfigComms,
+    pub pos_limits: ConfigPosLimits,
+    pub stall: ConfigStall,
+    pub thermal: ConfigThermal,
+    pub ctrl_pos: ConfigControlPosition,
+    pub calibration: ConfigCalibration,
+    #[ct_section(skip)]
+    pub _rsvd_tail: [u8; 44],
+}
+
+/// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct ConfigDefaults {
+    pub pos_min_phys_urad: i32,
+    pub pos_max_phys_urad: i32,
+    /// VDD-at-chip-pin in mV; the v006 ADC reference is VDD itself.
+    pub vdd_mv: u16,
+    pub id: u8,
+    pub baud: BaudRate,
+    pub response_deadline_us: u16,
+}

--- a/firmware/lib/core/src/regions/control.rs
+++ b/firmware/lib/core/src/regions/control.rs
@@ -1,0 +1,83 @@
+use crate::regions::config;
+use control_table::{Block, Enum, Section};
+
+/// Position controller mode. `repr(u8)` so the byte-level commit path round-trips
+/// cleanly; validators MUST gate writes to `Mode::ALLOWED` because constructing a
+/// `Mode` from an unlisted discriminant is UB.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
+#[repr(u8)]
+pub enum Mode {
+    #[default]
+    OpenLoop = 0,
+    PositionPid = 1,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
+#[repr(u8)]
+pub enum BootMode {
+    #[default]
+    App = 0,
+    Bootloader = 1,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ControlLifecycle {
+    pub torque_enable: bool,
+    pub mode: Mode,
+    #[ct_field(skip)]
+    pub _rsvd_align: [u8; 2],
+    #[ct_field(
+        ge = &config::addr::pos_limits::POS_MIN_SOFT_URAD,
+        le = &config::addr::pos_limits::POS_MAX_SOFT_URAD,
+    )]
+    pub goal_position: i32,
+    pub goal_velocity: i32,
+    #[ct_field(le = &config::addr::ctrl_pos::MAX_EFFORT, abs)]
+    pub goal_effort: i16,
+    #[ct_field(skip)]
+    pub _rsvd_tail: [u8; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ControlStreaming {
+    pub stream_enable: bool,
+    pub stream_decimation: u8,
+    #[ct_field(ge = 1u16)]
+    pub stream_duration_ms: u16,
+    pub stream_field_mask: u32,
+    #[ct_field(access = ro)]
+    pub stream_dropped: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ControlSystem {
+    pub boot_mode: BootMode,
+}
+
+#[repr(C)]
+#[derive(Section)]
+#[ct_section(base = crate::regions::CONTROL_BASE_ADDR, size = crate::regions::CONTROL_REGION_SIZE)]
+pub struct ControlRegs {
+    pub lifecycle: ControlLifecycle,
+    pub streaming: ControlStreaming,
+    pub system: ControlSystem,
+    #[ct_section(skip)]
+    pub _rsvd_tail: [u8; 99],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn region_fits_declared_size() {
+        assert_eq!(
+            size_of::<ControlRegs>(),
+            crate::regions::CONTROL_REGION_SIZE as usize
+        );
+    }
+}

--- a/firmware/lib/core/src/regions/hooks.rs
+++ b/firmware/lib/core/src/regions/hooks.rs
@@ -1,0 +1,41 @@
+//! Field-write hook surface for the `ControlTable` derive.
+//!
+//! Lives inside `regions` because it's a control-table concern: the
+//! macro-generated `dispatch_events` fires methods on this trait whenever a
+//! committed write touches a tagged field. The single [`ControlTableHooks`]
+//! translator forwards each new value to the bus's [`Reply`] deferred-apply
+//! queue.
+//!
+//! Kept `pub(crate)`: chip impls only see `Reply`; the field->reply wiring
+//! stays an internal concern of the table layer.
+
+use crate::regions::config::BaudRate;
+use crate::traits::Reply;
+
+pub(crate) trait ControlTableHookEvents {
+    fn on_id_write(&mut self, value: u8);
+    fn on_baud_rate_idx_write(&mut self, value: BaudRate);
+    fn on_response_deadline_us_write(&mut self, value: u16);
+}
+
+pub(crate) struct ControlTableHooks<'a, R: Reply + ?Sized> {
+    reply: &'a mut R,
+}
+
+impl<'a, R: Reply + ?Sized> ControlTableHooks<'a, R> {
+    pub(crate) fn new(reply: &'a mut R) -> Self {
+        Self { reply }
+    }
+}
+
+impl<R: Reply + ?Sized> ControlTableHookEvents for ControlTableHooks<'_, R> {
+    fn on_id_write(&mut self, value: u8) {
+        self.reply.stage_id(value);
+    }
+    fn on_baud_rate_idx_write(&mut self, value: BaudRate) {
+        self.reply.stage_baud(value);
+    }
+    fn on_response_deadline_us_write(&mut self, value: u16) {
+        self.reply.set_response_deadline(value);
+    }
+}

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -1,0 +1,89 @@
+//! Host-visible register state as a flat 1024-byte map. Sections carve
+//! contiguous byte ranges; every address in `[0, 1024)` reads back (reserved
+//! and skip bytes read as zero). Writes to non-writable bytes fail with
+//! `AccessError`; addresses past the map end fail with `DataRange`.
+//!
+//!   CONFIG    0x000..0x080  (128 B) -- persistent via MGMT SAVE
+//!   CALIB     0x080..0x180  (256 B) -- persistence deferred (unused today)
+//!   CONTROL   0x180..0x200  (128 B) -- RW volatile
+//!   TELEMETRY 0x200..0x280  (128 B) -- RO from host
+//!   PROFILE   0x280..0x2C0  ( 64 B) -- read-profile span words (sec 5.2)
+//!   (reserved 0x2C0..0x400  320 B)
+//!
+//! Owners go through `RegionStorage::with`/`with_mut` on the storage cell.
+//! Cross-domain readers that must avoid forming `&T` (aliasing-sensitive
+//! paths) use raw-pointer reads via `RegionStorageRaw::region_ptr`.
+
+pub mod calib;
+pub mod config;
+pub mod control;
+pub(crate) mod hooks;
+pub mod profile;
+pub mod telemetry;
+
+pub use calib::{BemfCalibBlock, CalibRegs, PotLutBlock};
+pub use config::{
+    BaudRate, ConfigCalibration, ConfigComms, ConfigControlPosition, ConfigIdentity,
+    ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal, StallResponse,
+};
+pub use control::{BootMode, ControlLifecycle, ControlRegs, ControlStreaming, ControlSystem, Mode};
+pub use profile::{PROFILE_SLOTS, ProfileRegs, ProfileSlots, SPANS_PER_SLOT};
+pub use telemetry::{
+    TelemetryBusLink, TelemetryConverted, TelemetryFault, TelemetryIntermediaries, TelemetryRaw,
+    TelemetryRegs,
+};
+
+use crate::regions::config::ConfigDefaults;
+use control_table::{RegionStorage, Table};
+
+pub const CONFIG_REGION_SIZE: u16 = 128;
+pub const CALIB_REGION_SIZE: u16 = 256;
+pub const CONTROL_REGION_SIZE: u16 = 128;
+pub const TELEMETRY_REGION_SIZE: u16 = 128;
+pub const PROFILE_REGION_SIZE: u16 = 64;
+
+pub const CONFIG_BASE_ADDR: u16 = 0x000;
+pub const CALIB_BASE_ADDR: u16 = 0x080;
+pub const CONTROL_BASE_ADDR: u16 = 0x180;
+pub const TELEMETRY_BASE_ADDR: u16 = 0x200;
+pub const PROFILE_BASE_ADDR: u16 = 0x280;
+
+#[repr(C)]
+#[derive(Table)]
+#[ct_table(size = 1024, hooks = crate::regions::hooks::ControlTableHookEvents)]
+pub struct ControlTable {
+    pub config: ConfigRegs,
+    pub calib: CalibRegs,
+    pub control: ControlRegs,
+    pub telemetry: TelemetryRegs,
+    pub profile: ProfileRegs,
+    #[ct_table(skip)]
+    _rsvd: [u8; 320],
+}
+
+impl ControlTableCell {
+    /// Soft limits init to physical limits per control-table doc.
+    /// Caller must be sole writer (install-time, pre-IRQ).
+    pub fn seed_config_defaults(&self, defaults: &ConfigDefaults) {
+        crate::log::debug!(
+            "seed CONFIG: phys=[{}, {}] urad  vdd_mv={}  id={}  baud_idx={}",
+            defaults.pos_min_phys_urad,
+            defaults.pos_max_phys_urad,
+            defaults.vdd_mv,
+            defaults.id,
+            defaults.baud.as_idx(),
+        );
+        // SAFETY: install-time, pre-IRQ, sole writer.
+        self.with_mut(|t| {
+            let cfg = &mut t.config;
+            cfg.pos_limits.pos_min_phys_urad = defaults.pos_min_phys_urad;
+            cfg.pos_limits.pos_max_phys_urad = defaults.pos_max_phys_urad;
+            cfg.pos_limits.pos_min_soft_urad = defaults.pos_min_phys_urad;
+            cfg.pos_limits.pos_max_soft_urad = defaults.pos_max_phys_urad;
+            cfg.calibration.vdd_mv = defaults.vdd_mv;
+            cfg.comms.id = defaults.id;
+            cfg.comms.baud_rate_idx = defaults.baud;
+            cfg.comms.response_deadline_us = defaults.response_deadline_us;
+        });
+    }
+}

--- a/firmware/lib/core/src/regions/profile.rs
+++ b/firmware/lib/core/src/regions/profile.rs
@@ -1,0 +1,85 @@
+//! PROFILE region (osc-native sec 5.2): span-granular read profiles. A READ or
+//! GREAD carrying the PROFILE flag names a slot; the reply streams the slot's
+//! spans back-to-back through the copy-once TX path, so scattered telemetry
+//! costs the wire one slot byte per cycle instead of a span list.
+//!
+//! Span word: `[addr:10][count:6]`, `count = 0` = word disabled. Disabled
+//! words are SKIPPED, not terminators -- a host can toggle one span with a
+//! single 2-byte write. The all-zero boot image is an empty slot. Any u16 is
+//! a valid word, so the region carries no field rules; span bounds and the
+//! reply ceiling are checked at read time (sec 5.3: `range` / `limit`).
+
+use control_table::{Block, Section};
+
+/// Profile slots in the region.
+pub const PROFILE_SLOTS: u8 = 4;
+/// Span words per slot.
+pub const SPANS_PER_SLOT: usize = 8;
+
+/// Pack a span word. `addr` caps at 10 bits (1023), `count` at 6 bits (63);
+/// out-of-range inputs are the caller's bug (host-side builders validate).
+#[inline]
+pub const fn span_word(addr: u16, count: u8) -> u16 {
+    (addr << 6) | (count as u16 & 0x3F)
+}
+
+/// Unpack a span word to `(addr, count)`; `None` for a disabled word.
+#[inline]
+pub const fn span_of(word: u16) -> Option<(u16, u16)> {
+    let count = word & 0x3F;
+    if count == 0 {
+        return None;
+    }
+    Some((word >> 6, count))
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct ProfileSlots {
+    pub words: [u16; PROFILE_SLOTS as usize * SPANS_PER_SLOT],
+}
+
+#[repr(C)]
+#[derive(Section)]
+#[ct_section(
+    base = crate::regions::PROFILE_BASE_ADDR,
+    size = crate::regions::PROFILE_REGION_SIZE,
+)]
+pub struct ProfileRegs {
+    pub slots: ProfileSlots,
+}
+
+impl ProfileRegs {
+    /// The span words of `slot`; `None` past the last slot (sec 5.3: `range`).
+    #[inline]
+    pub fn slot_words(&self, slot: u8) -> Option<&[u16; SPANS_PER_SLOT]> {
+        if slot >= PROFILE_SLOTS {
+            return None;
+        }
+        let at = slot as usize * SPANS_PER_SLOT;
+        self.slots.words[at..at + SPANS_PER_SLOT].try_into().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_word_packs_and_unpacks() {
+        assert_eq!(span_of(span_word(0x0200, 8)), Some((0x0200, 8)));
+        assert_eq!(span_of(span_word(1023, 63)), Some((1023, 63)));
+        assert_eq!(span_of(span_word(1, 1)), Some((1, 1)));
+        // count 0 = disabled, at any address.
+        assert_eq!(span_of(span_word(0x0200, 0)), None);
+        assert_eq!(span_of(0), None);
+    }
+
+    #[test]
+    fn slot_words_bounds() {
+        let r = ProfileRegs::new();
+        assert!(r.slot_words(0).is_some());
+        assert!(r.slot_words(PROFILE_SLOTS - 1).is_some());
+        assert!(r.slot_words(PROFILE_SLOTS).is_none());
+    }
+}

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -1,0 +1,114 @@
+use control_table::{Block, Section};
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryConverted {
+    #[ct_field(access = ro)]
+    pub present_position: i32,
+    #[ct_field(access = ro)]
+    pub present_velocity: i32,
+    #[ct_field(access = ro)]
+    pub present_current: i16,
+    #[ct_field(access = ro)]
+    pub present_temp: i16,
+    #[ct_field(access = ro)]
+    pub present_vbus_mv: u16,
+    #[ct_field(skip)]
+    pub _rsvd_tail: u16,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryIntermediaries {
+    #[ct_field(access = ro)]
+    pub vbus_filt_mv: u16,
+    #[ct_field(access = ro)]
+    pub t_winding_dc: i16,
+    #[ct_field(access = ro)]
+    pub pwm_duty_actual: i16,
+    #[ct_field(skip)]
+    pub _rsvd_align: u16,
+    #[ct_field(access = ro)]
+    pub pid_error_last: i32,
+    #[ct_field(access = ro)]
+    pub pid_output_last: i32,
+    #[ct_field(access = ro)]
+    pub internal_goal: i32,
+    #[ct_field(access = ro)]
+    pub sample_tick: u32,
+}
+
+/// `fault_flags` writable-RO carve-out: host writing 0x00 clears non-latched bits.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryFault {
+    #[ct_field(access = ro)]
+    pub mode_active: u8,
+    #[ct_field(access = ro)]
+    pub fault_flags: u8,
+    #[ct_field(access = ro)]
+    pub fault_code: u8,
+    /// Modified-since-save (sec 9.4): set when a committed write lands in
+    /// CONFIG or PROFILE, cleared by a successful SAVE; boot state is clean.
+    #[ct_field(access = ro)]
+    pub config_dirty: u8,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryRaw {
+    #[ct_field(access = ro)]
+    pub raw_pos: u16,
+    #[ct_field(access = ro)]
+    pub raw_current: u16,
+    #[ct_field(access = ro)]
+    pub raw_temp: u16,
+    #[ct_field(access = ro)]
+    pub raw_vbus: u16,
+    #[ct_field(access = ro)]
+    pub raw_vmotor_a: u16,
+    #[ct_field(access = ro)]
+    pub raw_vmotor_b: u16,
+    #[ct_field(access = ro)]
+    pub raw_enc_a: u16,
+    #[ct_field(access = ro)]
+    pub raw_enc_b: u16,
+}
+
+/// Host can Write zero to any field to clear it (bench instrumentation).
+/// Chip-side `report_fault` increments via raw pointer, bypassing the regmap.
+/// Concurrent host clear + ISR increment may drop one update -- acceptable for bench.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryBusLink {
+    #[ct_field(access = rw)]
+    pub crc_fail_count: u32,
+    #[ct_field(access = rw)]
+    pub framing_drop_count: u32,
+}
+
+/// Clock discipline (sec 9.3), read-only: the trim loop's applied total, in
+/// signed chip trim steps from the factory default (positive = slowed).
+/// Volatile by design -- every boot re-converges from live traffic.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryClock {
+    #[ct_field(access = ro)]
+    pub trim_steps: i8,
+    #[ct_field(skip)]
+    pub _rsvd_align: [u8; 3],
+}
+
+#[repr(C)]
+#[derive(Section)]
+#[ct_section(base = crate::regions::TELEMETRY_BASE_ADDR, size = crate::regions::TELEMETRY_REGION_SIZE)]
+pub struct TelemetryRegs {
+    pub converted: TelemetryConverted,
+    pub intermediaries: TelemetryIntermediaries,
+    pub fault: TelemetryFault,
+    pub raw: TelemetryRaw,
+    pub link: TelemetryBusLink,
+    pub clock: TelemetryClock,
+    #[ct_section(skip)]
+    pub _rsvd_tail: [u8; 56],
+}

--- a/firmware/lib/core/src/sample.rs
+++ b/firmware/lib/core/src/sample.rs
@@ -1,0 +1,78 @@
+use osc_units::{CentiCelsius, Microrads, Milliamps, Millivolts};
+
+use crate::Shared;
+use control_table::RegionStorageRaw;
+
+/// Per-frame snapshot of the live config slice the sample-conversion math
+/// needs. Lifted from `ControlTable` regions (`pos_limits`, `calibration`)
+/// via raw-pointer reads so the conversion never holds a `&` into the table.
+#[derive(Copy, Clone, Debug)]
+pub struct ConversionVariables {
+    pub pos_min_phys_urad: i32,
+    pub pos_max_phys_urad: i32,
+    pub vdd_mv: u16,
+}
+
+impl ConversionVariables {
+    pub fn snapshot(shared: &Shared) -> Self {
+        // SAFETY: per-field raw-pointer copy, no `&` into ConfigRegs/ConfigPosLimits.
+        unsafe {
+            let t = shared.table.region_ptr();
+            Self {
+                pos_min_phys_urad: (&raw const (*t).config.pos_limits.pos_min_phys_urad).read(),
+                pos_max_phys_urad: (&raw const (*t).config.pos_limits.pos_max_phys_urad).read(),
+                vdd_mv: (&raw const (*t).config.calibration.vdd_mv).read(),
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct Sample {
+    pub tick: u32,
+    pub pos: Microrads,
+    pub current: Milliamps,
+    pub current_post_trough: Milliamps,
+    pub temp: CentiCelsius,
+    pub vbus: Millivolts,
+    pub vmotor: Millivolts,
+    pub raw: RawSamples,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct RawSamples {
+    pub pos: u16,
+    pub current: u16,
+    pub shunt_post_trough: u16,
+    pub temp: u16,
+    pub vbus: u16,
+    pub vmotor_a: u16,
+    pub vmotor_a_trough: u16,
+    pub vmotor_b: u16,
+    pub vmotor_b_trough: u16,
+    pub vcal: u16,
+    pub vcal_lpf: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::regions::config::ConfigDefaults;
+
+    #[test]
+    fn snapshot_reads_back_seeded_defaults() {
+        let shared = Shared::new();
+        let defaults = ConfigDefaults {
+            pos_min_phys_urad: -1_500_000,
+            pos_max_phys_urad: 1_500_000,
+            vdd_mv: 3275,
+            ..Default::default()
+        };
+        shared.table.seed_config_defaults(&defaults);
+
+        let vars = ConversionVariables::snapshot(&shared);
+        assert_eq!(vars.pos_min_phys_urad, -1_500_000);
+        assert_eq!(vars.pos_max_phys_urad, 1_500_000);
+        assert_eq!(vars.vdd_mv, 3275);
+    }
+}

--- a/firmware/lib/core/src/services/bus/dispatch.rs
+++ b/firmware/lib/core/src/services/bus/dispatch.rs
@@ -1,0 +1,554 @@
+use control_table::{RegisterFile, Snapshot};
+use heapless::Vec;
+use osc_protocol::FrameBytes;
+use osc_protocol::frame::uid_prefix_matches;
+use osc_protocol::wire::{Id, MAX_PAYLOAD, MgmtOp, ResultCode, UID_LEN};
+
+use crate::persist::{CONFIG_LEN, PROFILE_LEN, StoreError};
+use crate::regions::hooks::ControlTableHooks;
+use crate::regions::{
+    CONFIG_BASE_ADDR, CONFIG_REGION_SIZE, PROFILE_BASE_ADDR, PROFILE_REGION_SIZE,
+};
+use crate::traits::{Dispatch, Dispatched, GATHER_MAX, Reply, Request, RequestCtx, Status};
+use crate::{Error, RegionStorage, Shared, StagedWrites};
+use control_table::STAGE_ENTRY_CAP;
+
+/// Map a control-table write/stage failure onto an osc-native result code
+/// (sec 5.3 layer 2). Read-only writes are `Access`; field-rule rejections are
+/// `Validation`; the rest (bounds, staging-full) are `Range`.
+fn error_to_result(e: Error) -> ResultCode {
+    match e {
+        Error::AccessError => ResultCode::Access,
+        Error::ValidationError(_) => ResultCode::Validation,
+        _ => ResultCode::Range,
+    }
+}
+
+/// A write staged before its CRC verdict (the dispatch spine). The bus
+/// rebuilds the [`Dispatcher`] each wake, so this lives in the [`Session`]
+/// and outlives the dispatcher that staged it.
+///
+/// [`Session`]: super::session::Session
+pub(crate) struct PendingWrite {
+    /// Staging watermark before this write -- commit/revert operate above it.
+    snap: Snapshot,
+    /// A held write keeps its entries for a later COMMIT; a plain write applies
+    /// them at commit time.
+    hold: bool,
+    /// The written span, for firing hooks at commit.
+    addr: u16,
+    len: u16,
+}
+
+/// Stateless single-shot dispatcher. Holds only borrowed shared state, the
+/// HOLD-write staging buffer, and the pending-write slot -- no per-frame
+/// reassembly; each [`Dispatch::dispatch`] call carries its whole payload.
+pub struct Dispatcher<'a> {
+    shared: &'a Shared,
+    staged: &'a mut StagedWrites,
+    pending: &'a mut Option<PendingWrite>,
+}
+
+impl<'a> Dispatcher<'a> {
+    pub(crate) fn new(
+        shared: &'a Shared,
+        staged: &'a mut StagedWrites,
+        pending: &'a mut Option<PendingWrite>,
+    ) -> Self {
+        Self {
+            shared,
+            staged,
+            pending,
+        }
+    }
+
+    /// Discard a pending write left dangling by a frame that died before its
+    /// CRC verdict (the bus has no dispatcher in the break ISR, so cleanup is
+    /// lazy). MUST run before any path that reads the staging buffer from the
+    /// zero watermark -- otherwise a real COMMIT would apply the phantom bytes.
+    fn revert_dangling(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            self.staged.revert_to(&pending.snap);
+        }
+    }
+
+    /// Device-level ALERT bit: set on every status while the alarm register is
+    /// nonzero (sec 5.3 layer 3).
+    fn alert(&self) -> bool {
+        self.shared
+            .table
+            .with(|t| t.telemetry.fault.fault_flags != 0)
+    }
+}
+
+impl Dispatch for Dispatcher<'_> {
+    fn dispatch<R: Reply>(
+        &mut self,
+        req: Request<'_>,
+        ctx: RequestCtx,
+        reply: &mut R,
+    ) -> Dispatched {
+        // A prior frame that died without its verdict left a dangling pending
+        // write -- drop it here (see revert_dangling) before this frame reads
+        // or stages anything.
+        self.revert_dangling();
+        let alert = self.alert();
+        match req {
+            Request::Ping => {
+                self.ping(alert, &ctx, reply);
+                Dispatched::Done
+            }
+            Request::Read { addr, count } => {
+                self.read(alert, &ctx, addr, count, reply);
+                Dispatched::Done
+            }
+            Request::ReadProfile { slot } => {
+                self.read_profile(alert, &ctx, slot, reply);
+                Dispatched::Done
+            }
+            Request::Write { addr, data, hold } => self.write(alert, &ctx, addr, data, hold, reply),
+            // Verdict-first ops (trait contract): the bus CRC-checked the
+            // frame before dispatching, so applying directly is sound.
+            Request::Commit => {
+                self.apply_commit(alert, &ctx, reply);
+                Dispatched::Done
+            }
+            Request::Enumerate { prefix_len, prefix } => {
+                self.enumerate(alert, &ctx, prefix_len, &prefix, reply);
+                Dispatched::Done
+            }
+            Request::Assign { uid, new_id } => {
+                self.assign(alert, &ctx, &uid, new_id, reply);
+                Dispatched::Done
+            }
+            // sec 9.3: broadcast-only (decode enforces), so no ack precedes the
+            // train -- an ack's own break would count as a ruler mark.
+            Request::Calibrate { gap_us, gaps } => {
+                reply.begin_clock_cal(gap_us, gaps);
+                Dispatched::Done
+            }
+            Request::Mgmt { op, .. } => {
+                self.mgmt(alert, &ctx, op, reply);
+                Dispatched::Done
+            }
+            Request::Unsupported => {
+                self.instruction_error(alert, &ctx, reply);
+                Dispatched::Done
+            }
+        }
+    }
+
+    fn commit<R: Reply>(&mut self, reply: &mut R) {
+        let Some(pending) = self.pending.take() else {
+            return; // defensive: nothing pending
+        };
+        if pending.hold {
+            return; // held entries stay staged until a real COMMIT
+        }
+        self.shared.table.commit_from(self.staged, &pending.snap);
+        self.mark_dirty_if_persistent(pending.addr, pending.len);
+        let mut hooks = ControlTableHooks::new(reply);
+        self.shared
+            .table
+            .with(|t| t.dispatch_events(pending.addr, pending.len, &mut hooks));
+    }
+
+    fn revert(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            self.staged.revert_to(&pending.snap);
+        }
+    }
+}
+
+impl Dispatcher<'_> {
+    fn send<R: Reply>(reply: &mut R, status: Status<'_>) {
+        // TX overflow is a sizing bug, not a runtime error -- bench telemetry
+        // catches it at integration.
+        let _ = reply.send_status(status);
+    }
+
+    /// Empty-payload status gated on the reply contract (sec 5.3 layer 2).
+    fn ack<R: Reply>(alert: bool, ctx: &RequestCtx, result: Result<(), Error>, reply: &mut R) {
+        let code = match result {
+            Ok(()) => ResultCode::Ok,
+            Err(e) => error_to_result(e),
+        };
+        Self::ack_code(alert, ctx, code, reply);
+    }
+
+    /// As [`Self::ack`] with an explicit result code (the store's `hardware`
+    /// verdict has no `Error` mapping).
+    fn ack_code<R: Reply>(alert: bool, ctx: &RequestCtx, code: ResultCode, reply: &mut R) {
+        if !ctx.may_reply {
+            return;
+        }
+        Self::send(
+            reply,
+            Status {
+                result: code,
+                alert,
+                data: &[],
+            },
+        );
+    }
+
+    /// sec 9.4 modified-since-save: a committed span landing in CONFIG or
+    /// PROFILE sets the telemetry dirty bit (a successful SAVE clears it).
+    fn mark_dirty_if_persistent(&self, addr: u16, len: u16) {
+        const CONFIG_END: u16 = CONFIG_BASE_ADDR + CONFIG_REGION_SIZE;
+        const PROFILE_END: u16 = PROFILE_BASE_ADDR + PROFILE_REGION_SIZE;
+        let end = addr.saturating_add(len);
+        // CONFIG starts at 0, so "before its end" is its whole intersect test.
+        let hits = addr < CONFIG_END || (addr < PROFILE_END && end > PROFILE_BASE_ADDR);
+        if hits {
+            self.shared
+                .table
+                .with_mut(|t| t.telemetry.fault.config_dirty = 1);
+        }
+    }
+
+    fn instruction_error<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, reply: &mut R) {
+        if !ctx.may_reply {
+            return;
+        }
+        Self::send(
+            reply,
+            Status {
+                result: ResultCode::Instruction,
+                alert,
+                data: &[],
+            },
+        );
+    }
+
+    fn ping<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, reply: &mut R) {
+        if !ctx.may_reply {
+            return;
+        }
+        // model_number + firmware_version are contiguous at the identity base:
+        // reply straight from the table so the TX engine streams in place (a
+        // stack copy would force the slow copy-stage path).
+        let data = RegisterFile::read(
+            &self.shared.table,
+            crate::regions::config::addr::identity::MODEL_NUMBER,
+            3,
+        )
+        .unwrap_or(&[]);
+        Self::send(
+            reply,
+            Status {
+                result: ResultCode::Ok,
+                alert,
+                data,
+            },
+        );
+    }
+
+    fn read<R: Reply>(
+        &mut self,
+        alert: bool,
+        ctx: &RequestCtx,
+        addr: u16,
+        count: u16,
+        reply: &mut R,
+    ) {
+        if !ctx.may_reply {
+            return;
+        }
+        if count == 0 {
+            return Self::send(
+                reply,
+                Status {
+                    result: ResultCode::Range,
+                    alert,
+                    data: &[],
+                },
+            );
+        }
+        if count > MAX_PAYLOAD as u16 {
+            return Self::send(
+                reply,
+                Status {
+                    result: ResultCode::Limit,
+                    alert,
+                    data: &[],
+                },
+            );
+        }
+        match RegisterFile::read(&self.shared.table, addr, count) {
+            Ok(data) => Self::send(
+                reply,
+                Status {
+                    result: ResultCode::Ok,
+                    alert,
+                    data,
+                },
+            ),
+            Err(_) => Self::send(
+                reply,
+                Status {
+                    result: ResultCode::Range,
+                    alert,
+                    data: &[],
+                },
+            ),
+        }
+    }
+
+    /// PROFILE read (sec 5.2): resolve the slot's span words against the live
+    /// table and gather-send the concatenation. Errors are read-time (sec 5.3):
+    /// a bad slot index, an empty slot, or an out-of-bounds span is `range`;
+    /// a total past the frame ceiling is `limit`.
+    fn read_profile<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, slot: u8, reply: &mut R) {
+        if !ctx.may_reply {
+            return;
+        }
+        let nack = |reply: &mut R, result: ResultCode| {
+            Self::send(
+                reply,
+                Status {
+                    result,
+                    alert,
+                    data: &[],
+                },
+            )
+        };
+        let words = self
+            .shared
+            .table
+            .with(|t| t.profile.slot_words(slot).copied());
+        let Some(words) = words else {
+            return nack(reply, ResultCode::Range);
+        };
+        let mut spans: [&[u8]; GATHER_MAX] = [&[]; GATHER_MAX];
+        let mut n = 0;
+        let mut total: u16 = 0;
+        for w in words {
+            let Some((addr, count)) = crate::regions::profile::span_of(w) else {
+                continue; // disabled word: skipped, not a terminator (sec 5.2)
+            };
+            let Ok(data) = RegisterFile::read(&self.shared.table, addr, count) else {
+                return nack(reply, ResultCode::Range);
+            };
+            spans[n] = data;
+            n += 1;
+            total += count;
+        }
+        if n == 0 {
+            return nack(reply, ResultCode::Range);
+        }
+        if total > MAX_PAYLOAD as u16 {
+            return nack(reply, ResultCode::Limit);
+        }
+        let _ = reply.send_status_gather(ResultCode::Ok, alert, &spans[..n]);
+    }
+
+    /// Write, the spine way: validate + stage above a watermark, ack per the
+    /// reply contract, but leave the live table untouched until the verdict's
+    /// [`Dispatch::commit`]. A validation reject nacks with nothing staged
+    /// (`Done`, no commit owed); a staging-capacity overflow (held entries
+    /// filled the buffer -- a COMMIT drains it) nacks `Busy`, nothing staged.
+    fn write<R: Reply>(
+        &mut self,
+        alert: bool,
+        ctx: &RequestCtx,
+        addr: u16,
+        data: FrameBytes<'_>,
+        hold: bool,
+        reply: &mut R,
+    ) -> Dispatched {
+        let (head, tail) = data.segments();
+        let snap = self.staged.snapshot();
+        match self.shared.table.stage_split(addr, head, tail, self.staged) {
+            Ok(()) => {
+                Self::ack(alert, ctx, Ok(()), reply);
+                *self.pending = Some(PendingWrite {
+                    snap,
+                    hold,
+                    addr,
+                    len: data.len() as u16,
+                });
+                Dispatched::Pending
+            }
+            Err(Error::StagingFull) => {
+                if ctx.may_reply {
+                    Self::send(
+                        reply,
+                        Status {
+                            result: ResultCode::Busy,
+                            alert,
+                            data: &[],
+                        },
+                    );
+                }
+                Dispatched::Done
+            }
+            // Bounds / rule / lock reject: validate pushed nothing. Nack now;
+            // the error reply is sequenced iff the CRC passes.
+            Err(e) => {
+                Self::ack(alert, ctx, Err(e), reply);
+                Dispatched::Done
+            }
+        }
+    }
+
+    fn apply_commit<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, reply: &mut R) {
+        // Capture each entry's span before commit_staged clears the buffer, so
+        // hooks fire on the applied values (apply-then-events, mirroring write).
+        let mut spans: Vec<(u16, u16), STAGE_ENTRY_CAP> = Vec::new();
+        for (addr, data) in self.staged.iter_all() {
+            let _ = spans.push((addr, data.len() as u16));
+        }
+        self.shared.table.commit_staged(self.staged);
+        Self::ack(alert, ctx, Ok(()), reply);
+        let mut hooks = ControlTableHooks::new(reply);
+        for (addr, len) in spans {
+            self.mark_dirty_if_persistent(addr, len);
+            self.shared
+                .table
+                .with(|t| t.dispatch_events(addr, len, &mut hooks));
+        }
+    }
+
+    /// sec 9.2 ENUM: reply with the full UID iff ours begins with the queried
+    /// prefix. A mismatch stays silent -- on the broadcast wire, silence and
+    /// collision garbage are the host's two tree-descent signals, and a nack
+    /// would only manufacture collisions.
+    fn enumerate<R: Reply>(
+        &mut self,
+        alert: bool,
+        ctx: &RequestCtx,
+        prefix_len: u8,
+        prefix: &[u8; UID_LEN],
+        reply: &mut R,
+    ) {
+        if !ctx.may_reply {
+            return;
+        }
+        let uid = self.shared.uid();
+        if !uid_prefix_matches(uid, prefix_len, prefix) {
+            return;
+        }
+        Self::send(
+            reply,
+            Status {
+                result: ResultCode::Ok,
+                alert,
+                data: uid,
+            },
+        );
+    }
+
+    /// sec 9.2 ASSIGN: the servo whose UID matches takes the id -- applied
+    /// immediately (`set_id`, not the deferred `stage_id`) so the ack leaves
+    /// from the new id, and mirrored into the config ID register so a later
+    /// SAVE persists it (volatile until then). Non-matching servos stay
+    /// silent; the sole matching servo can nack without colliding.
+    fn assign<R: Reply>(
+        &mut self,
+        alert: bool,
+        ctx: &RequestCtx,
+        uid: &[u8; UID_LEN],
+        new_id: u8,
+        reply: &mut R,
+    ) {
+        if uid != self.shared.uid() {
+            return;
+        }
+        if Id::try_unicast(new_id).is_none() {
+            let e = Error::ValidationError(control_table::ValidationKind::Compare);
+            return Self::ack(alert, ctx, Err(e), reply);
+        }
+        self.shared.table.with_mut(|t| {
+            t.config.comms.id = new_id;
+            t.telemetry.fault.config_dirty = 1;
+        });
+        reply.set_id(new_id);
+        Self::ack(alert, ctx, Ok(()), reply);
+    }
+
+    fn mgmt<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, op: MgmtOp, reply: &mut R) {
+        match op {
+            MgmtOp::Save => self.save(alert, ctx, reply),
+            MgmtOp::Factory => self.factory(alert, ctx, reply),
+            MgmtOp::Reboot => {
+                Self::ack(alert, ctx, Ok(()), reply);
+                let mode = self.shared.table.with(|t| t.control.system.boot_mode);
+                reply.stage_reboot(mode);
+            }
+            // ENUM/ASSIGN/CAL decode to dedicated Request variants; one
+            // arriving Mgmt-wrapped is answered like any unknown op.
+            MgmtOp::Enum | MgmtOp::Assign | MgmtOp::Cal => {
+                self.instruction_error(alert, ctx, reply)
+            }
+        }
+    }
+
+    /// sec 9.4 SAVE -- the only flash-touching operation. Torque gates it (the
+    /// ms-scale program stall is the mid-motion hazard, not the data), and
+    /// the ack leaves AFTER the store returns: ack == durable, and a failed
+    /// program surfaces as `hardware` instead of a lie.
+    fn save<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, reply: &mut R) {
+        if self
+            .shared
+            .table
+            .with(|t| t.control.lifecycle.torque_enable)
+        {
+            return Self::ack(alert, ctx, Err(Error::AccessError), reply);
+        }
+        let saved = self.persist_table();
+        let code = match saved {
+            Ok(()) => {
+                self.shared
+                    .table
+                    .with_mut(|t| t.telemetry.fault.config_dirty = 0);
+                ResultCode::Ok
+            }
+            Err(StoreError) => ResultCode::Hardware,
+        };
+        Self::ack_code(alert, ctx, code, reply);
+    }
+
+    /// Stream the persisted regions into the store -- the slices borrow the
+    /// table in place (no staging copy, sec 9.4); blocking for the erase +
+    /// program duration.
+    fn persist_table(&self) -> Result<(), StoreError> {
+        let store = self.shared.store().ok_or(StoreError)?;
+        // Bounded by the region consts -- the reads cannot fail; the fallback
+        // keeps the no-panic contract.
+        let config: &[u8; CONFIG_LEN] =
+            RegisterFile::read(&self.shared.table, CONFIG_BASE_ADDR, CONFIG_REGION_SIZE)
+                .ok()
+                .and_then(|s| s.try_into().ok())
+                .ok_or(StoreError)?;
+        let profile: &[u8; PROFILE_LEN] =
+            RegisterFile::read(&self.shared.table, PROFILE_BASE_ADDR, PROFILE_REGION_SIZE)
+                .ok()
+                .and_then(|s| s.try_into().ok())
+                .ok_or(StoreError)?;
+        store.save(config, profile)
+    }
+
+    /// sec 9.5 FACTORY: wipe both saved slots, ack, then stage the reboot that
+    /// re-seeds board defaults -- the erased store IS the factory state.
+    /// Same torque gate as SAVE (erase is the same stall class, and it ends
+    /// in a reboot); a failed wipe nacks `hardware` and does NOT reboot.
+    fn factory<R: Reply>(&mut self, alert: bool, ctx: &RequestCtx, reply: &mut R) {
+        if self
+            .shared
+            .table
+            .with(|t| t.control.lifecycle.torque_enable)
+        {
+            return Self::ack(alert, ctx, Err(Error::AccessError), reply);
+        }
+        let wiped = self.shared.store().ok_or(StoreError).and_then(|s| s.wipe());
+        match wiped {
+            Ok(()) => {
+                Self::ack(alert, ctx, Ok(()), reply);
+                let mode = self.shared.table.with(|t| t.control.system.boot_mode);
+                reply.stage_reboot(mode);
+            }
+            Err(StoreError) => Self::ack_code(alert, ctx, ResultCode::Hardware, reply),
+        }
+    }
+}

--- a/firmware/lib/core/src/services/bus/mod.rs
+++ b/firmware/lib/core/src/services/bus/mod.rs
@@ -1,0 +1,11 @@
+mod dispatch;
+mod session;
+
+#[cfg(test)]
+mod tests;
+
+pub use dispatch::Dispatcher;
+pub use session::Session;
+
+#[cfg(test)]
+pub(crate) use dispatch::PendingWrite;

--- a/firmware/lib/core/src/services/bus/session.rs
+++ b/firmware/lib/core/src/services/bus/session.rs
@@ -1,0 +1,34 @@
+use control_table::StagedWrites;
+
+use crate::Shared;
+
+use super::dispatch::{Dispatcher, PendingWrite};
+
+/// Per-servo dispatch session: owns the HOLD-write staging buffer that spans
+/// a WRITE+HOLD ... COMMIT sequence, plus the pending-write slot (the one write
+/// staged ahead of its CRC verdict -- the dispatch spine). Both outlive the
+/// [`Dispatcher`], which the bus rebuilds each wake. The bus driver holds one
+/// and asks it for a [`Dispatcher`] each time it has a decoded request to run.
+pub struct Session {
+    staged: StagedWrites,
+    pending: Option<PendingWrite>,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        Self {
+            staged: StagedWrites::new(),
+            pending: None,
+        }
+    }
+
+    pub fn dispatcher<'a>(&'a mut self, shared: &'a Shared) -> Dispatcher<'a> {
+        Dispatcher::new(shared, &mut self.staged, &mut self.pending)
+    }
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/firmware/lib/core/src/services/bus/tests/mod.rs
+++ b/firmware/lib/core/src/services/bus/tests/mod.rs
@@ -1,0 +1,1282 @@
+//! Request-level spec tests for the single-shot [`Dispatcher`]. Each case
+//! drives one decoded [`Request`] with a recording [`FakeReply`] and asserts on
+//! the decoded reply shape (result / alert / data) plus any staged side effect.
+
+use heapless::Vec;
+
+use osc_protocol::FrameBytes;
+use osc_protocol::wire::{MgmtOp, ResultCode};
+
+use crate::regions::CONTROL_BASE_ADDR;
+use crate::regions::config::BaudRate;
+use crate::services::bus::Dispatcher;
+use crate::traits::{Dispatch, Dispatched, Reply, Request, RequestCtx, SendError, Status};
+use crate::{BootMode, RegionStorage, Shared, StagedWrites};
+
+/// One recorded `send_status` call.
+struct Sent {
+    result: ResultCode,
+    alert: bool,
+    data: Vec<u8, 256>,
+}
+
+struct FakeReply {
+    sends: Vec<Sent, 8>,
+    /// Span count of the last `send_status_gather` (0 = none seen).
+    gather_spans: usize,
+    staged_id: Option<u8>,
+    /// `set_id` value, plus the send count at that instant -- ASSIGN must
+    /// apply the id BEFORE its ack so the ack leaves from the new id (sec 9.2).
+    set_id: Option<(u8, usize)>,
+    staged_baud: Option<BaudRate>,
+    response_deadline: Option<u16>,
+    reboot: Option<BootMode>,
+    clock_cal: Option<(u16, u8)>,
+}
+
+impl FakeReply {
+    fn new() -> Self {
+        Self {
+            sends: Vec::new(),
+            gather_spans: 0,
+            staged_id: None,
+            set_id: None,
+            staged_baud: None,
+            response_deadline: None,
+            reboot: None,
+            clock_cal: None,
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.sends.len()
+    }
+
+    fn last(&self) -> &Sent {
+        self.sends.last().expect("a status was sent")
+    }
+}
+
+impl Reply for FakeReply {
+    fn send_status(&mut self, status: Status<'_>) -> Result<(), SendError> {
+        let mut data = Vec::new();
+        data.extend_from_slice(status.data)
+            .map_err(|_| SendError::Overflow)?;
+        self.sends
+            .push(Sent {
+                result: status.result,
+                alert: status.alert,
+                data,
+            })
+            .map_err(|_| SendError::Overflow)?;
+        Ok(())
+    }
+
+    fn send_status_gather(
+        &mut self,
+        result: ResultCode,
+        alert: bool,
+        spans: &[&[u8]],
+    ) -> Result<(), SendError> {
+        let mut data = Vec::new();
+        for s in spans {
+            data.extend_from_slice(s).map_err(|_| SendError::Overflow)?;
+        }
+        self.gather_spans = spans.len();
+        self.sends
+            .push(Sent {
+                result,
+                alert,
+                data,
+            })
+            .map_err(|_| SendError::Overflow)?;
+        Ok(())
+    }
+
+    fn stage_id(&mut self, id: u8) {
+        self.staged_id = Some(id);
+    }
+
+    fn set_id(&mut self, id: u8) {
+        self.set_id = Some((id, self.sends.len()));
+    }
+
+    fn stage_baud(&mut self, baud: BaudRate) {
+        self.staged_baud = Some(baud);
+    }
+
+    fn set_response_deadline(&mut self, us: u16) {
+        self.response_deadline = Some(us);
+    }
+
+    fn stage_reboot(&mut self, mode: BootMode) {
+        self.reboot = Some(mode);
+    }
+
+    fn begin_clock_cal(&mut self, gap_us: u16, gaps: u8) {
+        self.clock_cal = Some((gap_us, gaps));
+    }
+}
+
+/// Dispatch one request and deliver a PASS verdict -- the common whole-exchange
+/// shape (dispatch stages effects; the verdict commit promotes a staged table
+/// effect, exactly as the bus does after a clean CRC).
+fn go(shared: &Shared, staged: &mut StagedWrites, req: Request<'_>, may_reply: bool) -> FakeReply {
+    let mut reply = FakeReply::new();
+    let mut pending = None;
+    let mut d = Dispatcher::new(shared, staged, &mut pending);
+    if matches!(
+        d.dispatch(req, RequestCtx { may_reply }, &mut reply),
+        Dispatched::Pending
+    ) {
+        d.commit(&mut reply);
+    }
+    reply
+}
+
+fn enable_torque(shared: &Shared) {
+    shared
+        .table
+        .with_mut(|t| t.control.lifecycle.torque_enable = true);
+}
+
+// --- Ping -----------------------------------------------------------------
+
+#[test]
+fn ping_replies_model_and_firmware() {
+    let shared = Shared::new();
+    shared.table.with_mut(|t| {
+        t.config.identity.model_number = 0x1234;
+        t.config.identity.firmware_version = 0x56;
+    });
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::Ping, true);
+    assert_eq!(reply.count(), 1);
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(&reply.last().data[..], &[0x34, 0x12, 0x56]);
+}
+
+#[test]
+fn ping_silent_when_may_reply_false() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::Ping, false);
+    assert_eq!(reply.count(), 0);
+}
+
+// --- Read -----------------------------------------------------------------
+
+#[test]
+fn read_returns_table_slice() {
+    let shared = Shared::new();
+    shared
+        .table
+        .with_mut(|t| t.config.identity.model_number = 0xABCD);
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Read { addr: 0, count: 2 },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(&reply.last().data[..], &[0xCD, 0xAB]);
+}
+
+#[test]
+fn read_count_zero_rejects_range() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Read { addr: 0, count: 0 },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Range);
+    assert!(reply.last().data.is_empty());
+}
+
+#[test]
+fn read_odd_addr_serves_bytes() {
+    // sec 5: any read address is legal -- odd-addressed spans stage through the
+    // chip CRC provider's copy path (sec 3.2); dispatch is parity-blind.
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Read { addr: 1, count: 2 },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(reply.last().data.len(), 2);
+}
+
+#[test]
+fn read_over_ceiling_rejects_limit() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Read {
+            addr: 0,
+            count: 253,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Limit);
+}
+
+#[test]
+fn read_out_of_bounds_rejects_range() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Read {
+            addr: 0xFFFE,
+            count: 1,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Range);
+}
+
+#[test]
+fn read_silent_when_may_reply_false() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Read { addr: 0, count: 2 },
+        false,
+    );
+    assert_eq!(reply.count(), 0);
+}
+
+// --- Profile read (sec 5.2) ---------------------------------------------------
+
+use crate::regions::profile::span_word;
+
+/// Slot 0 -> two spans: model_number (2 B at 0x000) and comms id (1 B).
+fn seed_profile_slot0(shared: &Shared) {
+    use crate::regions::config::addr::comms::ID;
+    shared.table.with_mut(|t| {
+        t.config.identity.model_number = 0xABCD;
+        t.config.comms.id = 7;
+        t.profile.slots.words[0] = span_word(0, 2);
+        t.profile.slots.words[1] = span_word(ID, 1);
+    });
+}
+
+#[test]
+fn profile_read_gathers_spans_in_order() {
+    let shared = Shared::new();
+    seed_profile_slot0(&shared);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::ReadProfile { slot: 0 }, true);
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(&reply.last().data[..], &[0xCD, 0xAB, 7]);
+    assert_eq!(reply.gather_spans, 2);
+}
+
+#[test]
+fn profile_read_skips_disabled_words() {
+    let shared = Shared::new();
+    shared.table.with_mut(|t| {
+        t.config.identity.model_number = 0xABCD;
+        // Hole at word 0 and word 2: disabled words are skipped, not
+        // terminators (sec 5.2).
+        t.profile.slots.words[1] = span_word(0, 1);
+        t.profile.slots.words[3] = span_word(1, 1);
+    });
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::ReadProfile { slot: 0 }, true);
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(&reply.last().data[..], &[0xCD, 0xAB]);
+    assert_eq!(reply.gather_spans, 2);
+}
+
+#[test]
+fn profile_read_bad_slot_rejects_range() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::ReadProfile { slot: 4 }, true);
+    assert_eq!(reply.last().result, ResultCode::Range);
+    assert!(reply.last().data.is_empty());
+}
+
+#[test]
+fn profile_read_empty_slot_rejects_range() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::ReadProfile { slot: 1 }, true);
+    assert_eq!(reply.last().result, ResultCode::Range);
+}
+
+#[test]
+fn profile_read_oob_span_rejects_range() {
+    let shared = Shared::new();
+    // addr 1020 + count 8 overruns the 1024 B table.
+    shared
+        .table
+        .with_mut(|t| t.profile.slots.words[0] = span_word(1020, 8));
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::ReadProfile { slot: 0 }, true);
+    assert_eq!(reply.last().result, ResultCode::Range);
+}
+
+#[test]
+fn profile_read_over_ceiling_rejects_limit() {
+    let shared = Shared::new();
+    // 5 x 63 B = 315 B > MAX_PAYLOAD.
+    shared.table.with_mut(|t| {
+        for w in 0..5 {
+            t.profile.slots.words[w] = span_word(0, 63);
+        }
+    });
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::ReadProfile { slot: 0 }, true);
+    assert_eq!(reply.last().result, ResultCode::Limit);
+}
+
+#[test]
+fn profile_read_silent_when_may_reply_false() {
+    let shared = Shared::new();
+    seed_profile_slot0(&shared);
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::ReadProfile { slot: 0 },
+        false,
+    );
+    assert_eq!(reply.count(), 0);
+}
+
+// --- Write ----------------------------------------------------------------
+
+#[test]
+fn write_acks_ok_and_mutates() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: CONTROL_BASE_ADDR,
+            data: FrameBytes::from(&[1][..]),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert!(reply.last().data.is_empty());
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn write_validation_reject_maps_to_validation() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    // 2 is outside a bool field's allowed {0, 1} -- a field-rule rejection.
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: CONTROL_BASE_ADDR,
+            data: FrameBytes::from(&[2][..]),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Validation);
+}
+
+/// osc separates write from persistence (sec 9.4): config writes are never
+/// torque-gated -- only MGMT SAVE is.
+#[test]
+fn write_config_allowed_with_torque_on() {
+    use crate::regions::config::addr::comms::ID;
+    let shared = Shared::new();
+    enable_torque(&shared);
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: ID,
+            data: FrameBytes::from(&[5][..]),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(shared.table.with(|t| t.config.comms.id), 5);
+    assert_eq!(reply.staged_id, Some(5));
+}
+
+#[test]
+fn write_applies_even_when_may_reply_false() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: CONTROL_BASE_ADDR,
+            data: FrameBytes::from(&[1][..]),
+            hold: false,
+        },
+        false,
+    );
+    assert_eq!(reply.count(), 0);
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn write_id_stages_via_reply() {
+    use crate::regions::config::addr::comms::ID;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: ID,
+            data: FrameBytes::from(&[42][..]),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(reply.staged_id, Some(42));
+}
+
+#[test]
+fn write_baud_stages_via_reply() {
+    use crate::regions::config::addr::comms::BAUD_RATE_IDX;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: BAUD_RATE_IDX,
+            data: FrameBytes::from(&[BaudRate::B2000000 as u8][..]),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(reply.staged_baud, Some(BaudRate::B2000000));
+}
+
+#[test]
+fn write_response_deadline_sets_via_reply() {
+    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: RESPONSE_DEADLINE_US,
+            data: FrameBytes::from(&200u16.to_le_bytes()[..]),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(reply.response_deadline, Some(200));
+}
+
+// --- Hold write + commit --------------------------------------------------
+
+#[test]
+fn hold_write_stages_without_touching_live_table() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: CONTROL_BASE_ADDR,
+            data: FrameBytes::from(&[1][..]),
+            hold: true,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert!(!shared.table.with(|t| t.control.lifecycle.torque_enable));
+
+    let reply = go(&shared, &mut staged, Request::Commit, true);
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn commit_silent_when_may_reply_false() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: CONTROL_BASE_ADDR,
+            data: FrameBytes::from(&[1][..]),
+            hold: true,
+        },
+        false,
+    );
+    let reply = go(&shared, &mut staged, Request::Commit, false);
+    assert_eq!(reply.count(), 0);
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+// --- Mgmt -----------------------------------------------------------------
+
+#[test]
+fn mgmt_reboot_acks_and_stages_boot_mode() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Mgmt {
+            op: MgmtOp::Reboot,
+            args: FrameBytes::from(&[][..]),
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert!(reply.last().data.is_empty());
+    assert_eq!(reply.reboot, Some(BootMode::App));
+}
+
+#[test]
+fn mgmt_reboot_stages_without_ack_when_silent() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Mgmt {
+            op: MgmtOp::Reboot,
+            args: FrameBytes::from(&[][..]),
+        },
+        false,
+    );
+    assert_eq!(reply.count(), 0);
+    assert_eq!(reply.reboot, Some(BootMode::App));
+}
+
+#[test]
+fn mgmt_wrapped_enum_assign_reply_instruction() {
+    // ENUM/ASSIGN decode to dedicated Request variants; the Mgmt-wrapped
+    // form is a bus bug, answered like any unknown op.
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    for op in [MgmtOp::Enum, MgmtOp::Assign] {
+        let reply = go(
+            &shared,
+            &mut staged,
+            Request::Mgmt {
+                op,
+                args: FrameBytes::from(&[][..]),
+            },
+            true,
+        );
+        assert_eq!(reply.last().result, ResultCode::Instruction);
+    }
+}
+
+// --- Save / Factory (sec 9.4/sec 9.5) ---------------------------------------------
+
+use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+
+use crate::persist::{CONFIG_LEN, ConfigStore, PROFILE_LEN, StoreError};
+
+/// Atomics-only recording store (these tests are no_std): counts calls,
+/// fingerprints the saved bytes by CRC, arms failure via `fail`.
+struct FakeStore {
+    saves: AtomicUsize,
+    wipes: AtomicUsize,
+    fail: AtomicBool,
+    saved_crc: AtomicU32,
+}
+
+impl FakeStore {
+    const fn new() -> Self {
+        Self {
+            saves: AtomicUsize::new(0),
+            wipes: AtomicUsize::new(0),
+            fail: AtomicBool::new(false),
+            saved_crc: AtomicU32::new(0),
+        }
+    }
+}
+
+impl ConfigStore for FakeStore {
+    fn save(
+        &self,
+        config: &[u8; CONFIG_LEN],
+        profile: &[u8; PROFILE_LEN],
+    ) -> Result<(), StoreError> {
+        if self.fail.load(Ordering::Relaxed) {
+            return Err(StoreError);
+        }
+        let crc = osc_protocol::crc::osc_crc_continue(osc_protocol::crc::osc_crc(config), profile);
+        self.saved_crc.store(crc as u32, Ordering::Relaxed);
+        self.saves.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn wipe(&self) -> Result<(), StoreError> {
+        if self.fail.load(Ordering::Relaxed) {
+            return Err(StoreError);
+        }
+        self.wipes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+fn mgmt_req(op: MgmtOp) -> Request<'static> {
+    Request::Mgmt {
+        op,
+        args: FrameBytes::from(&[][..]),
+    }
+}
+
+fn dirty(shared: &Shared) -> u8 {
+    shared.table.with(|t| t.telemetry.fault.config_dirty)
+}
+
+/// CRC fingerprint of the live persisted regions, mirroring FakeStore::save.
+fn table_crc(shared: &Shared) -> u32 {
+    use crate::regions::{
+        CONFIG_BASE_ADDR, CONFIG_REGION_SIZE, PROFILE_BASE_ADDR, PROFILE_REGION_SIZE,
+    };
+    use control_table::RegisterFile;
+    let config = RegisterFile::read(&shared.table, CONFIG_BASE_ADDR, CONFIG_REGION_SIZE).unwrap();
+    let profile =
+        RegisterFile::read(&shared.table, PROFILE_BASE_ADDR, PROFILE_REGION_SIZE).unwrap();
+    osc_protocol::crc::osc_crc_continue(osc_protocol::crc::osc_crc(config), profile) as u32
+}
+
+fn write_at(shared: &Shared, staged: &mut StagedWrites, addr: u16, data: &[u8]) {
+    let reply = go(
+        shared,
+        staged,
+        Request::Write {
+            addr,
+            data: FrameBytes::from(data),
+            hold: false,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+}
+
+#[test]
+fn save_streams_the_table_and_acks_after() {
+    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    static STORE: FakeStore = FakeStore::new();
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    let mut staged = StagedWrites::new();
+    write_at(
+        &shared,
+        &mut staged,
+        RESPONSE_DEADLINE_US,
+        &200u16.to_le_bytes(),
+    );
+    assert_eq!(dirty(&shared), 1, "config write marks modified-since-save");
+
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Save), true);
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert!(reply.last().data.is_empty());
+    assert_eq!(STORE.saves.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        STORE.saved_crc.load(Ordering::Relaxed),
+        table_crc(&shared),
+        "the saved bytes are the live table's persisted regions"
+    );
+    assert_eq!(dirty(&shared), 0, "a successful SAVE clears the dirty bit");
+}
+
+#[test]
+fn save_with_torque_on_nacks_access() {
+    static STORE: FakeStore = FakeStore::new();
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    enable_torque(&shared);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Save), true);
+    assert_eq!(reply.last().result, ResultCode::Access);
+    assert_eq!(STORE.saves.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn save_store_failure_nacks_hardware_and_stays_dirty() {
+    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    static STORE: FakeStore = FakeStore::new();
+    STORE.fail.store(true, Ordering::Relaxed);
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    let mut staged = StagedWrites::new();
+    write_at(
+        &shared,
+        &mut staged,
+        RESPONSE_DEADLINE_US,
+        &200u16.to_le_bytes(),
+    );
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Save), true);
+    assert_eq!(reply.last().result, ResultCode::Hardware);
+    assert_eq!(dirty(&shared), 1);
+}
+
+#[test]
+fn save_without_store_nacks_hardware() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Save), true);
+    assert_eq!(reply.last().result, ResultCode::Hardware);
+}
+
+#[test]
+fn noreply_save_still_saves() {
+    static STORE: FakeStore = FakeStore::new();
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Save), false);
+    assert_eq!(reply.count(), 0);
+    assert_eq!(STORE.saves.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn factory_wipes_acks_and_stages_reboot() {
+    static STORE: FakeStore = FakeStore::new();
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Factory), true);
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(STORE.wipes.load(Ordering::Relaxed), 1);
+    assert_eq!(reply.reboot, Some(BootMode::App));
+}
+
+#[test]
+fn factory_with_torque_on_nacks_access() {
+    static STORE: FakeStore = FakeStore::new();
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    enable_torque(&shared);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Factory), true);
+    assert_eq!(reply.last().result, ResultCode::Access);
+    assert_eq!(STORE.wipes.load(Ordering::Relaxed), 0);
+    assert_eq!(reply.reboot, None);
+}
+
+#[test]
+fn factory_wipe_failure_nacks_hardware_without_reboot() {
+    static STORE: FakeStore = FakeStore::new();
+    STORE.fail.store(true, Ordering::Relaxed);
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, mgmt_req(MgmtOp::Factory), true);
+    assert_eq!(reply.last().result, ResultCode::Hardware);
+    assert_eq!(reply.reboot, None);
+}
+
+#[test]
+fn dirty_bit_tracks_persistent_regions_only() {
+    use crate::regions::PROFILE_BASE_ADDR;
+    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    static STORE: FakeStore = FakeStore::new();
+    let shared = Shared::new();
+    shared.seed_store(&STORE);
+    let mut staged = StagedWrites::new();
+    assert_eq!(dirty(&shared), 0, "boot state is clean");
+
+    write_at(&shared, &mut staged, CONTROL_BASE_ADDR, &[1]);
+    assert_eq!(dirty(&shared), 0, "volatile CONTROL writes don't mark");
+    shared
+        .table
+        .with_mut(|t| t.control.lifecycle.torque_enable = false);
+
+    write_at(
+        &shared,
+        &mut staged,
+        RESPONSE_DEADLINE_US,
+        &200u16.to_le_bytes(),
+    );
+    assert_eq!(dirty(&shared), 1);
+    go(&shared, &mut staged, mgmt_req(MgmtOp::Save), true);
+    assert_eq!(dirty(&shared), 0);
+
+    write_at(&shared, &mut staged, PROFILE_BASE_ADDR, &[0x41, 0x00]);
+    assert_eq!(dirty(&shared), 1, "PROFILE writes mark too");
+}
+
+#[test]
+fn held_write_marks_dirty_at_commit_not_before() {
+    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Write {
+            addr: RESPONSE_DEADLINE_US,
+            data: FrameBytes::from(&200u16.to_le_bytes()[..]),
+            hold: true,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    assert_eq!(dirty(&shared), 0, "held entries aren't applied yet");
+    go(&shared, &mut staged, Request::Commit, true);
+    assert_eq!(dirty(&shared), 1);
+}
+
+// --- Enumerate / Assign (sec 9.2) ----------------------------------------------
+
+const UID: [u8; 16] = [0xA5, 0x5A, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0xF0];
+
+fn shared_with_uid() -> Shared {
+    let shared = Shared::new();
+    shared.seed_uid(UID);
+    shared
+}
+
+fn prefix_of(bits: u8) -> [u8; 16] {
+    // A prefix that matches UID for any length: UID itself, masked by parse
+    // semantics (the dispatcher only compares the first `bits` bits).
+    let mut p = UID;
+    if bits < 128 {
+        let full = (bits / 8) as usize;
+        for b in p.iter_mut().skip(full + 1) {
+            *b = 0;
+        }
+        p[full] &= (1u8 << (bits % 8)).wrapping_sub(1);
+    }
+    p
+}
+
+#[test]
+fn enumerate_matching_prefix_replies_full_uid() {
+    let shared = shared_with_uid();
+    let mut staged = StagedWrites::new();
+    for bits in [0u8, 1, 8, 127, 128] {
+        let reply = go(
+            &shared,
+            &mut staged,
+            Request::Enumerate {
+                prefix_len: bits,
+                prefix: prefix_of(bits),
+            },
+            true,
+        );
+        assert_eq!(reply.last().result, ResultCode::Ok, "prefix_len {bits}");
+        assert_eq!(reply.last().data, UID, "prefix_len {bits}");
+    }
+}
+
+#[test]
+fn enumerate_mismatch_is_silent() {
+    let shared = shared_with_uid();
+    let mut staged = StagedWrites::new();
+    let mut prefix = prefix_of(1);
+    prefix[0] ^= 1; // flip the queried bit
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Enumerate {
+            prefix_len: 1,
+            prefix,
+        },
+        true,
+    );
+    assert_eq!(reply.count(), 0, "a mismatch draws no reply, not a nack");
+}
+
+#[test]
+fn assign_matching_uid_sets_id_before_ack() {
+    let shared = shared_with_uid();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Assign {
+            uid: UID,
+            new_id: 42,
+        },
+        true,
+    );
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    // The id applies immediately and BEFORE the ack stages, so the ack
+    // already leaves from the new id (sec 9.2).
+    assert_eq!(reply.set_id, Some((42, 0)));
+    assert_eq!(reply.staged_id, None, "immediate, not deferred");
+    // Mirrored into the config table so a later SAVE persists it -- which
+    // also marks modified-since-save (sec 9.4).
+    assert_eq!(shared.table.with(|t| t.config.comms.id), 42);
+    assert_eq!(dirty(&shared), 1);
+}
+
+#[test]
+fn assign_foreign_uid_is_silent_and_inert() {
+    let shared = shared_with_uid();
+    let mut staged = StagedWrites::new();
+    let before = shared.table.with(|t| t.config.comms.id);
+    let mut uid = UID;
+    uid[15] ^= 0x80;
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Assign { uid, new_id: 42 },
+        true,
+    );
+    assert_eq!(reply.count(), 0);
+    assert_eq!(reply.set_id, None);
+    assert_eq!(shared.table.with(|t| t.config.comms.id), before);
+}
+
+#[test]
+fn assign_invalid_id_nacks_validation() {
+    let shared = shared_with_uid();
+    let mut staged = StagedWrites::new();
+    for bad in [0u8, 250, 254, 255] {
+        let reply = go(
+            &shared,
+            &mut staged,
+            Request::Assign {
+                uid: UID,
+                new_id: bad,
+            },
+            true,
+        );
+        assert_eq!(reply.last().result, ResultCode::Validation, "id {bad}");
+        assert_eq!(reply.set_id, None, "id {bad}");
+    }
+}
+
+#[test]
+fn assign_noreply_still_applies() {
+    let shared = shared_with_uid();
+    let mut staged = StagedWrites::new();
+    let reply = go(
+        &shared,
+        &mut staged,
+        Request::Assign {
+            uid: UID,
+            new_id: 9,
+        },
+        false,
+    );
+    assert_eq!(reply.count(), 0);
+    assert_eq!(reply.set_id, Some((9, 0)));
+    assert_eq!(shared.table.with(|t| t.config.comms.id), 9);
+}
+
+// --- Unsupported ----------------------------------------------------------
+
+#[test]
+fn unsupported_replies_instruction() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::Unsupported, true);
+    assert_eq!(reply.last().result, ResultCode::Instruction);
+}
+
+#[test]
+fn unsupported_silent_when_may_reply_false() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::Unsupported, false);
+    assert_eq!(reply.count(), 0);
+}
+
+// --- Alert bit ------------------------------------------------------------
+
+#[test]
+fn alert_bit_set_when_fault_flags_nonzero() {
+    let shared = Shared::new();
+    shared
+        .table
+        .with_mut(|t| t.telemetry.fault.fault_flags = 0x04);
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::Ping, true);
+    assert!(reply.last().alert);
+}
+
+#[test]
+fn alert_bit_clear_when_no_fault() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let reply = go(&shared, &mut staged, Request::Ping, true);
+    assert!(!reply.last().alert);
+}
+
+// --- The verdict gate (dispatch stages; commit/revert resolve) -------------
+
+use crate::regions::control::addr::lifecycle::GOAL_VELOCITY;
+
+fn write(addr: u16, data: &[u8], hold: bool) -> Request<'_> {
+    Request::Write {
+        addr,
+        data: FrameBytes::from(data),
+        hold,
+    }
+}
+
+/// A fresh dispatcher over the same session-owned `staged` + `pending` --
+/// mirrors the bus rebuilding one per wake.
+fn disp<'a>(
+    shared: &'a Shared,
+    staged: &'a mut StagedWrites,
+    pending: &'a mut Option<crate::services::bus::PendingWrite>,
+) -> Dispatcher<'a> {
+    Dispatcher::new(shared, staged, pending)
+}
+
+#[test]
+fn write_stages_then_commit_applies() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    let out = disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[1], false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(matches!(out, Dispatched::Pending));
+    assert_eq!(reply.last().result, ResultCode::Ok);
+    // Staged only -- the live table is untouched until the verdict commits.
+    assert!(!shared.table.with(|t| t.control.lifecycle.torque_enable));
+
+    disp(&shared, &mut staged, &mut pending).commit(&mut reply);
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+    assert!(pending.is_none());
+    assert!(
+        staged.is_empty(),
+        "a plain write clears its staging on commit"
+    );
+}
+
+#[test]
+fn write_reverts_on_fail_verdict() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    let out = disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[1], false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(matches!(out, Dispatched::Pending));
+
+    // CRC failed: revert -- the table and staging are byte-identical to before.
+    disp(&shared, &mut staged, &mut pending).revert();
+    assert!(pending.is_none());
+    assert!(staged.is_empty());
+    assert!(!shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn write_validation_reject_nacks_nothing_staged() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    // 2 is outside a bool field's allowed {0, 1}: validation reject.
+    let out = disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[2], false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(matches!(out, Dispatched::Done), "a reject owes no verdict");
+    assert_eq!(reply.last().result, ResultCode::Validation);
+    assert!(staged.is_empty());
+    assert!(pending.is_none());
+}
+
+#[test]
+fn write_staging_full_nacks_busy_nothing_staged() {
+    use control_table::STAGE_DATA_CAP;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    // Fill the staging data buffer to capacity (direct push bypasses validate).
+    staged
+        .push(CONTROL_BASE_ADDR, &[0u8; STAGE_DATA_CAP])
+        .unwrap();
+
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+    let out = disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[1], false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(matches!(out, Dispatched::Done));
+    // Held entries filled the buffer -- a COMMIT drains it, so Busy is honest.
+    assert_eq!(reply.last().result, ResultCode::Busy);
+    assert!(pending.is_none());
+    // Nothing staged on top: only the pre-existing filler entry remains.
+    assert_eq!(staged.iter_all().count(), 1);
+}
+
+#[test]
+fn dangling_pending_write_auto_reverts_on_next_dispatch() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    // Stage a write but never commit/revert (frame died with no verdict).
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[1], false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(pending.is_some());
+    assert!(!staged.is_empty());
+
+    // A following dispatch drops the dangling write before running.
+    let mut reply2 = FakeReply::new();
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        Request::Ping,
+        RequestCtx { may_reply: true },
+        &mut reply2,
+    );
+    assert!(pending.is_none());
+    assert!(staged.is_empty());
+    assert!(!shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn real_commit_after_dangling_write_applies_only_held_entries() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    // A HOLD write stages torque_enable=1 and gets its PASS verdict (the held
+    // entry persists across frames, awaiting COMMIT).
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[1], true),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    disp(&shared, &mut staged, &mut pending).commit(&mut reply);
+    // A write on top stages goal_velocity, then dies (dangling -- no verdict).
+    let gv = 5i32.to_le_bytes();
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        write(GOAL_VELOCITY, &gv, false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(pending.is_some());
+
+    // Real COMMIT auto-reverts the dangling write, then applies only the held
+    // torque_enable -- the phantom goal_velocity is gone.
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        Request::Commit,
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+    assert_eq!(shared.table.with(|t| t.control.lifecycle.goal_velocity), 0);
+}
+
+#[test]
+fn held_write_keeps_entries_through_its_verdict() {
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    let out = disp(&shared, &mut staged, &mut pending).dispatch(
+        write(CONTROL_BASE_ADDR, &[1], true),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(matches!(out, Dispatched::Pending));
+    assert_eq!(reply.last().result, ResultCode::Ok);
+
+    // CRC passed: a held write keeps its entry staged (it applies on COMMIT).
+    disp(&shared, &mut staged, &mut pending).commit(&mut reply);
+    assert!(pending.is_none());
+    assert!(
+        !staged.is_empty(),
+        "the held entry survives its own verdict"
+    );
+    assert!(!shared.table.with(|t| t.control.lifecycle.torque_enable));
+
+    // A real COMMIT lands it.
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        Request::Commit,
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn hooks_fire_on_write_commit() {
+    use crate::regions::config::addr::comms::ID;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        write(ID, &[42], false),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    // Hooks are deferred to the verdict -- nothing staged through the reply yet.
+    assert_eq!(reply.staged_id, None);
+
+    disp(&shared, &mut staged, &mut pending).commit(&mut reply);
+    assert_eq!(reply.staged_id, Some(42));
+}
+
+#[test]
+fn hooks_fire_on_real_commit() {
+    // A real COMMIT of a held hooked field fires its hook.
+    use crate::regions::config::addr::comms::ID;
+    let shared = Shared::new();
+    let mut staged = StagedWrites::new();
+    let mut pending = None;
+    let mut reply = FakeReply::new();
+
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        write(ID, &[42], true),
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert_eq!(reply.staged_id, None, "HOLD stages, no hook yet");
+    disp(&shared, &mut staged, &mut pending).commit(&mut reply);
+    assert_eq!(reply.staged_id, None, "held verdict defers to COMMIT");
+
+    disp(&shared, &mut staged, &mut pending).dispatch(
+        Request::Commit,
+        RequestCtx { may_reply: true },
+        &mut reply,
+    );
+    assert_eq!(reply.staged_id, Some(42), "COMMIT fires the deferred hook");
+}

--- a/firmware/lib/core/src/services/mod.rs
+++ b/firmware/lib/core/src/services/mod.rs
@@ -1,0 +1,3 @@
+pub mod bus;
+
+pub use bus::{Dispatcher, Session};

--- a/firmware/lib/core/src/shared.rs
+++ b/firmware/lib/core/src/shared.rs
@@ -1,0 +1,55 @@
+use core::cell::SyncUnsafeCell;
+
+use osc_protocol::wire::UID_LEN;
+
+use crate::ControlTableCell;
+use crate::persist::ConfigStore;
+
+#[repr(C)]
+pub struct Shared {
+    pub table: ControlTableCell,
+    /// The factory UID, silicon ID zero-padded to the 16-byte wire field
+    /// (osc-native sec 9.2) -- internal identity, not a table register; MGMT ENUM
+    /// is its only wire reader.
+    uid: SyncUnsafeCell<[u8; UID_LEN]>,
+    /// The sec 9.4 persistence store; MGMT SAVE/FACTORY are its only callers
+    /// (cold path -- `dyn` costs nothing that matters here).
+    store: SyncUnsafeCell<Option<&'static dyn ConfigStore>>,
+}
+
+#[allow(clippy::new_without_default)]
+impl Shared {
+    pub const fn new() -> Self {
+        Self {
+            table: ControlTableCell::new(),
+            uid: SyncUnsafeCell::new([0; UID_LEN]),
+            store: SyncUnsafeCell::new(None),
+        }
+    }
+
+    /// Seed the ESIG-derived UID. Bringup-only, pre-IRQ; sole writer (the
+    /// `seed_config_defaults` contract).
+    pub fn seed_uid(&self, uid: [u8; UID_LEN]) {
+        // SAFETY: see fn doc -- no reader exists before IRQs enable.
+        unsafe { *self.uid.get() = uid };
+    }
+
+    /// Stable-address borrow: ENUM replies stream straight from it (sec 4.2).
+    pub fn uid(&self) -> &[u8; UID_LEN] {
+        // SAFETY: written only by `seed_uid` pre-IRQ; read-only afterward.
+        unsafe { &*self.uid.get() }
+    }
+
+    /// Seed the persistence store. Bringup-only, pre-IRQ; sole writer (the
+    /// `seed_config_defaults` contract).
+    pub fn seed_store(&self, store: &'static dyn ConfigStore) {
+        // SAFETY: see fn doc -- no reader exists before IRQs enable.
+        unsafe { *self.store.get() = Some(store) };
+    }
+
+    /// The sec 9.4 store; `None` until seeded (dispatch answers `hardware`).
+    pub fn store(&self) -> Option<&'static dyn ConfigStore> {
+        // SAFETY: written only by `seed_store` pre-IRQ; read-only afterward.
+        unsafe { *self.store.get() }
+    }
+}

--- a/firmware/lib/core/src/traits/control.rs
+++ b/firmware/lib/core/src/traits/control.rs
@@ -1,0 +1,75 @@
+use osc_units::Effort;
+
+use crate::{ConversionVariables, Sample};
+
+/// What the kernel control loop reads from the board hardware.
+pub trait Sensors {
+    /// One full ADC/encoder frame, called from the kernel tick.
+    fn sample(&mut self, vars: &ConversionVariables) -> Sample;
+}
+
+/// What the kernel control loop writes to the motor driver.
+pub trait Motor {
+    fn write(&mut self, cmd: MotorCmd);
+}
+
+/// Bag of chip-side capabilities the control loop needs. Splits into
+/// disjoint sub-trait borrows so the kernel can hold both at once.
+pub trait ControlIo {
+    type Sensors: Sensors;
+    type Motor: Motor;
+
+    /// Servo-wide capability flags (e.g., HAS_MOTOR_ENCODER).
+    fn caps(&self) -> Capabilities {
+        Capabilities::default()
+    }
+    fn parts(&mut self) -> (&mut Self::Sensors, &mut Self::Motor);
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum MotorCmd {
+    /// `drv_en` LOW. Driver powered down; outputs hi-Z. Boot/fault state.
+    Disabled,
+    /// `drv_en` HIGH, both half-bridges hi-Z. Motor free-wheels.
+    Coast,
+    /// `drv_en` HIGH, both low-side FETs on. Short-circuit braking.
+    Brake,
+    /// `drv_en` HIGH, PWM drive with selectable off-window decay.
+    Drive { duty: Effort, decay: DecayMode },
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum DecayMode {
+    /// Off-window = COAST (idle leg LOW). Low EMI, near-zero avg current on DRV8212P.
+    Fast,
+    /// Off-window = BRAKE (idle leg HIGH). DRV8212P-correct for usable torque.
+    Slow,
+}
+
+bitflags::bitflags! {
+    /// Mirrors `capability_flags` in `ConfigIdentity`. Protocol-relevant only.
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct Capabilities: u32 {
+        const HAS_MOTOR_ENCODER = 1 << 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem::size_of;
+
+    #[test]
+    fn motor_cmd_stays_small() {
+        assert!(size_of::<MotorCmd>() <= 8, "got {}", size_of::<MotorCmd>());
+    }
+
+    #[test]
+    fn capabilities_compose() {
+        let none = Capabilities::default();
+        assert!(none.is_empty());
+        let with_enc = Capabilities::HAS_MOTOR_ENCODER;
+        assert!(with_enc.contains(Capabilities::HAS_MOTOR_ENCODER));
+        assert_eq!(with_enc.bits(), 1);
+    }
+}

--- a/firmware/lib/core/src/traits/mod.rs
+++ b/firmware/lib/core/src/traits/mod.rs
@@ -1,0 +1,19 @@
+//! One-stop surface for chip implementers.
+//!
+//! The chip-side board crate implements these traits to plug into the kernel
+//! control loop (`ControlIo`/`Sensors`/`Motor`) and the bus services layer
+//! (`Dispatch`/`Reply`). Associated boundary types are re-exported here so
+//! `use osc_core::traits::*` covers the full contract.
+
+mod control;
+mod services;
+
+pub use control::{Capabilities, ControlIo, DecayMode, Motor, MotorCmd, Sensors};
+pub use services::{
+    Dispatch, Dispatched, GATHER_MAX, Reply, Request, RequestCtx, SendError, Status,
+};
+
+// Boundary types defined elsewhere that callers of the traits need in scope.
+pub use crate::regions::BootMode;
+pub use crate::regions::config::ConfigDefaults;
+pub use crate::sample::{ConversionVariables, RawSamples, Sample};

--- a/firmware/lib/core/src/traits/services.rs
+++ b/firmware/lib/core/src/traits/services.rs
@@ -1,0 +1,144 @@
+use osc_protocol::FrameBytes;
+use osc_protocol::wire::{MgmtOp, ResultCode, UID_LEN};
+
+use crate::{BaudRate, BootMode};
+
+/// Reply-side runtime failure. Overflow is a sizing bug (reply exceeds the
+/// bus's staging buffer); Busy means a previous reply is still draining.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SendError {
+    Busy,
+    Overflow,
+}
+
+/// One encoded status reply, data-centric per driver-pattern sec 7.4: the bus
+/// derives all wire placement (frame layout, chain slot timing, PAD) from
+/// its cached request state; core hands only result + payload.
+/// `alert` mirrors the device-level alarm state (osc-native sec 5.3 layer 3).
+pub struct Status<'a> {
+    pub result: ResultCode,
+    pub alert: bool,
+    pub data: &'a [u8],
+}
+
+/// A decoded instruction addressed to this servo; addressing and group-op
+/// slot resolution already done by the bus. Core sees no wire bytes.
+pub enum Request<'a> {
+    Ping,
+    Read {
+        addr: u16,
+        count: u16,
+    },
+    /// READ/GREAD with the PROFILE flag: reply with the named slot's spans
+    /// concatenated (sec 5.2).
+    ReadProfile {
+        slot: u8,
+    },
+    Write {
+        addr: u16,
+        data: FrameBytes<'a>,
+        hold: bool,
+    },
+    Commit,
+    /// MGMT ENUM (sec 9.2): reply with the full UID iff ours begins with the
+    /// prefix; silent otherwise.
+    Enumerate {
+        prefix_len: u8,
+        prefix: [u8; UID_LEN],
+    },
+    /// MGMT ASSIGN (sec 9.2): the servo whose UID matches takes `new_id`
+    /// immediately and acks from it.
+    Assign {
+        uid: [u8; UID_LEN],
+        new_id: u8,
+    },
+    /// MGMT CAL (sec 9.3, broadcast-only): `gaps + 1` bare breaks spaced
+    /// `gap_us` apart follow this frame -- the host-crystal ruler the bus
+    /// measures its clock against.
+    Calibrate {
+        gap_us: u16,
+        gaps: u8,
+    },
+    Mgmt {
+        op: MgmtOp,
+        args: FrameBytes<'a>,
+    },
+    /// Valid frame the bus cannot resolve (unknown opcode/flag combination).
+    /// Dispatch answers `ResultCode::Instruction` (sec 5.3 layer 2).
+    Unsupported,
+}
+
+/// Bus-derived context core may not derive itself.
+pub struct RequestCtx {
+    /// The wire contract permits a status for this request (false for
+    /// NOREPLY-flagged instructions and non-acking broadcasts).
+    pub may_reply: bool,
+}
+
+/// Max spans per gathered status -- mirrors the profile region's slot width
+/// (`regions::profile::SPANS_PER_SLOT`).
+pub const GATHER_MAX: usize = 8;
+
+/// Dispatcher-facing reply surface.
+pub trait Reply {
+    fn send_status(&mut self, status: Status<'_>) -> Result<(), SendError>;
+    /// Scattered status (sec 5.2): the payload is `spans` concatenated in order --
+    /// the bus copies them once into its snapshot and streams one frame.
+    /// `spans` holds at most [`GATHER_MAX`] entries.
+    fn send_status_gather(
+        &mut self,
+        result: ResultCode,
+        alert: bool,
+        spans: &[&[u8]],
+    ) -> Result<(), SendError>;
+    /// Deferred ID change -- applies after the in-flight TX completes.
+    fn stage_id(&mut self, id: u8);
+    /// Immediate ID change -- a status staged after this call already carries
+    /// the new id (the ASSIGN ack leaves from it, sec 9.2).
+    fn set_id(&mut self, id: u8);
+    /// Deferred baud change -- applied at TX complete so the ack leaves at the old rate.
+    fn stage_baud(&mut self, baud: BaudRate);
+    /// Immediate: the bus caches this for chain-reclaim timing (sec 6).
+    fn set_response_deadline(&mut self, us: u16);
+    /// Deferred reboot, honored after any in-flight TX drains.
+    fn stage_reboot(&mut self, mode: BootMode);
+    /// MGMT CAL accepted (sec 9.3): the bus measures the announced break train
+    /// against its own clock and trims the oscillator from it.
+    fn begin_clock_cal(&mut self, gap_us: u16, gaps: u8);
+}
+
+/// Outcome of a [`Dispatch::dispatch`]: whether a table effect was staged.
+pub enum Dispatched {
+    /// No table effect -- nothing awaits a verdict in the dispatcher (any
+    /// staged reply is the bus's wire effect to gate).
+    Done,
+    /// A table effect is staged; the caller owes the verdict --
+    /// [`Dispatch::commit`] on CRC pass, [`Dispatch::revert`] on fail.
+    Pending,
+}
+
+/// Single-shot typed dispatch: the bus hands one fully-decoded request plus
+/// its ctx. `R` is generic per call so the hot path avoids `dyn Reply`.
+///
+/// Dispatch-before-verdict is the spine: `dispatch` runs before the frame's
+/// CRC verdict and STAGES effects -- the reply through `R` (the wire effect,
+/// sent or dropped by the bus) and writes into the staging buffer (the table
+/// effect, gated by [`Self::commit`]/[`Self::revert`]). COMMIT and MGMT
+/// cannot stage their effects; the bus routes them verdict-first (CRC checked
+/// before dispatch), and `dispatch` applies them directly on that contract.
+pub trait Dispatch {
+    fn dispatch<R: Reply>(
+        &mut self,
+        req: Request<'_>,
+        ctx: RequestCtx,
+        reply: &mut R,
+    ) -> Dispatched;
+
+    /// Verdict pass: promote the staged table effect -- a plain write applies
+    /// into the live table and fires its hooks; a held write keeps its
+    /// entries for a later COMMIT.
+    fn commit<R: Reply>(&mut self, reply: &mut R);
+
+    /// Verdict fail (or frame died): discard the staged table effect.
+    fn revert(&mut self);
+}


### PR DESCRIPTION
osc-core, from #20's tip: the chip-agnostic middle of the firmware.

The region layout (config / telemetry / control views over the flat table), the bus service that turns decoded instructions into table operations and staged replies, and the persistence machinery behind MGMT SAVE — A/B page alternation, gated on torque-off because the actual mid-motion hazard is the flash-program stall, not the write itself.

70 unit tests. Depends only on the crates already landed; the bus driver that feeds it comes next.
