### PR TITLE
firmware: osc-drivers (servo bus driver family)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,7 @@ jobs:
         run: cargo build --workspace
       - name: cargo test
         run: cargo test --workspace
+      - name: cargo check --features mocks
+        run: cargo check -p osc-drivers --features mocks
+      - name: cargo check --features bench
+        run: cargo check -p osc-drivers --features bench

--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["control-table", "control-table-derive", "core", "log", "osc-protocol", "units"]
+members = ["control-table", "control-table-derive", "core", "drivers", "log", "osc-protocol", "units"]
 
 [workspace.package]
 edition = "2024"

--- a/firmware/lib/drivers/Cargo.toml
+++ b/firmware/lib/drivers/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name    = "osc-drivers"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[features]
+# Hot-path probe bodies (crate::bench): counters in no_mangle statics the
+# debug link dumps by symbol. Call sites stay unconditional.
+bench = []
+defmt = ["osc-log/defmt", "osc-core/defmt"]
+log   = ["osc-log/log"]
+mocks = ["dep:mockall", "osc-protocol/software-crc"]
+
+[dependencies]
+osc-core.workspace = true
+osc-log.workspace = true
+osc-protocol.workspace = true
+heapless.workspace = true
+mockall            = { version = "0.14", optional = true }
+
+[dev-dependencies]
+osc-protocol = { workspace = true, features = ["software-crc"] }
+heapless.workspace = true
+mockall      = "0.14"

--- a/firmware/lib/drivers/src/bench.rs
+++ b/firmware/lib/drivers/src/bench.rs
@@ -1,0 +1,98 @@
+//! Bench-only probes: counter bodies exist under the `bench` feature; call
+//! sites stay unconditional in hot paths and compile to nothing without it
+//! (the closure is never called and the empty inline erases).
+//!
+//! Counters live in `no_mangle` statics so the debug link can dump them by
+//! symbol address (`nm` the ELF) on a running chip -- no wire traffic, no
+//! table space, and they survive test tails that re-center transport state.
+
+/// Trim chain-pair pipeline counters: where do BURST-food pairs die between
+/// the break stamp and a window verdict? One field per exit of
+/// [`ServoBus::on_drift_break`]'s decision ladder, in ladder order.
+#[repr(C)]
+pub struct TrimProbe {
+    /// Drift stamps taken (fresh break wakes with a break byte newest).
+    pub stamps: u32,
+    /// Stamp with no predecessor (first after boot/restart) -- no pair.
+    pub no_prev: u32,
+    /// Pair rejected: NO verified frame between the stamps (a coalesced or
+    /// spurious service -- the fault-contract starvation class).
+    pub span_none: u32,
+    /// Pair rejected: MORE than one verified frame between the stamps
+    /// (coalesced break service under zero-gap bursts).
+    pub span_many: u32,
+    /// Pair rejected: exactly one verified frame, but a solicited shape (a
+    /// reply's turnaround rides the responder's clock).
+    pub unsilent: u32,
+    /// Pair rejected: ring span != the verified footprint (something else
+    /// ringed -- status, garble, echo).
+    pub inexact: u32,
+    /// Pair rejected by the 1/16 span gate (a real inter-burst pause).
+    pub gated: u32,
+    /// Pair accepted into the seam baseline.
+    pub base_pairs: u32,
+    /// Pair accepted into a drift window (baseline established).
+    pub win_pairs: u32,
+    /// Window verdicts handed to the trim loop.
+    pub verdicts: u32,
+    // --- verdict-content layer ---
+    /// Latest drift verdict's raw window sums at handoff.
+    pub verdict_err: i32,
+    pub verdict_span: u32,
+    /// `poll_clock_trim` consumptions by source.
+    pub poll_cal: u32,
+    pub poll_drift: u32,
+    /// Drift polls discarded by the +/-8k ppm sanity band.
+    pub sanity_drop: u32,
+    /// Latest drift poll's computed ppm (pre-sanity).
+    pub poll_ppm: i32,
+    /// `TrimLoop::on_window` invocations (both sources) and its latest
+    /// measurement, effect estimate, applied steps, and running total.
+    pub windows: u32,
+    pub tw_ppm: i32,
+    pub tw_effect: i32,
+    pub tw_applied: i32,
+    pub tw_total: i32,
+}
+
+impl TrimProbe {
+    pub const ZERO: Self = Self {
+        stamps: 0,
+        no_prev: 0,
+        span_none: 0,
+        span_many: 0,
+        unsilent: 0,
+        inexact: 0,
+        gated: 0,
+        base_pairs: 0,
+        win_pairs: 0,
+        verdicts: 0,
+        verdict_err: 0,
+        verdict_span: 0,
+        poll_cal: 0,
+        poll_drift: 0,
+        sanity_drop: 0,
+        poll_ppm: 0,
+        windows: 0,
+        tw_ppm: 0,
+        tw_effect: 0,
+        tw_applied: 0,
+        tw_total: 0,
+    };
+}
+
+#[cfg(feature = "bench")]
+#[unsafe(no_mangle)]
+pub static mut TRIM_PROBE: TrimProbe = TrimProbe::ZERO;
+
+/// Run `f` over the trim probe -- a no-op without the `bench` feature.
+#[inline(always)]
+#[allow(unused_variables)]
+pub fn trim_probe(f: impl FnOnce(&mut TrimProbe)) {
+    // SAFETY: single-hart; every writer runs at the one transport priority
+    // (HIGH), so accesses never interleave. The debug link only reads.
+    #[cfg(feature = "bench")]
+    unsafe {
+        f(&mut *core::ptr::addr_of_mut!(TRIM_PROBE));
+    }
+}

--- a/firmware/lib/drivers/src/bus/chain.rs
+++ b/firmware/lib/drivers/src/bus/chain.rs
@@ -1,0 +1,294 @@
+//! Reply sequencing for every reply (`docs/osc-native-protocol.md` sec 6, sec 7).
+//!
+//! Pure state machine: the composite owns the deadline provider and drives
+//! this with plain ticks. Every reply is deadline-triggered >= reply gap after the
+//! frame it answers; a GREAD chain slot `k > 0` additionally waits for `k`
+//! predecessor status frames, each with a reclaim window so a silent
+//! predecessor can't collapse the tail (sec 6). A unicast reply is just slot 0.
+
+/// What the chain wants from the composite after an event.
+pub enum ChainOut {
+    None,
+    /// Arm the chain deadline at this absolute tick.
+    Wait(u32),
+    /// Start the staged reply now. `predecessor_silent` sets the status error
+    /// field (sec 6): true when any reclaim window expired during this chain.
+    Trigger {
+        predecessor_silent: bool,
+    },
+}
+
+enum State {
+    Idle,
+    /// Reply staged; the trigger deadline is armed. `silent` carries whether a
+    /// reclaim fired earlier in the chain.
+    Pending {
+        silent: bool,
+    },
+    /// A chain slot awaiting `remaining` predecessor status frames. `silent`
+    /// latches once any reclaim window expires.
+    Waiting {
+        remaining: u8,
+        silent: bool,
+    },
+}
+
+pub struct Chain {
+    state: State,
+    // Baud is fixed for a chain, so these are captured once at staging (sec 7).
+    reply_gap: u32,
+    reclaim: u32,
+    allowance: u32,
+}
+
+impl Default for Chain {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Chain {
+    pub const fn new() -> Self {
+        Self {
+            state: State::Idle,
+            reply_gap: 0,
+            reclaim: 0,
+            allowance: 0,
+        }
+    }
+
+    pub fn active(&self) -> bool {
+        !matches!(self.state, State::Idle)
+    }
+
+    /// Awaiting predecessor status frames (sec 6): a predecessor's break is
+    /// expected, so the composite suspends its reclaim window on that break
+    /// instead of killing the staged reply.
+    pub fn waiting(&self) -> bool {
+        matches!(self.state, State::Waiting { .. })
+    }
+
+    /// Own reply started, or a new instruction superseded the chain.
+    pub fn reset(&mut self) {
+        self.state = State::Idle;
+    }
+
+    /// Own reply staged for `slot` (0 = unicast or first chain slot) after the
+    /// instruction frame ended at `end`. `reclaim` covers a predecessor's
+    /// trigger -> break lead only (sec 6 keys reclaim off the break, so the
+    /// default stays baud-independent); `allowance` bounds how long an
+    /// observed break suspends reclaim while its frame plays out.
+    pub fn on_reply_staged(
+        &mut self,
+        slot: u8,
+        end: u32,
+        reply_gap: u32,
+        reclaim: u32,
+        allowance: u32,
+    ) -> ChainOut {
+        self.reply_gap = reply_gap;
+        self.reclaim = reclaim;
+        self.allowance = allowance;
+        if slot == 0 {
+            // sec 7: reply >= reply gap after the instruction end, like a unicast read.
+            self.state = State::Pending { silent: false };
+            ChainOut::Wait(end.wrapping_add(reply_gap))
+        } else {
+            // sec 6: wait for `slot` predecessors; the reclaim guards slot 0's own
+            // trigger (its trigger is end + reply_gap, so its window ends one
+            // reclaim later).
+            self.state = State::Waiting {
+                remaining: slot,
+                silent: false,
+            };
+            ChainOut::Wait(end.wrapping_add(reply_gap).wrapping_add(reclaim))
+        }
+    }
+
+    /// A break landed on the wire while we hold a staged reply. sec 6: reclaim
+    /// fires only when a predecessor produces *no break* within its window --
+    /// a break means it is alive, so the window suspends for the bounded
+    /// frame allowance while its frame plays out. The frame's completion
+    /// re-sequences via [`Self::on_status_end`]; a frame that garbles or
+    /// wedges instead lets the suspended deadline fire as the reclaim.
+    pub fn on_break_observed(&mut self, now: u32) -> ChainOut {
+        match self.state {
+            State::Waiting { .. } => ChainOut::Wait(now.wrapping_add(self.allowance)),
+            _ => ChainOut::None,
+        }
+    }
+
+    /// A status frame (someone else's -- own TX never rings, F9) ended at `end`.
+    pub fn on_status_end(&mut self, end: u32) -> ChainOut {
+        match self.state {
+            State::Waiting { remaining, silent } => {
+                let remaining = remaining.saturating_sub(1);
+                if remaining == 0 {
+                    self.state = State::Pending { silent };
+                    ChainOut::Wait(end.wrapping_add(self.reply_gap))
+                } else {
+                    self.state = State::Waiting { remaining, silent };
+                    ChainOut::Wait(end.wrapping_add(self.reply_gap).wrapping_add(self.reclaim))
+                }
+            }
+            // Idle or already pending: a stale snoop, normal (sec 6).
+            _ => ChainOut::None,
+        }
+    }
+
+    pub fn on_deadline(&mut self, now: u32) -> ChainOut {
+        match self.state {
+            State::Pending { silent } => {
+                self.state = State::Idle;
+                ChainOut::Trigger {
+                    predecessor_silent: silent,
+                }
+            }
+            State::Waiting { remaining, .. } => {
+                // Reclaim expiry: this predecessor was silent (sec 6).
+                let remaining = remaining.saturating_sub(1);
+                if remaining == 0 {
+                    self.state = State::Idle;
+                    ChainOut::Trigger {
+                        predecessor_silent: true,
+                    }
+                } else {
+                    // Each silent predecessor's window cascades from its own
+                    // missed trigger (now), not the original anchor.
+                    self.state = State::Waiting {
+                        remaining,
+                        silent: true,
+                    };
+                    ChainOut::Wait(now.wrapping_add(self.reclaim))
+                }
+            }
+            State::Idle => ChainOut::None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const END: u32 = 1000;
+    const REPLY_GAP: u32 = 60;
+    const RECLAIM: u32 = 600;
+    const ALLOWANCE: u32 = 5000;
+
+    fn wait_tick(out: ChainOut) -> u32 {
+        match out {
+            ChainOut::Wait(t) => t,
+            _ => panic!("expected Wait"),
+        }
+    }
+
+    fn trigger_silent(out: ChainOut) -> bool {
+        match out {
+            ChainOut::Trigger { predecessor_silent } => predecessor_silent,
+            _ => panic!("expected Trigger"),
+        }
+    }
+
+    #[test]
+    fn slot0_triggers_after_reply_gap() {
+        let mut c = Chain::new();
+        assert_eq!(
+            wait_tick(c.on_reply_staged(0, END, REPLY_GAP, RECLAIM, ALLOWANCE)),
+            END + REPLY_GAP
+        );
+        assert!(c.active());
+        assert!(!trigger_silent(c.on_deadline(END + REPLY_GAP)));
+        assert!(!c.active());
+    }
+
+    #[test]
+    fn slot2_two_statuses_then_trigger() {
+        let mut c = Chain::new();
+        // reclaim guards slot 0's trigger.
+        assert_eq!(
+            wait_tick(c.on_reply_staged(2, END, REPLY_GAP, RECLAIM, ALLOWANCE)),
+            END + REPLY_GAP + RECLAIM
+        );
+        // predecessor 0 replies.
+        assert_eq!(wait_tick(c.on_status_end(1200)), 1200 + REPLY_GAP + RECLAIM);
+        // predecessor 1 replies -> our slot pends, trigger reply gap after it.
+        assert_eq!(wait_tick(c.on_status_end(1400)), 1400 + REPLY_GAP);
+        assert!(!trigger_silent(c.on_deadline(1400 + REPLY_GAP)));
+    }
+
+    #[test]
+    fn slot1_reclaim_triggers_silent() {
+        let mut c = Chain::new();
+        assert_eq!(
+            wait_tick(c.on_reply_staged(1, END, REPLY_GAP, RECLAIM, ALLOWANCE)),
+            END + REPLY_GAP + RECLAIM
+        );
+        // No status arrives: the reclaim window expires and we take the slot.
+        assert!(trigger_silent(c.on_deadline(END + REPLY_GAP + RECLAIM)));
+        assert!(!c.active());
+    }
+
+    #[test]
+    fn slot3_one_status_then_two_reclaims() {
+        let mut c = Chain::new();
+        assert_eq!(
+            wait_tick(c.on_reply_staged(3, END, REPLY_GAP, RECLAIM, ALLOWANCE)),
+            END + REPLY_GAP + RECLAIM
+        );
+        // predecessor 0 replies (real).
+        assert_eq!(wait_tick(c.on_status_end(1200)), 1200 + REPLY_GAP + RECLAIM);
+        // predecessor 1 goes silent: reclaim cascades from now.
+        assert_eq!(wait_tick(c.on_deadline(1860)), 1860 + RECLAIM);
+        // predecessor 2 goes silent: last one -> trigger, silent.
+        assert!(trigger_silent(c.on_deadline(2460)));
+    }
+
+    #[test]
+    fn break_suspends_reclaim_for_frame_allowance() {
+        let mut c = Chain::new();
+        c.on_reply_staged(1, END, REPLY_GAP, RECLAIM, ALLOWANCE);
+        // Predecessor's break lands inside its reclaim window: alive -- the
+        // window suspends for the frame allowance instead of expiring.
+        assert_eq!(wait_tick(c.on_break_observed(1100)), 1100 + ALLOWANCE);
+        // Its frame completes: normal sequencing resumes.
+        assert_eq!(wait_tick(c.on_status_end(1500)), 1500 + REPLY_GAP);
+        assert!(!trigger_silent(c.on_deadline(1500 + REPLY_GAP)));
+    }
+
+    #[test]
+    fn wedged_after_break_reclaims_at_allowance() {
+        let mut c = Chain::new();
+        c.on_reply_staged(1, END, REPLY_GAP, RECLAIM, ALLOWANCE);
+        c.on_break_observed(1100);
+        // The frame never resolves (garbled/wedged): the suspended deadline
+        // fires as the reclaim.
+        assert!(trigger_silent(c.on_deadline(1100 + ALLOWANCE)));
+    }
+
+    #[test]
+    fn break_while_idle_or_pending_is_none() {
+        let mut c = Chain::new();
+        assert!(matches!(c.on_break_observed(500), ChainOut::None));
+        c.on_reply_staged(0, END, REPLY_GAP, RECLAIM, ALLOWANCE);
+        // Pending our own trigger: a break is not a predecessor signal.
+        assert!(matches!(c.on_break_observed(1010), ChainOut::None));
+    }
+
+    #[test]
+    fn status_while_idle_is_none() {
+        let mut c = Chain::new();
+        assert!(matches!(c.on_status_end(500), ChainOut::None));
+        assert!(matches!(c.on_deadline(500), ChainOut::None));
+    }
+
+    #[test]
+    fn reset_mid_chain_goes_idle() {
+        let mut c = Chain::new();
+        c.on_reply_staged(2, END, REPLY_GAP, RECLAIM, ALLOWANCE);
+        assert!(c.active());
+        c.reset();
+        assert!(!c.active());
+        assert!(matches!(c.on_deadline(9999), ChainOut::None));
+    }
+}

--- a/firmware/lib/drivers/src/bus/clock.rs
+++ b/firmware/lib/drivers/src/bus/clock.rs
@@ -1,0 +1,345 @@
+//! Clock-discipline sub-driver (`docs/osc-native-protocol.md` sec 9.3): MGMT CAL
+//! break-train measurement, the differential drift tracker, and the trim-loop
+//! gating between them.
+//!
+//! Pure state machine: the composite owns the ring and deadline providers and
+//! drives this with plain ticks, cursors, and ring-derived values; the one
+//! deadline the CAL train needs (its watchdog, then the post-train hunt) is
+//! returned for the composite's mux to arm.
+
+use super::ring_wrap;
+use super::trim::TrimLoop;
+
+/// Trim measurement accept gate (sec 9.3), right-shift of the nominal span
+/// (1/16 ~ 6%): wider than any legal clock offset (the HSITRIM throw is
+/// +/-3.4%), far under a missed/spurious break or a real inter-frame pause.
+/// Gates CAL gaps and drift chain-pairs alike.
+const TRIM_GATE_SHIFT: u32 = 4;
+
+/// CAL train watchdog, in announced gaps: a train silent this long is
+/// abandoned -- no decision -- and the framer resumes (a suspended resolver
+/// needs a deadline backstop like any busy-wait).
+const CAL_WATCHDOG_GAPS: u32 = 2;
+
+/// Seam-baseline capture length, in accepted chain-pairs (sec 9.3; a power of
+/// two -- the mean divides by shift on the divider-less chip build). Right
+/// after a trim decision the clock is freshly measured, so the mean pair
+/// error over these IS the host's queuing seam.
+const DRIFT_BASELINE_PAIRS: u8 = 32;
+
+/// Chain-pairs per drift window -- a decision every second or two at
+/// hot-loop rates, against thermal drift that moves over minutes.
+const DRIFT_WINDOW_PAIRS: u8 = 128;
+
+/// Drift-window verdicts past this are not thermal (HSI tempco cannot move
+/// thousands of ppm between adjacent windows): a host seam shift or a
+/// garbage window -- discarded; the baseline stands, the next CAL re-anchors.
+const DRIFT_SANITY_PPM: u32 = 8_000;
+
+/// A live MGMT CAL break train (sec 9.3): the host's crystal spaces the breaks,
+/// and break-FE entry stamps measure that ruler with the local clock. Both
+/// stamps of every gap are the SAME ISR flavor, so entry latency cancels in
+/// the difference; what survives is clock skew plus sub-us jitter the
+/// per-gap gate and the gap sum average out.
+struct CalRun {
+    gap_ticks: u32,
+    gaps_left: u8,
+    /// Announced gap count -- the >=-half validity bar at train end.
+    total: u8,
+    valid: u8,
+    last_break: u32,
+    /// Ring cursor at the last counted break: a real break rings its 0x00
+    /// byte, a latched-flag re-fire does not -- cursor progress is what
+    /// distinguishes a ruler mark from a storm re-entry (the fault
+    /// contract's freshness idiom, cal-local).
+    cursor: u16,
+    err: i32,
+    span: u32,
+}
+
+/// What the wire delivered between two break-FE stamps (sec 9.3): the drift
+/// tracker pairs the stamps only around exactly ONE CRC-verified SILENT
+/// instruction -- the one frame shape whose break-to-break span is
+/// host-clocked end to end. Anything solicited puts a responder's
+/// turnaround (its clock, not the host's) inside the span, and a reply gap
+/// can slip under the 1/16 gate at 1M.
+#[derive(Copy, Clone)]
+enum VerifiedSpan {
+    None,
+    One { footprint: u16, silent: bool },
+    Many,
+}
+
+pub struct ClockTracker {
+    // MGMT CAL (sec 9.3): a dispatched-but-not-started train (the announce),
+    // the live train, and a completed measurement awaiting the main loop.
+    pub(super) pending_cal: Option<(u16, u8)>,
+    cal: Option<CalRun>,
+    cal_ready: bool,
+    // Differential drift tracker (sec 9.3): the last break-FE stamp + ring
+    // cursor, the one silent instruction verified since it, the seam
+    // baseline, and the current drift window.
+    drift_prev: Option<(u32, u16)>,
+    drift_seen: VerifiedSpan,
+    drift_base: Option<i32>,
+    drift_base_err: i32,
+    drift_base_n: u8,
+    drift_win_err: i32,
+    drift_win_span: u32,
+    drift_win_n: u8,
+    drift_ready: bool,
+    // Completed-measurement handoff to the main loop's `poll_clock_trim`:
+    // one (err, span) at a time, owned by whichever ready flag is set.
+    cadence_err: i32,
+    cadence_span: u32,
+    trim: TrimLoop,
+}
+
+impl ClockTracker {
+    pub const fn new(step_ppm: u32) -> Self {
+        Self {
+            pending_cal: None,
+            cal: None,
+            cal_ready: false,
+            drift_prev: None,
+            drift_seen: VerifiedSpan::None,
+            drift_base: None,
+            drift_base_err: 0,
+            drift_base_n: 0,
+            drift_win_err: 0,
+            drift_win_span: 0,
+            drift_win_n: 0,
+            drift_ready: false,
+            cadence_err: 0,
+            cadence_span: 0,
+            trim: TrimLoop::new(step_ppm),
+        }
+    }
+
+    /// A live or announced CAL train: breaks are ruler marks, not traffic.
+    pub fn cal_active(&self) -> bool {
+        self.cal.is_some() || self.pending_cal.is_some()
+    }
+
+    /// One CAL ruler mark (sec 9.3). The stamp is the CALLER's `now`, read at
+    /// service entry before any other work -- every gap's two ends then carry
+    /// the same entry path, and its latency cancels in the difference.
+    /// Returns the framer deadline to arm: the train's watchdog while it
+    /// runs, the pend-on-past hunt at its end, nothing on a non-mark entry.
+    pub fn on_cal_break(&mut self, now: u32, cursor: u16, ticks_per_us: u32) -> Option<u32> {
+        if let Some((gap_us, gaps)) = self.pending_cal.take() {
+            self.restart();
+            // Train start: the first break after the announce opens gap 1.
+            let gap_ticks = (gap_us as u32).wrapping_mul(ticks_per_us);
+            self.cal = Some(CalRun {
+                gap_ticks,
+                gaps_left: gaps,
+                total: gaps,
+                valid: 0,
+                last_break: now,
+                cursor,
+                err: 0,
+                span: 0,
+            });
+            return Some(cal_watchdog_at(now, gap_ticks));
+        }
+        let (finished, gap_ticks) = {
+            let Some(cal) = &mut self.cal else {
+                return None; // SAFETY: caller guards; a bare entry changes nothing
+            };
+            if cursor == cal.cursor {
+                return None; // latched-flag re-fire: no byte ringed, not a mark
+            }
+            cal.cursor = cursor;
+            let delta = now.wrapping_sub(cal.last_break);
+            cal.last_break = now;
+            let err = delta.wrapping_sub(cal.gap_ticks) as i32;
+            if err.unsigned_abs() <= cal.gap_ticks >> TRIM_GATE_SHIFT {
+                cal.err = cal.err.wrapping_add(err);
+                cal.span = cal.span.wrapping_add(cal.gap_ticks);
+                cal.valid += 1;
+            }
+            cal.gaps_left = cal.gaps_left.saturating_sub(1);
+            (cal.gaps_left == 0, cal.gap_ticks)
+        };
+        if !finished {
+            return Some(cal_watchdog_at(now, gap_ticks));
+        }
+        if let Some(c) = self.cal.take() {
+            // >= half the announced gaps measured clean, or no decision -- a
+            // mangled train yields nothing rather than something.
+            if c.valid as u32 * 2 >= c.total as u32 {
+                self.cadence_err = c.err;
+                self.cadence_span = c.span;
+                self.cal_ready = true;
+            }
+        }
+        // Pend-on-past: hunt the train's break bytes off the ring now.
+        Some(now)
+    }
+
+    /// The watchdog fired: the train (or a dangling announce) dies, no
+    /// decision.
+    pub fn abandon_cal(&mut self) {
+        self.cal = None;
+        self.pending_cal = None;
+    }
+
+    /// Drift chain-pair (sec 9.3): adjacent break-FE stamps bracketing one
+    /// silent verified instruction measure `seam + drift*span` -- the host's
+    /// queuing seam is unknown but stationary, so the mean pair error right
+    /// after a trim decision IS the seam (baseline), and every later window
+    /// reads drift as its shift from it. Anything constant -- seam, FE latch
+    /// offset, entry-path residue -- dies in the subtraction; only changes
+    /// survive, and the sanity band catches the non-thermal ones.
+    pub fn on_drift_break(&mut self, now: u32, cursor: u16, len: usize, tpb: u32) {
+        let prev = self.drift_prev.replace((now, cursor));
+        let seen = core::mem::replace(&mut self.drift_seen, VerifiedSpan::None);
+        crate::bench::trim_probe(|p| p.stamps += 1);
+        let (t1, c1) = match prev {
+            Some(pair) => pair,
+            None => {
+                crate::bench::trim_probe(|p| p.no_prev += 1);
+                return;
+            }
+        };
+        let footprint = match seen {
+            VerifiedSpan::One {
+                footprint,
+                silent: true,
+            } => footprint,
+            VerifiedSpan::One { silent: false, .. } => {
+                crate::bench::trim_probe(|p| p.unsilent += 1);
+                return;
+            }
+            VerifiedSpan::None => {
+                crate::bench::trim_probe(|p| p.span_none += 1);
+                return;
+            }
+            VerifiedSpan::Many => {
+                crate::bench::trim_probe(|p| p.span_many += 1);
+                return;
+            }
+        };
+        // Byte-exactness: the pair's ring span must be exactly the verified
+        // frame -- anything else intervened (a status, garble, an echo).
+        if len == 0 || ring_wrap(cursor as usize + len - c1 as usize, len) as u16 != footprint {
+            crate::bench::trim_probe(|p| p.inexact += 1);
+            return;
+        }
+        let span = (footprint as u32).wrapping_mul(tpb);
+        let err = now.wrapping_sub(t1).wrapping_sub(span) as i32;
+        if err.unsigned_abs() > span >> TRIM_GATE_SHIFT {
+            crate::bench::trim_probe(|p| p.gated += 1);
+            return; // a real pause (inter-chain gap), not a seam
+        }
+        match self.drift_base {
+            None => {
+                crate::bench::trim_probe(|p| p.base_pairs += 1);
+                self.drift_base_err = self.drift_base_err.wrapping_add(err);
+                self.drift_base_n += 1;
+                if self.drift_base_n >= DRIFT_BASELINE_PAIRS {
+                    self.drift_base = Some(self.drift_base_err / DRIFT_BASELINE_PAIRS as i32);
+                }
+            }
+            Some(base) => {
+                crate::bench::trim_probe(|p| p.win_pairs += 1);
+                self.drift_win_err = self.drift_win_err.wrapping_add(err.wrapping_sub(base));
+                self.drift_win_span = self.drift_win_span.saturating_add(span);
+                self.drift_win_n += 1;
+                if self.drift_win_n >= DRIFT_WINDOW_PAIRS {
+                    if !self.cal_ready && !self.drift_ready {
+                        crate::bench::trim_probe(|p| {
+                            p.verdicts += 1;
+                            p.verdict_err = self.drift_win_err;
+                            p.verdict_span = self.drift_win_span;
+                        });
+                        self.cadence_err = self.drift_win_err;
+                        self.cadence_span = self.drift_win_span;
+                        self.drift_ready = true;
+                    }
+                    self.drift_win_err = 0;
+                    self.drift_win_span = 0;
+                    self.drift_win_n = 0;
+                }
+            }
+        }
+    }
+
+    /// The drift pair is still open for its one verified frame -- the shape
+    /// classification is only worth computing for that first frame.
+    pub fn pair_open(&self) -> bool {
+        matches!(self.drift_seen, VerifiedSpan::None)
+    }
+
+    /// A verified frame between breaks -- the drift tracker's qualification
+    /// record. Only exactly-one counts, and only silent shapes pair.
+    pub fn note_verified(&mut self, footprint: u16, silent: bool) {
+        self.drift_seen = match self.drift_seen {
+            VerifiedSpan::None => VerifiedSpan::One { footprint, silent },
+            _ => VerifiedSpan::Many,
+        };
+    }
+
+    /// Tracker restart: baseline, window, and pair continuity all drop --
+    /// after a trim decision (the baseline's residual-skew term is stale),
+    /// a CAL train (continuity broken), or a rate change.
+    pub fn restart(&mut self) {
+        self.drift_prev = None;
+        self.drift_seen = VerifiedSpan::None;
+        self.drift_base = None;
+        self.drift_base_err = 0;
+        self.drift_base_n = 0;
+        self.drift_win_err = 0;
+        self.drift_win_span = 0;
+        self.drift_win_n = 0;
+        self.drift_ready = false;
+    }
+
+    /// Drain a completed measurement -- a CAL train (absolute) or a drift
+    /// window (baseline-relative) -- through the trim loop.
+    pub fn poll(&mut self) -> Option<i8> {
+        if self.cal_ready {
+            crate::bench::trim_probe(|p| p.poll_cal += 1);
+            self.cal_ready = false;
+            let (err, span) = (self.cadence_err, self.cadence_span);
+            self.cadence_err = 0;
+            self.cadence_span = 0;
+            // The clock is freshly measured either way the decision goes:
+            // the next pairs re-capture the seam baseline against it.
+            self.restart();
+            return self.trim.on_window(err, span);
+        }
+        if !self.drift_ready {
+            return None;
+        }
+        self.drift_ready = false;
+        let (err, span) = (self.cadence_err, self.cadence_span);
+        self.cadence_err = 0;
+        self.cadence_span = 0;
+        if span == 0 {
+            return None; // defensive: an empty window decides nothing
+        }
+        let ppm = (err as i64 * 1_000_000 / span as i64) as i32;
+        crate::bench::trim_probe(|p| {
+            p.poll_drift += 1;
+            p.poll_ppm = ppm;
+        });
+        if ppm.unsigned_abs() > DRIFT_SANITY_PPM {
+            crate::bench::trim_probe(|p| p.sanity_drop += 1);
+            return None; // not thermal -- seam shift or garbage, discarded
+        }
+        let out = self.trim.on_window(err, span);
+        if out.is_some() {
+            // The clock moved: the baseline's residual-skew term is stale.
+            self.restart();
+        }
+        out
+    }
+}
+
+/// The train's silence bound: `on_deadline` reads an expiring framer
+/// slot during a live train as "the train died" and abandons it.
+fn cal_watchdog_at(now: u32, gap_ticks: u32) -> u32 {
+    now.wrapping_add(gap_ticks.wrapping_mul(CAL_WATCHDOG_GAPS))
+}

--- a/firmware/lib/drivers/src/bus/decode.rs
+++ b/firmware/lib/drivers/src/bus/decode.rs
@@ -1,0 +1,210 @@
+//! Linearized frame -> decoded request mapping (`docs/osc-native-protocol.md`
+//! sec 5, sec 6). Input is a whole, CRC-clean frame (header pre-validated by the
+//! framer): `[0x00][ID][LEN][INST][payload][PAD?][crc][crc]`. Output is the
+//! chip-agnostic [`Request`] plus its reply contract and chain slot, or a
+//! classification the composite acts on without dispatching.
+//!
+//! Addressing: plain ops address by frame ID (unicast-to-us or broadcast);
+//! group ops address by their id-lists regardless of the (broadcast) frame ID.
+//! Own instruction frames never echo while we are the responder (F9), so no
+//! self-filtering is coded here.
+
+use osc_core::traits::{Request, RequestCtx};
+use osc_protocol::FrameBytes;
+use osc_protocol::frame::{
+    AssignReq, CalReq, EnumReq, Header, MgmtReq, ProfileReq, ReadReq, WriteReq,
+};
+use osc_protocol::group::{
+    GreadPerTarget, GreadProfilePerTarget, GreadProfileUniform, GreadUniform, GwritePerTarget,
+    GwriteUniform,
+};
+use osc_protocol::wire::{Id, Inst, MgmtOp, Opcode};
+
+/// What the frame is, from the composite's point of view.
+pub enum Decoded<'a> {
+    /// Status frame (INST bit 7): a chain predecessor's reply -- snoop it.
+    Status,
+    /// Not addressed to us (or a group op that doesn't list us): ignore.
+    Skip,
+    /// Addressed to us: dispatch this request, reply per `ctx`, chain at `slot`.
+    Own(Request<'a>, RequestCtx, u8),
+}
+
+pub fn decode(frame: FrameBytes<'_>, id: u8) -> Decoded<'_> {
+    let (Some(b0), Some(b1), Some(b2), Some(b3)) = (
+        frame.u8_at(0),
+        frame.u8_at(1),
+        frame.u8_at(2),
+        frame.u8_at(3),
+    ) else {
+        return Decoded::Skip;
+    };
+    let head = [b0, b1, b2, b3];
+    let h = Header::from_bytes(&head);
+    if h.inst.is_status() {
+        return Decoded::Status;
+    }
+    let Some(op) = h.inst.opcode() else {
+        return Decoded::Skip; // framer already rejects opcode 0
+    };
+    let p = h.payload_len() as usize;
+    let Some(pay) = frame.sub(Header::SIZE, p) else {
+        return Decoded::Skip;
+    };
+    let inst = h.inst;
+    let own = Id::new(id);
+
+    match op {
+        Opcode::Gread => gread(inst, pay, own),
+        Opcode::Gwrite => gwrite(inst, pay, own),
+        _ => plain(op, inst, h.id, pay, own),
+    }
+}
+
+/// PING / READ / WRITE / COMMIT / MGMT: addressed by frame ID, reply at slot 0.
+fn plain<'a>(op: Opcode, inst: Inst, frame_id: Id, pay: FrameBytes<'a>, own: Id) -> Decoded<'a> {
+    let broadcast = frame_id.is_broadcast();
+    if !frame_id.addresses(own) {
+        return Decoded::Skip;
+    }
+    let req = match op {
+        Opcode::Ping => Request::Ping,
+        // READ + PROFILE names a profile slot instead of addr+count (sec 5.2).
+        Opcode::Read if inst.profile() => match ProfileReq::parse(pay) {
+            Some(r) => Request::ReadProfile { slot: r.slot },
+            None => Request::Unsupported,
+        },
+        Opcode::Read => match ReadReq::parse(pay) {
+            Some(r) => Request::Read {
+                addr: r.addr,
+                count: r.count,
+            },
+            None => Request::Unsupported,
+        },
+        Opcode::Write => match WriteReq::parse(pay) {
+            Some(w) => Request::Write {
+                addr: w.addr,
+                data: w.data,
+                hold: inst.hold(),
+            },
+            None => Request::Unsupported,
+        },
+        Opcode::Commit => Request::Commit,
+        Opcode::Mgmt => match MgmtReq::parse(pay) {
+            Some(m) => match m.op {
+                MgmtOp::Enum => match EnumReq::parse(m.args) {
+                    Some(e) => Request::Enumerate {
+                        prefix_len: e.prefix_len,
+                        prefix: e.prefix,
+                    },
+                    None => Request::Unsupported,
+                },
+                MgmtOp::Assign => match AssignReq::parse(m.args) {
+                    Some(a) => Request::Assign {
+                        uid: a.uid,
+                        new_id: a.new_id,
+                    },
+                    None => Request::Unsupported,
+                },
+                // sec 9.3: broadcast-only -- a unicast CAL's ack would put our
+                // own break on the wire right where the train starts.
+                MgmtOp::Cal => match CalReq::parse(m.args) {
+                    Some(c) if broadcast => Request::Calibrate {
+                        gap_us: c.gap_us,
+                        gaps: c.gaps,
+                    },
+                    _ => Request::Unsupported,
+                },
+                _ => Request::Mgmt {
+                    op: m.op,
+                    args: m.args,
+                },
+            },
+            None => Request::Unsupported,
+        },
+        // Group opcodes are routed before this call.
+        _ => Request::Unsupported,
+    };
+    // sec 5: a broadcast reply would collide on the shared push-pull wire, so
+    // plain ops answer only unicast; NOREPLY suppresses either way. ENUM and
+    // ASSIGN are the sec 9.2 carve-out: broadcast-addressed by design, with the
+    // dispatcher's UID match electing the sole replier -- a malformed pair
+    // decodes Unsupported and stays under broadcast suppression.
+    let may_reply = !inst.noreply()
+        && (!broadcast || matches!(req, Request::Enumerate { .. } | Request::Assign { .. }));
+    Decoded::Own(req, RequestCtx { may_reply }, 0)
+}
+
+/// GREAD: our span comes from the id-list; the chain slot is our list position.
+/// A GREAD slot always replies (that is the chain, sec 6). A list we can't parse
+/// leaves our addressing unknowable -- skip rather than answer blind. With the
+/// PROFILE flag the payload names profile slots instead of spans (sec 5.2).
+fn gread<'a>(inst: Inst, pay: FrameBytes<'a>, own: Id) -> Decoded<'a> {
+    match (inst.profile(), inst.per_target()) {
+        (false, true) => match GreadPerTarget::parse(pay).and_then(|g| g.find(own)) {
+            Some((slot, t)) => own_read(t.addr, t.count, slot),
+            None => Decoded::Skip,
+        },
+        (false, false) => match GreadUniform::parse(pay) {
+            Some(g) => match g.slot_of(own) {
+                Some(slot) => own_read(g.addr, g.count, slot),
+                None => Decoded::Skip,
+            },
+            None => Decoded::Skip,
+        },
+        (true, true) => match GreadProfilePerTarget::parse(pay).and_then(|g| g.find(own)) {
+            Some((slot, t)) => own_read_profile(t.slot, slot),
+            None => Decoded::Skip,
+        },
+        (true, false) => match GreadProfileUniform::parse(pay) {
+            Some(g) => match g.slot_of(own) {
+                Some(slot) => own_read_profile(g.slot, slot),
+                None => Decoded::Skip,
+            },
+            None => Decoded::Skip,
+        },
+    }
+}
+
+fn own_read<'a>(addr: u16, count: u16, slot: u8) -> Decoded<'a> {
+    Decoded::Own(
+        Request::Read { addr, count },
+        RequestCtx { may_reply: true },
+        slot,
+    )
+}
+
+fn own_read_profile<'a>(profile: u8, slot: u8) -> Decoded<'a> {
+    Decoded::Own(
+        Request::ReadProfile { slot: profile },
+        RequestCtx { may_reply: true },
+        slot,
+    )
+}
+
+/// GWRITE: our entry's span + data, applied silently (sec 5: no reply implied).
+fn gwrite<'a>(inst: Inst, pay: FrameBytes<'a>, own: Id) -> Decoded<'a> {
+    let hold = inst.hold();
+    if inst.per_target() {
+        match GwritePerTarget::parse(pay).and_then(|g| g.find(own)) {
+            Some(t) => own_write(t.addr, t.data, hold),
+            None => Decoded::Skip,
+        }
+    } else {
+        match GwriteUniform::parse(pay) {
+            Some(g) => match g.find(own) {
+                Some(data) => own_write(g.addr, data, hold),
+                None => Decoded::Skip,
+            },
+            None => Decoded::Skip,
+        }
+    }
+}
+
+fn own_write<'a>(addr: u16, data: FrameBytes<'a>, hold: bool) -> Decoded<'a> {
+    Decoded::Own(
+        Request::Write { addr, data, hold },
+        RequestCtx { may_reply: false },
+        0,
+    )
+}

--- a/firmware/lib/drivers/src/bus/framer.rs
+++ b/firmware/lib/drivers/src/bus/framer.rs
@@ -1,0 +1,387 @@
+//! Stream-continuity RX resolver (`docs/osc-servo-transport.md` sec 5,
+//! `docs/osc-native-protocol.md` sec 4.1).
+//!
+//! Pure state machine: the composite owns the ring, deadline, and CRC
+//! providers and drives this with plain values. Anchors are DERIVED, never
+//! sampled: frames are contiguous, so `next anchor = anchor + footprint`,
+//! bootstrapped only at provably-quiet moments (boot = index 0, rescue = a
+//! still cursor). Every legal frame fits whole in the ring (258 B max vs
+//! 512 B, sec 3.1), so resolution is a pure function of ring content -- the
+//! clock only schedules *when to look again* for the one frame still
+//! arriving (the frontier). A frame with bytes beyond its end is complete
+//! by construction and resolves with zero clock involvement, however late
+//! or coalesced the FE wakes were (position from the stream: the ring is the
+//! queue).
+//!
+//! TIME is derived the way position is (the same stream-derivation extended
+//! to the clock): every aim and estimate is `now + missing*tpb` -- the bytes
+//! still owed, at wire pace. An FE carries neither position nor time; it is
+//! only a wake. ISR delivery lag cancels out of every projection (`now` and
+//! the cursor advance together), bounding the error to under one byte-time,
+//! always on the late side: a byte counted as missing can only finish sooner
+//! than assumed, so the reply grid measured from these estimates never fires
+//! into a frame's own tail.
+
+use osc_protocol::frame::Header;
+
+use super::ring_wrap;
+use crate::traits::bus::tick_reached;
+
+/// A resolved frame's location in the ring: anchor index + ring-byte count,
+/// plus the wire-end estimate (`packet_end`) the reply trigger's reply gap is
+/// measured from (sec 7). Frontier frames project it from ring cadence at the
+/// covered checkpoint (late by less than a byte-time, never early); backlog
+/// frames ended in the past and carry `now` (elastic best-effort timing).
+pub struct FrameSpan {
+    pub anchor: u16,
+    pub footprint: u16,
+    pub packet_end: u32,
+}
+
+/// What the resolver wants from the composite after a step. The composite
+/// loops on [`Framer::resolve`] until it yields `None` or `Wait`.
+pub enum FramerOut {
+    /// Nothing resolvable; no framer deadline wanted.
+    None,
+    /// Arm/refresh the framer deadline at this absolute tick (frontier only).
+    Wait(u32),
+    /// The frontier frame's CRC-covered span is fully ringed -- only the two
+    /// wire-CRC bytes are still inbound -- so the composite may front-load the
+    /// CRC feed + dispatch now. The frame-end deadline is already armed at
+    /// `end_due`; the matching [`FramerOut::Frame`] follows there. Emitted at
+    /// most once per frame, never for backlog frames (they are complete --
+    /// there is nothing left to overlap with).
+    Covered { span: FrameSpan, end_due: u32 },
+    /// A whole frame is in the ring (geometry pre-validated); the ladder has
+    /// advanced past it. Resolve again for the next backlog frame.
+    Frame(FrameSpan),
+}
+
+// sec 4.1: header = BREAK, ID, LEN, INST; the break byte is index 0 of the
+// frame, so the header is readable `HEADER_SPAN_BYTES` in.
+const HEADER_SPAN_BYTES: u16 = Header::SIZE as u16;
+
+// sec 3.2 / position from the stream: a real break rings an all-zero byte;
+// the ladder expects it at the derived anchor. Anything else there is desync
+// (noise inserted/lost bytes).
+const BREAK_RING_BYTE: u8 = 0x00;
+
+// Header-aim epsilon (half a byte-time): the break rings at its FE point,
+// ~4 bit-times before the line rises [F5], so the first data byte starts
+// that far outside the byte cadence -- header aims bridge the tail or they
+// land one self-paced re-wake early. Data-anchored aims (covered, end)
+// need no epsilon: `now` is at-or-past the last completion, so a cadence
+// projection is never early, and the drift pad covers the rest.
+const BREAK_TAIL_EPS_DIV: u32 = 2;
+
+// Wire-proportional drift pad on every projection (~1.6%, sec 9.3): an
+// in-spec-slow transmitter can never make a projection early.
+const DRIFT_SHIFT: u32 = 6;
+
+// The wire CRC tail: the covered span completes this many byte-times before
+// the frame end, so the covered checkpoint leads the frame end by it.
+const COVERED_TAIL_BYTES: u32 = 2;
+
+// Dead-transmitter detector: a frontier whose ring made no progress for this
+// many byte-times is a sacrificed partial (host died, or a junk header's
+// footprint trapped the ladder) -- the hunt resumes one byte in (sec 3.3).
+// Generous by design: a live host's feeder can stall mid-frame (bench:
+// pirate walker bubbles pause the wire ~100 us mid-write and an 8-byte
+// horizon sacrificed live partials), waiting is free under break framing
+// (position, not the clock, is the truth), and the real bounds are the
+// host's retry timeout (~ms) and ring pressure (512 byte-times).
+const STARVE_GIVEUP_BYTES: u32 = 64;
+
+// Hunt scan bound per resolve call, so a desynced wake stays bounded; the
+// composite's drive loop re-enters via pend-on-past.
+const HUNT_BYTES_PER_WAKE: u16 = 64;
+
+/// Wire time for `bytes` more bytes at `tpb`, drift-padded -- the one
+/// projection formula behind every aim and estimate.
+#[inline]
+fn wire_lead(bytes: u32, tpb: u32) -> u32 {
+    let t = bytes.wrapping_mul(tpb);
+    t.wrapping_add(t >> DRIFT_SHIFT)
+}
+
+/// Frontier bookkeeping -- schedule hints only; the ring stays the truth.
+struct Frontier {
+    /// Covered checkpoint emitted for the frame at the ladder anchor.
+    covered: bool,
+    /// Giveup baseline taken (first observation of this frontier).
+    observed: bool,
+    /// Ring progress watermark + its tick: the dead-transmitter detector.
+    seen: u16,
+    progress_tick: u32,
+}
+
+impl Frontier {
+    const fn idle() -> Self {
+        Self {
+            covered: false,
+            observed: false,
+            seen: 0,
+            progress_tick: 0,
+        }
+    }
+
+    /// Progress observation: advance the watermark (giveup baseline).
+    fn advance(&mut self, cursor: u16, now: u32) {
+        if !self.observed {
+            self.observed = true;
+        } else if cursor == self.seen {
+            return;
+        }
+        self.seen = cursor;
+        self.progress_tick = now;
+    }
+}
+
+impl Default for Framer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct Framer {
+    /// The ladder (position from the stream): ring index where the current
+    /// frame's break byte sits.
+    anchor: u16,
+    /// A recovery episode is in progress (desync/reject/giveup): drops count
+    /// once per episode, and probe candidates that fail CRC are not wire
+    /// faults. Cleared when a candidate resolves as a whole valid frame.
+    hunting: bool,
+    frontier: Frontier,
+    /// Cursor at the last wire-fault service ([`Self::on_wire_fault`]).
+    fault_seen: u16,
+    drops: u32,
+}
+
+impl Framer {
+    pub const fn new() -> Self {
+        Self {
+            anchor: 0,
+            hunting: false,
+            frontier: Frontier::idle(),
+            fault_seen: 0,
+            drops: 0,
+        }
+    }
+
+    /// Frames dropped at transport layer 1 (sec 5.3), monotonic.
+    pub fn drops(&self) -> u32 {
+        self.drops
+    }
+
+    /// Re-sync the ladder to a known ring position -- bootstrap only (boot is
+    /// position 0 by construction; rescue reads a provably-still cursor).
+    pub fn resync(&mut self, cursor: u16) {
+        self.anchor = cursor;
+        self.frontier = Frontier::idle();
+        self.fault_seen = cursor;
+    }
+
+    /// USART FE/RX-error service -- a pure wake, in the strong sense (the
+    /// fault contract, osc-native sec 3.4): the event carries no position, no
+    /// time, and no identity, and NOTHING may be derived from it beyond "look
+    /// at the ring again". Latched flags re-fire and service lags behind the
+    /// wire, so any cursor sampled here describes the service, not the event
+    /// -- a fence built on it killed live frames under burst load (bench: hot
+    /// chains fell 95% -> 80%). The one thing this service computes is
+    /// freshness: `false` means no bytes ringed since the last service -- the
+    /// wake's evidence (if any) is still in flight, and the composite arms a
+    /// one-byte-time recheck.
+    pub fn on_wire_fault(&mut self, cursor: u16) -> bool {
+        if cursor == self.fault_seen {
+            return false;
+        }
+        self.fault_seen = cursor;
+        true
+    }
+
+    /// The composite rejected a resolved frame (CRC fail): the header that
+    /// sized the stride was itself unverified, so the stride cannot be
+    /// trusted. Resume the hunt one byte past the rejected anchor -- a real
+    /// frame hiding inside the rejected span (e.g. behind noise) is still
+    /// found and CRC-gated (sec 3.3).
+    pub fn on_frame_rejected(&mut self, anchor: u16, ring_len: usize) {
+        // The fault is already counted (`crc_fail`); the hunt is recovery.
+        self.hunting = true;
+        self.anchor = ring_wrap(anchor as usize + 1, ring_len) as u16;
+        self.frontier = Frontier::idle();
+    }
+
+    /// The composite verified a resolved frame: the ladder is trusted again;
+    /// any recovery episode ends here.
+    pub fn on_frame_verified(&mut self) {
+        self.hunting = false;
+    }
+
+    /// The ladder has consumed every ringed byte: nothing on the wire
+    /// follows the last resolved frame. The composite's staged-reply kill
+    /// keys off this (positional truth from the stream): a reply is stale
+    /// only if newer bytes follow its own frame.
+    pub fn caught_up(&self, cursor: u16) -> bool {
+        self.anchor == cursor
+    }
+
+    /// A rejected probe (a hunt candidate that failed CRC) is scan noise,
+    /// not a received frame -- the composite uses this to keep `crc_fail`
+    /// meaning "a trusted frame failed", once per episode.
+    pub fn probing(&self) -> bool {
+        self.hunting
+    }
+
+    /// One resolution step against the CURRENT ring state (data-first from
+    /// the stream). The composite loops until `None`/`Wait`. `cursor` is the
+    /// live DMA cursor read at call time -- progress truth, not a stale event
+    /// snapshot.
+    pub fn resolve(&mut self, ring: &[u8], cursor: u16, now: u32, tpb: u32) -> FramerOut {
+        let len = ring.len();
+        if len == 0 {
+            return FramerOut::None; // defensive: no ring to resolve against
+        }
+        let mut received = dist(cursor, self.anchor, len);
+        if received == 0 {
+            self.frontier = Frontier::idle();
+            return FramerOut::None; // ladder caught up; wait for wire
+        }
+        // The ladder's first byte must be a break with plausible geometry
+        // (LEN covers INST + CRC). Anything else means the stream lost or
+        // gained bytes (noise, or a sacrificed partial): HUNT -- scan forward
+        // for the next plausible candidate; the CRC gates everything
+        // downstream, so a wrong candidate costs nothing but the scan
+        // (sec 3.3). Bounded per wake; counted once per episode.
+        let mut budget = HUNT_BYTES_PER_WAKE;
+        loop {
+            let a = self.anchor as usize;
+            let plausible = ring[a] == BREAK_RING_BYTE
+                && (received < HEADER_SPAN_BYTES || ring[ring_wrap(a + 2, len)] >= 3);
+            if plausible {
+                break;
+            }
+            // Skipping noise sacrifices nothing: scan silently. Sacrificed
+            // FRAMES are counted where they die (giveup / crc_fail).
+            self.hunting = true;
+            self.anchor = ring_wrap(a + 1, len) as u16;
+            self.frontier = Frontier::idle();
+            received -= 1;
+            if received == 0 {
+                return FramerOut::None; // scanned everything; next break lands here
+            }
+            budget -= 1;
+            if budget == 0 {
+                return FramerOut::Wait(now); // pend-on-past re-entry
+            }
+        }
+        if received < HEADER_SPAN_BYTES {
+            let aim = now
+                .wrapping_add(wire_lead((HEADER_SPAN_BYTES - received) as u32, tpb))
+                .wrapping_add(tpb / BREAK_TAIL_EPS_DIV);
+            return self.wait(aim, now, tpb, cursor, len);
+        }
+        // Header readable: geometry pre-checked by the scan. The composite's
+        // decoder owns addressing/opcode (a foreign frame still advances the
+        // ladder; its bytes occupy the ring either way).
+        let mut hb = [0u8; Header::SIZE];
+        for (i, cell) in hb.iter_mut().enumerate() {
+            *cell = ring[ring_wrap(self.anchor as usize + i, len)];
+        }
+        let h = Header::from_bytes(&hb);
+        let footprint = h.frame_end() as u16;
+        if received >= footprint {
+            // Complete -- the fast path: process now; the frame ended in the
+            // past, so the estimate degenerates to elastic `now`.
+            let anchor = self.anchor;
+            self.anchor = ring_wrap(anchor as usize + footprint as usize, len) as u16;
+            self.frontier = Frontier::idle();
+            return FramerOut::Frame(FrameSpan {
+                anchor,
+                footprint,
+                packet_end: now,
+            });
+        }
+        let missing = (footprint - received) as u32;
+        if !self.frontier.covered && missing <= COVERED_TAIL_BYTES {
+            // Covered checkpoint: freeze the wire-end estimate here -- the
+            // tightest projection this frame gets (missing <= 2, so the
+            // ring-cadence error is under a byte-time) -- and hand the
+            // composite the overlap window. This branch returns before
+            // `wait`, so advance the progress watermark here too.
+            self.frontier.advance(cursor, now);
+            self.frontier.covered = true;
+            let packet_end = now.wrapping_add(wire_lead(missing, tpb));
+            let end_due = packet_end;
+            return FramerOut::Covered {
+                span: FrameSpan {
+                    anchor: self.anchor,
+                    footprint,
+                    packet_end,
+                },
+                end_due,
+            };
+        }
+        // Aim at the next milestone: the covered point, or (once emitted)
+        // the frame end. Data-anchored: pure cadence, no epsilon.
+        let to_target = if self.frontier.covered {
+            missing
+        } else {
+            missing - COVERED_TAIL_BYTES
+        };
+        let aim = now.wrapping_add(wire_lead(to_target, tpb));
+        self.wait(aim, now, tpb, cursor, len)
+    }
+
+    /// Progress-track the frontier and wake at the sooner of the aim and the
+    /// giveup horizon. Aims are fresh projections from live ring state, so a
+    /// stalled wire self-paces at byte-time intervals with no recheck
+    /// bookkeeping; the horizon is the sole death authority -- a wire that
+    /// makes NO progress for [`STARVE_GIVEUP_BYTES`] declares the partial
+    /// dead regardless of the aim (a junk header's far-future footprint must
+    /// not park the ladder).
+    fn wait(&mut self, aim: u32, now: u32, tpb: u32, cursor: u16, len: usize) -> FramerOut {
+        let giveup_span = STARVE_GIVEUP_BYTES.wrapping_mul(tpb);
+        let stalled = self.frontier.observed && cursor == self.frontier.seen;
+        self.frontier.advance(cursor, now);
+        if stalled && tick_reached(now, self.frontier.progress_tick.wrapping_add(giveup_span)) {
+            return self.give_up(len, now);
+        }
+        // A long wait is bounded by the horizon, so death is decidable the
+        // moment it falls due: a junk header's far-future footprint costs
+        // one horizon, not its whole claimed length (recovery bound, sec 3.4).
+        let horizon = self.frontier.progress_tick.wrapping_add(giveup_span);
+        let sooner = if aim.wrapping_sub(now) <= horizon.wrapping_sub(now) {
+            aim
+        } else {
+            horizon
+        };
+        FramerOut::Wait(sooner)
+    }
+
+    /// The candidate is dead -- the starve horizon expired (transmitter died,
+    /// or a junk header trapped the ladder): sacrifice one byte and resume
+    /// the hunt -- a real frame inside the span is still found, CRC-gated
+    /// (sec 3.3). Data is the only death authority (the fault contract): a
+    /// phantom born from garble dies by footprint-fill CRC or by starve,
+    /// never by fault position.
+    fn give_up(&mut self, len: usize, now: u32) -> FramerOut {
+        // A partial that will never complete is sacrificed -- count it, once
+        // per recovery episode (junk candidates inside an episode also give
+        // up, but they were never frames).
+        if !self.hunting {
+            self.drops = self.drops.wrapping_add(1);
+            self.hunting = true;
+        }
+        self.anchor = ring_wrap(self.anchor as usize + 1, len) as u16;
+        self.frontier = Frontier::idle();
+        FramerOut::Wait(now) // pend-on-past re-entry: hunt continues
+    }
+}
+
+/// Wrap-distance from `anchor` to `cursor` (bytes ringed since the anchor).
+/// The ring is far larger than one frame, so this cannot alias within a
+/// frame's window (sec 4.1).
+#[inline]
+fn dist(cursor: u16, anchor: u16, len: usize) -> u16 {
+    ring_wrap((cursor as usize + len) - anchor as usize, len) as u16
+}

--- a/firmware/lib/drivers/src/bus/mod.rs
+++ b/firmware/lib/drivers/src/bus/mod.rs
@@ -1,0 +1,61 @@
+//! osc-native transport driver (`docs/osc-native-protocol.md`): break-framed
+//! RX over a counted DMA ring, enable-when-ready TX with hardware CRC,
+//! snoop-driven status chains. The composite lands with the composition
+//! chunk; sub-drivers are pure state machines.
+
+pub mod chain;
+mod clock;
+mod decode;
+pub mod framer;
+mod servo_bus;
+mod trim;
+pub mod tx;
+
+pub use servo_bus::{LinkDiag, ServoBus};
+
+/// Minimum reply lead after the frame being answered, in us (sec 7). Fixed
+/// time, not byte-times: the margin covers the host's TC->release register
+/// poke -- a time-domain quantity -- so it neither balloons at 0.5M (2
+/// byte-times was 40 us of mandated silence) nor thins at 3M.
+pub const REPLY_GAP_US: u32 = 12;
+
+/// sec 9.1: a dominant low at least this long commands the rescue-rate switch.
+/// Measured chip-side (the main-loop line sampler), not by the transport --
+/// the break detector latches only at a span's END, so no wake can observe
+/// a pulse in progress.
+pub const RESCUE_LOW_US: u32 = 300;
+
+/// Ring-index wrap. The RX ring length is a power of two by contract
+/// (512 on V006, sec 11), so this is a mask -- rv32ec has no hardware divide
+/// and a `% len` on a runtime length is a ~100-cycle `__udivsi3` call the
+/// resolver would pay several times per frame.
+#[inline(always)]
+pub(crate) fn ring_wrap(i: usize, len: usize) -> usize {
+    debug_assert!(
+        len.is_power_of_two(),
+        "RX ring length must be a power of two"
+    );
+    i & (len - 1)
+}
+
+/// Largest legal frame footprint in ring bytes (sec 3.1).
+pub const FRAME_MAX: usize = osc_protocol::wire::footprint(u8::MAX);
+
+/// View a resolved frame as up to two ring segments (one span unless it
+/// wraps the seam).
+pub(crate) fn frame_view(ring: &[u8], anchor: u16, footprint: u16) -> osc_protocol::FrameBytes<'_> {
+    let anchor = anchor as usize;
+    let footprint = footprint as usize;
+    let len = ring.len();
+    if anchor + footprint <= len {
+        osc_protocol::FrameBytes::from(&ring[anchor..anchor + footprint])
+    } else {
+        osc_protocol::FrameBytes::new(&ring[anchor..], &ring[..footprint - (len - anchor)])
+    }
+}
+
+/// CRC spin backstop, iterations per covered byte: the hardware engine runs
+/// ~8x wire speed (F6), so this is orders of magnitude past any healthy
+/// completion. Shared by TX generation ([`tx`]) and RX validation
+/// ([`servo_bus`]) -- one CRC engine serves both.
+pub(crate) const SPIN_PER_BYTE: u32 = 64;

--- a/firmware/lib/drivers/src/bus/servo_bus.rs
+++ b/firmware/lib/drivers/src/bus/servo_bus.rs
@@ -1,0 +1,433 @@
+//! osc-native transport composite (`docs/osc-native-protocol.md`, driver-pattern
+//! sec 4, sec 5.4). Routes break/deadline/TX events between the four sub-drivers
+//! (`Framer`, `Chain`, `TxEngine`, `ClockTracker`), owns the one hardware CRC
+//! engine both TX generation and RX validation share, and muxes their
+//! deadlines onto the single tick-compare.
+
+use osc_core::traits::Dispatch;
+use osc_core::{BaudRate, BootMode};
+use osc_protocol::wire::{Id, Opcode};
+
+use super::chain::Chain;
+use super::clock::ClockTracker;
+use super::framer::Framer;
+use super::ring_wrap;
+use super::tx::{TxEngine, TxOut};
+use crate::traits::bus::{Deadline, Providers, RxRing, UsartBaud, tick_reached};
+
+mod crc;
+mod reply;
+mod route;
+
+/// us-per-byte numerator: 10 bit-times/byte x 1e6 us/s. `tpb = TICKS_PER_US x
+/// this / baud` stays within u32 for all four operational rates.
+const BYTE_TIME_NUMERATOR: u32 = 10_000_000;
+
+/// Slack on the reclaim-suspension frame allowance (sec 6): covers the snooper's
+/// deadline-B margin on the predecessor's frame end.
+const FRAME_ALLOWANCE_SLACK_BYTES: u32 = 8;
+
+/// Bound on same-wake deadline draining. Generous: one frame consumes at most
+/// a handful of due slots per wake (header lock, covered, end, chain, rescue);
+/// anything past the bound falls out to `arm_deadline`, whose pend-on-past
+/// contract re-enters the ISR rather than losing the slot.
+const DEADLINE_DRAIN_MAX: u32 = 8;
+
+/// Backlog frames resolved per wake before yielding via pend-on-past (position
+/// from the stream): bounds one wake's dispatch work without ever dropping --
+/// the ring holds the rest.
+const FRAMES_PER_WAKE: u32 = 16;
+
+/// Transport health counters the chip publishes into the telemetry region
+/// (sec 5.3 layer 1: dropped frames are counted, never answered).
+pub struct LinkDiag {
+    pub crc_fail_count: u32,
+    pub framing_drop_count: u32,
+}
+
+/// A frame dispatched ahead of its CRC verdict -- the spine (sec 4): dispatch
+/// always runs under the CRC's own latency; the verdict gates EFFECTS, never
+/// work. The reply (if any) sits staged in the TX engine and the write (if
+/// any) in the staging buffer until the frame end verifies.
+struct Pending {
+    anchor: u16,
+    footprint: u16,
+    packet_end: u32,
+    slot: u8,
+    /// Wire effect staged: a reply awaits the send/don't-send verdict.
+    staged: bool,
+    /// Table effect staged in the dispatcher: a write awaits commit/revert.
+    table: bool,
+}
+
+pub struct ServoBus<P: Providers> {
+    framer: Framer,
+    chain: Chain,
+    tx: TxEngine<P::Tx>,
+    crc: P::Crc,
+    ring: P::Ring,
+    deadline: P::Deadline,
+    baud: P::Baud,
+    id: u8,
+    rate: BaudRate,
+    tpb: u32,
+    response_deadline_us: u16,
+    pending_id: Option<u8>,
+    pending_baud: Option<BaudRate>,
+    pending_reboot: Option<BootMode>,
+    crc_fails: u32,
+    // The one frame dispatched ahead of its CRC verdict (sec 4: the spine).
+    // Backpressure bounds it to one: a pending frame IS the frontier, so the
+    // single staging slot and the single CRC accumulator are never contended.
+    pending: Option<Pending>,
+    // Deadline mux (sec 4.1/sec 6/sec 9.1): the soonest live slot arms the compare.
+    framer_at: Option<u32>,
+    chain_at: Option<u32>,
+    // Clock discipline (sec 9.3): MGMT CAL + drift tracker + trim loop.
+    clock: ClockTracker,
+}
+
+/// Ticks per byte-time at `rate` on the transport clock. Each arm folds to a
+/// literal via `const {}` (TICKS_PER_US is an associated const) -- the board
+/// build targets +zmmul (no hardware divide), so no runtime division is emitted
+/// (mirrors the chip `brr_for` idiom).
+fn tpb_for<P: Providers>(rate: BaudRate) -> u32 {
+    const fn compute(ticks_per_us: u32, baud_hz: u32) -> u32 {
+        ticks_per_us * BYTE_TIME_NUMERATOR / baud_hz
+    }
+    match rate {
+        BaudRate::B500000 => const { compute(<P::Deadline as Deadline>::TICKS_PER_US, 500_000) },
+        BaudRate::B1000000 => const { compute(<P::Deadline as Deadline>::TICKS_PER_US, 1_000_000) },
+        BaudRate::B2000000 => const { compute(<P::Deadline as Deadline>::TICKS_PER_US, 2_000_000) },
+        BaudRate::B3000000 => const { compute(<P::Deadline as Deadline>::TICKS_PER_US, 3_000_000) },
+    }
+}
+
+/// Wrap-aware "slot `at` is due at `now`".
+#[inline]
+fn due(now: u32, at: Option<u32>) -> bool {
+    matches!(at, Some(at) if tick_reached(now, at))
+}
+
+impl<P: Providers> ServoBus<P> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        ring: P::Ring,
+        deadline: P::Deadline,
+        crc: P::Crc,
+        tx: P::Tx,
+        mut baud: P::Baud,
+        id: u8,
+        rate: BaudRate,
+        response_deadline_us: u16,
+    ) -> Self {
+        baud.apply(rate);
+        Self {
+            framer: Framer::new(),
+            chain: Chain::new(),
+            tx: TxEngine::new(tx),
+            crc,
+            ring,
+            deadline,
+            baud,
+            id,
+            rate,
+            tpb: tpb_for::<P>(rate),
+            response_deadline_us,
+            pending_id: None,
+            pending_baud: None,
+            pending_reboot: None,
+            crc_fails: 0,
+            pending: None,
+            framer_at: None,
+            chain_at: None,
+            clock: ClockTracker::new(<P::Deadline as Deadline>::CLOCK_TRIM_STEP_PPM),
+        }
+    }
+
+    /// Break-wake ISR (LBD: a genuine >=10-bit dominant span landed, sec 3.4
+    /// -- garble never reaches this handler) -- a pure wake. It carries
+    /// neither position nor time (both are derived from the stream): the
+    /// resolver reads them from ring data, so a delayed or coalesced entry
+    /// costs nothing (any frames completed meanwhile resolve on the fast path
+    /// right here).
+    pub fn on_break<D: Dispatch>(&mut self, d: &mut D) {
+        let now = self.deadline.now();
+        // MGMT CAL train (sec 9.3): while a train is live, breaks are ruler
+        // marks, not frame traffic -- stamp against the announced gap and
+        // return. The ring still collects the break bytes; the framer's
+        // hunt scans them off silently once the train ends (0x00 runs are
+        // implausible candidates, and any junk lock dies CRC-uncounted
+        // under the hunt's probing flag).
+        if self.clock.cal_active() {
+            if let Some(at) = self.clock.on_cal_break(
+                now,
+                self.ring.cursor(),
+                <P::Deadline as Deadline>::TICKS_PER_US,
+            ) {
+                self.framer_at = Some(at);
+                self.arm_deadline();
+            }
+            return;
+        }
+        // Freshness first, resolve second: the fault service computes one
+        // bit (did bytes ring since the last service?) and nothing else --
+        // the fault contract. The resolve consumes whatever the ring holds.
+        let cursor = self.ring.cursor();
+        let fresh = self.framer.on_wire_fault(cursor);
+        // Drift stamp only when the newest ringed byte IS a break's 0x00 --
+        // classification from ring data, per the contract. A spurious or
+        // lagged wake can land at frame end looking FRESH (the frame's own
+        // bytes drained since the break's service), and stamping it
+        // clobbers the pair in flight -- the tracker starved to zero on
+        // silicon under the FE-era latched re-fires (DES pin:
+        // `tracker_survives_latched_refires_between_frames`). A CRC tail
+        // that happens to end 0x00 leaks one stamp and costs one pair --
+        // the byte-exactness and span gates absorb it.
+        if fresh && self.newest_is_break_byte(cursor) {
+            self.clock
+                .on_drift_break(now, self.ring.cursor(), self.ring.bytes().len(), self.tpb);
+        }
+        self.drive_framer(d);
+        // A wake whose evidence isn't ringed yet leaves the resolver with
+        // nothing (a coalesced or lagged service -- the contract's
+        // spurious-wake case): the ring tells the truth one byte-time
+        // later -- arm the recheck. A spurious re-fire costs one empty wake.
+        if !fresh && self.framer_at.is_none() {
+            self.framer_at = Some(now.wrapping_add(self.tpb));
+        }
+        // Wire safety: a staged, not-yet-streaming reply must never fire
+        // into the host's NEXT frame. But an FE alone doesn't mean the host
+        // moved on -- lagged deliveries routinely resolve the reply's own
+        // frame (or reach its covered checkpoint) inside this very wake
+        // (silicon event-trace: COVERED -> KILL 2 us apart, then verify
+        // armed the chain over the emptied engine -- ghost trigger, silent
+        // no-reply). Positional truth from the stream decides: kill only when
+        // ringed bytes FOLLOW the reply's own frame. A pending frame is
+        // mid-verdict by definition (its CRC gate reclaims the reply if this
+        // break garbled the frame); a Waiting chain expects predecessor
+        // breaks and only suspends its reclaim window (sec 6). Broadcast-ENUM
+        // replies are exempt (sec 9.2): colliding with a peer matcher IS their
+        // contract -- a yielded laggard turns the walk's collision signal
+        // into one clean frame and prunes its subtree. A CRC-verified fresh
+        // instruction still supersedes them (route_frame).
+        if self.tx.staged()
+            && !self.tx.collision_tolerant()
+            && !self.chain.waiting()
+            && self.pending.is_none()
+            && !self.framer.caught_up(self.ring.cursor())
+        {
+            self.tx.abort();
+            self.chain.reset();
+            self.chain_at = None;
+        }
+        // sec 6: a break while we hold a staged chain slot means the predecessor
+        // is alive -- suspend its reclaim window while the frame plays out.
+        let out = self.chain.on_break_observed(now);
+        self.route_chain(out);
+        self.arm_deadline();
+    }
+
+    /// The newest ringed byte -- the wire-fault service's break/re-fire
+    /// discriminator (a break rings its 0x00 last; a frame-end re-fire
+    /// sees the CRC tail).
+    fn newest_is_break_byte(&self, cursor: u16) -> bool {
+        let ring = self.ring.bytes();
+        let len = ring.len();
+        len != 0 && ring[ring_wrap(cursor as usize + len - 1, len)] == 0x00
+    }
+
+    /// A verified frame between breaks: classify its shape from ring data
+    /// (only silent shapes pair) and record it with the tracker.
+    pub(super) fn drift_note_verified(&mut self, anchor: u16, footprint: u16) {
+        // A second frame collapses the record to Many -- its shape is never
+        // read, so skip the ring classification.
+        if !self.clock.pair_open() {
+            self.clock.note_verified(footprint, false);
+            return;
+        }
+        let inst = self.ring_inst(anchor);
+        let ring = self.ring.bytes();
+        let len = ring.len();
+        if len == 0 {
+            return; // defensive: no ring, no record
+        }
+        let id = ring[ring_wrap(anchor as usize + 1, len)];
+        let silent = match inst.opcode() {
+            Some(Opcode::Gwrite) => true,
+            Some(Opcode::Write | Opcode::Commit) => inst.noreply() || id == Id::BROADCAST.as_byte(),
+            _ => false,
+        };
+        self.clock.note_verified(footprint, silent);
+    }
+
+    /// Tick-compare ISR: one or more muxed deadlines are due. Every slot a
+    /// handler body overruns (front-loaded dispatch inside the covered window
+    /// routinely overruns `end_due`) is drained in this same invocation -- a
+    /// pend->exit->re-enter round trip costs ~10 us of turnaround.
+    pub fn on_deadline<D: Dispatch>(&mut self, d: &mut D) {
+        for _ in 0..DEADLINE_DRAIN_MAX {
+            let now = self.deadline.now();
+            let mut progressed = false;
+            if due(now, self.framer_at) {
+                progressed = true;
+                self.framer_at = None;
+                // CAL watchdog (sec 9.3): during a live train the framer slot
+                // is the train's silence bound and nothing else -- expiry
+                // means the train died. Abandon it (no decision) and let
+                // the framer hunt whatever actually arrived. A dangling
+                // announce (train never started) dies here too.
+                self.clock.abandon_cal();
+                self.drive_framer(d);
+            }
+            if due(now, self.chain_at) {
+                progressed = true;
+                self.chain_at = None;
+                let out = self.chain.on_deadline(now);
+                self.route_chain(out);
+            }
+            if !progressed {
+                break;
+            }
+        }
+        self.arm_deadline();
+    }
+
+    /// TX DMA arm-complete ISR: stream the next arm, or apply deferred config
+    /// once the whole reply has drained (sec 4.2) -- the ack always leaves at
+    /// the old id/baud, the change lands after.
+    pub fn on_tx_complete(&mut self) {
+        if self.tx.on_arm_complete(&mut self.crc) == TxOut::Released {
+            if let Some(id) = self.pending_id.take() {
+                self.id = id;
+            }
+            if let Some(baud) = self.pending_baud.take() {
+                self.baud.apply(baud);
+                self.rate = baud;
+                self.tpb = tpb_for::<P>(self.rate);
+                self.clock.restart();
+            }
+            // A pending reboot waits for the main loop's `take_reboot`.
+        }
+    }
+
+    /// Main-loop poll for a deferred reboot -- withheld while a reply is
+    /// draining (a reset mid-ack truncates the frame on the wire; bench-
+    /// caught), honored on the first poll after the TX released. A silent
+    /// (NOREPLY/broadcast) reboot stages no ack and takes immediately.
+    pub fn take_reboot(&mut self) -> Option<BootMode> {
+        if self.tx.busy() {
+            return None;
+        }
+        self.pending_reboot.take()
+    }
+
+    pub fn diag(&self) -> LinkDiag {
+        LinkDiag {
+            crc_fail_count: self.crc_fails,
+            framing_drop_count: self.framer.drops(),
+        }
+    }
+
+    /// Main-loop poll, ISRs masked by the caller (the `diag` idiom): drain a
+    /// completed measurement -- a CAL train (absolute) or a drift window
+    /// (baseline-relative) -- through the trim loop. Returns the new trim
+    /// total -- signed chip steps from the factory default, positive =
+    /// slower -- for the caller to apply to the oscillator between frames.
+    pub fn poll_clock_trim(&mut self) -> Option<i8> {
+        self.clock.poll()
+    }
+
+    pub(super) fn reply_gap(&self) -> u32 {
+        super::REPLY_GAP_US * <P::Deadline as Deadline>::TICKS_PER_US
+    }
+
+    pub(super) fn reclaim(&self) -> u32 {
+        self.response_deadline_us as u32 * <P::Deadline as Deadline>::TICKS_PER_US
+    }
+
+    /// How long an observed predecessor break suspends its reclaim window:
+    /// the largest legal frame plus the snooper's own end-detection slack.
+    pub(super) fn frame_allowance(&self) -> u32 {
+        (super::FRAME_MAX as u32 + FRAME_ALLOWANCE_SLACK_BYTES) * self.tpb
+    }
+
+    /// Arm the compare at the soonest live slot, or cancel if none. A slot
+    /// already reached counts as due NOW, not as a full wrap away -- an ISR
+    /// body that overruns a pending deadline (front-loaded dispatch inside
+    /// the covered window does, routinely) must pend it, not push it behind
+    /// every future slot (bench signature: deadline B riding the +100 us
+    /// rescue wake).
+    fn arm_deadline(&mut self) {
+        let now = self.deadline.now();
+        let remaining = |at: u32| {
+            if tick_reached(now, at) {
+                0
+            } else {
+                at.wrapping_sub(now)
+            }
+        };
+        let mut best: Option<u32> = None;
+        for at in [self.framer_at, self.chain_at].into_iter().flatten() {
+            best = Some(match best {
+                Some(b) if remaining(b) <= remaining(at) => b,
+                _ => at,
+            });
+        }
+        match best {
+            Some(at) => self.deadline.set(at),
+            None => self.deadline.cancel(),
+        }
+    }
+
+    /// sec 9.1 rescue: the chip's line sampler measured a >=[`RESCUE_LOW_US`]
+    /// dominant low with zero ring progress -- a signal no transport wake can
+    /// observe (the break detector latches only at a span's END). Called from
+    /// the main loop under a critical section; the pulse is still holding the
+    /// line when the sampler declares, so the cursor is provably still.
+    ///
+    /// [`RESCUE_LOW_US`]: super::RESCUE_LOW_US
+    pub fn on_rescue_break(&mut self) {
+        // Own-TX guard: unreachable by physics on both wire configs (own
+        // data always carries stop-bit highs; the buffered wire's sense pin
+        // reads forced mark during TX), kept because an abort of a draining
+        // ack is the one real damage a spurious call could do.
+        if self.tx.streaming() {
+            return;
+        }
+        // sec 9.1: volatile rate switch -- the config register is untouched.
+        self.baud.apply(BaudRate::B500000);
+        self.rate = BaudRate::B500000;
+        self.tpb = tpb_for::<P>(self.rate);
+        self.clock.restart();
+        // Ladder bootstrap (position from the stream): a rescue pulse delivers
+        // no start edges, so the cursor is provably still -- the one
+        // sanctioned cursor read.
+        let cursor = self.ring.cursor();
+        self.framer.resync(cursor);
+        self.chain.reset();
+        self.tx.abort();
+        // A dropped pending frame's staged table effect is reclaimed by the
+        // dispatcher's auto-revert on the next dispatch.
+        self.pending = None;
+        self.framer_at = None;
+        self.chain_at = None;
+        self.arm_deadline();
+    }
+
+    /// Verdict-first ops: COMMIT (applies the whole staging buffer), MGMT
+    /// (reboots/config), and anything undecodable -- their effects can't stage,
+    /// so the CRC verdict must come first (the bus checks it, then dispatch
+    /// applies directly on that contract). Everything else dispatches ahead of
+    /// its verdict, effects gated by it. Read from the same INST byte
+    /// [`decode`] reads, so routing and dispatch can never disagree.
+    pub(super) fn verdict_first(&self, anchor: u16) -> bool {
+        !matches!(
+            self.ring_inst(anchor).opcode(),
+            Some(Opcode::Ping | Opcode::Read | Opcode::Gread | Opcode::Write | Opcode::Gwrite)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/firmware/lib/drivers/src/bus/servo_bus/crc.rs
+++ b/firmware/lib/drivers/src/bus/servo_bus/crc.rs
@@ -1,0 +1,95 @@
+//! RX-side CRC feed/verify over the ring, plus the anchor's INST accessor.
+
+use osc_protocol::wire::Inst;
+
+use super::ServoBus;
+use crate::traits::bus::{CrcEngine, Providers, RxRing};
+
+impl<P: Providers> ServoBus<P> {
+    /// Feed the covered span into the CRC engine straight from the ring -- no
+    /// M2M staging. Even-align the halfword feed by dropping the break's
+    /// leading `0x00` when the anchor is odd (an init-0 no-op, so the CRC is
+    /// unchanged); the ring base is halfword-aligned (`ring` is
+    /// `repr(align(2))`). A ring-wrap splits into two accumulating arms -- the
+    /// engine sums across them. A trailing odd byte is left for the fold at
+    /// verify. Direct feed is safe against the live circular ring: the engine
+    /// runs ~8x wire speed, so it drains the covered span long before the write
+    /// cursor could lap the ring back onto it.
+    #[cfg_attr(target_os = "none", unsafe(link_section = ".highcode"))]
+    #[cfg_attr(target_os = "none", inline(never))]
+    pub(super) fn crc_feed(&mut self, anchor: u16, footprint: u16) {
+        let ring = self.ring.bytes();
+        let len = ring.len();
+        let anchor = anchor as usize;
+        let start = anchor + (anchor & 1);
+        let end = anchor + footprint as usize - 2;
+        let bulk_end = end - ((end - start) & 1);
+        self.crc.reset();
+        if bulk_end <= len {
+            self.crc.feed(&ring[start..bulk_end]);
+        } else {
+            self.crc.feed(&ring[start..len]);
+            self.crc.feed(&ring[..bulk_end - len]);
+        }
+    }
+
+    /// The covered byte the even-bulk feed left behind, if the span was odd.
+    fn crc_tail(&self, anchor: u16, footprint: u16) -> Option<u8> {
+        let ring = self.ring.bytes();
+        let len = ring.len();
+        let anchor = anchor as usize;
+        let start = anchor + (anchor & 1);
+        let end = anchor + footprint as usize - 2;
+        if (end - start) & 1 == 1 {
+            Some(ring[(end - 1) % len])
+        } else {
+            None
+        }
+    }
+
+    /// Poll the CRC result, fold the trailing odd byte if the feed left one
+    /// (sec 3.2), and compare against the little-endian wire CRC at the
+    /// covered-span end. A spin miss counts as a fail -- indistinguishable from
+    /// a bad frame, and never wedges the wire. Requires a prior
+    /// [`Self::crc_feed`] of the same span.
+    pub(super) fn crc_verify(&mut self, anchor: u16, footprint: u16) -> bool {
+        let ring = self.ring.bytes();
+        let len = ring.len();
+        let covered = footprint as usize - 2;
+        let end = anchor as usize + covered;
+        let wire = u16::from_le_bytes([ring[end % len], ring[(end + 1) % len]]);
+        let tail = self.crc_tail(anchor, footprint);
+        let mut budget = super::super::SPIN_PER_BYTE * covered as u32;
+        loop {
+            if let Some(v) = self.crc.result() {
+                let v = match tail {
+                    Some(b) => osc_protocol::crc::osc_crc_continue(v, &[b]),
+                    None => v,
+                };
+                return v == wire;
+            }
+            if budget == 0 {
+                return false;
+            }
+            budget -= 1;
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Feed then verify the covered span against the wire CRC (the full,
+    /// non-front-loaded path).
+    pub(super) fn crc_ok(&mut self, anchor: u16, footprint: u16) -> bool {
+        if self.ring.bytes().is_empty() || (footprint as usize) < 2 {
+            return false;
+        }
+        self.crc_feed(anchor, footprint);
+        self.crc_verify(anchor, footprint)
+    }
+
+    /// The INST byte, 3 slots past the anchor (`[0x00][ID][LEN][INST]`).
+    pub(super) fn ring_inst(&self, anchor: u16) -> Inst {
+        let ring = self.ring.bytes();
+        let len = ring.len();
+        Inst(ring[(anchor as usize + 3) % len])
+    }
+}

--- a/firmware/lib/drivers/src/bus/servo_bus/reply.rs
+++ b/firmware/lib/drivers/src/bus/servo_bus/reply.rs
@@ -1,0 +1,118 @@
+//! The reply surface: `ReplyHandle` over disjoint bus fields and its builders.
+
+use osc_core::traits::{Reply, SendError, Status};
+use osc_core::{BaudRate, BootMode};
+use osc_protocol::wire::ResultCode;
+
+use super::super::tx::TxEngine;
+use super::ServoBus;
+use crate::traits::bus::{CrcEngine, Providers, TxWire};
+
+/// Reply surface over disjoint `ServoBus` fields (driver-pattern sec 4.3): the
+/// decoded request still borrows the ring while the dispatcher stages the
+/// reply into the TX engine and the deferred-config fields.
+pub(super) struct ReplyHandle<'a, W: TxWire, C: CrcEngine> {
+    pub(super) tx: &'a mut TxEngine<W>,
+    pub(super) crc: &'a mut C,
+    /// Write-through to the bus id: `set_id` applies here so a status staged
+    /// after it already carries the new id (the ASSIGN ack, sec 9.2).
+    pub(super) id: &'a mut u8,
+    pub(super) pending_id: &'a mut Option<u8>,
+    pub(super) pending_baud: &'a mut Option<BaudRate>,
+    pub(super) pending_reboot: &'a mut Option<BootMode>,
+    pub(super) pending_cal: &'a mut Option<(u16, u8)>,
+    pub(super) response_deadline_us: &'a mut u16,
+    pub(super) staged: bool,
+    /// sec 9.2: the request is a broadcast ENUM -- a reply staged through this
+    /// handle is marked collision-tolerant, keyed off its own payload (the
+    /// responder's UID) for the slot draw.
+    pub(super) tolerant: bool,
+}
+
+/// sec 9.2 slot key: the reply payload IS the responder's UID for ENUM -- fold
+/// its osc-CRC to a byte. The CRC mixing keeps same-reel sequential serials
+/// apart; sequencing XORs in the live tick, so equal keys still re-roll.
+fn slot_key(payload: &[u8]) -> u8 {
+    let crc = osc_protocol::crc::osc_crc(payload);
+    (crc ^ (crc >> 8)) as u8
+}
+
+impl<P: Providers> ServoBus<P> {
+    /// A reply surface over the deferred-config fields, with no request decode --
+    /// used at verdict commit, where hooks stage baud/id but no frame is
+    /// re-parsed (the ring isn't borrowed here).
+    pub(super) fn reply_handle(&mut self) -> ReplyHandle<'_, P::Tx, P::Crc> {
+        ReplyHandle {
+            tx: &mut self.tx,
+            crc: &mut self.crc,
+            id: &mut self.id,
+            pending_id: &mut self.pending_id,
+            pending_baud: &mut self.pending_baud,
+            pending_reboot: &mut self.pending_reboot,
+            pending_cal: &mut self.clock.pending_cal,
+            response_deadline_us: &mut self.response_deadline_us,
+            staged: false,
+            tolerant: false,
+        }
+    }
+}
+
+impl<W: TxWire, C: CrcEngine> Reply for ReplyHandle<'_, W, C> {
+    fn send_status(&mut self, status: Status<'_>) -> Result<(), SendError> {
+        let r = self
+            .tx
+            .stage(self.crc, *self.id, status.result, status.alert, status.data);
+        if r.is_ok() {
+            self.staged = true;
+            if self.tolerant {
+                self.tx.mark_collision_tolerant(slot_key(status.data));
+            }
+        }
+        r
+    }
+
+    fn send_status_gather(
+        &mut self,
+        result: ResultCode,
+        alert: bool,
+        spans: &[&[u8]],
+    ) -> Result<(), SendError> {
+        let r = self
+            .tx
+            .stage_gather(self.crc, *self.id, result, alert, spans);
+        if r.is_ok() {
+            self.staged = true;
+            if self.tolerant {
+                let crc = spans
+                    .iter()
+                    .fold(0, |c, s| osc_protocol::crc::osc_crc_continue(c, s));
+                self.tx.mark_collision_tolerant((crc ^ (crc >> 8)) as u8);
+            }
+        }
+        r
+    }
+
+    fn stage_id(&mut self, id: u8) {
+        *self.pending_id = Some(id);
+    }
+
+    fn set_id(&mut self, id: u8) {
+        *self.id = id;
+    }
+
+    fn stage_baud(&mut self, baud: BaudRate) {
+        *self.pending_baud = Some(baud);
+    }
+
+    fn set_response_deadline(&mut self, us: u16) {
+        *self.response_deadline_us = us;
+    }
+
+    fn stage_reboot(&mut self, mode: BootMode) {
+        *self.pending_reboot = Some(mode);
+    }
+
+    fn begin_clock_cal(&mut self, gap_us: u16, gaps: u8) {
+        *self.pending_cal = Some((gap_us, gaps));
+    }
+}

--- a/firmware/lib/drivers/src/bus/servo_bus/route.rs
+++ b/firmware/lib/drivers/src/bus/servo_bus/route.rs
@@ -1,0 +1,301 @@
+//! The dispatch spine: resolver -> frame routing -> CRC verdict -> reply sequencing.
+
+use osc_core::traits::{Dispatch, Dispatched, Request, RequestCtx};
+use osc_protocol::wire::{ENUM_REPLY_SLOTS, ResultCode};
+
+use super::super::chain::ChainOut;
+use super::super::decode::{Decoded, decode};
+use super::super::frame_view;
+use super::super::framer::{FrameSpan, FramerOut};
+use super::reply::ReplyHandle;
+use super::{Pending, ServoBus};
+use crate::traits::bus::{Deadline, Providers, RxRing, tick_reached};
+
+impl<P: Providers> ServoBus<P> {
+    /// Drive the resolver as far as ring DATA allows (data-first from the
+    /// stream): complete backlog frames process in-line with zero clock
+    /// involvement; the frontier arms a deadline and returns. Bounded per
+    /// wake -- past the bound the framer
+    /// slot re-arms at `now` (pend-on-past re-entry) so the other mux slots
+    /// are never starved by a deep backlog.
+    pub(super) fn drive_framer<D: Dispatch>(&mut self, d: &mut D) {
+        for _ in 0..super::FRAMES_PER_WAKE {
+            let now = self.deadline.now();
+            let out = self
+                .framer
+                .resolve(self.ring.bytes(), self.ring.cursor(), now, self.tpb);
+            match out {
+                FramerOut::None => {
+                    self.framer_at = None;
+                    return;
+                }
+                FramerOut::Wait(t) => {
+                    self.framer_at = Some(t);
+                    return;
+                }
+                FramerOut::Covered { span, end_due } => {
+                    self.framer_at = Some(end_due);
+                    self.route_frame(span, false, d);
+                    return;
+                }
+                FramerOut::Frame(span) => {
+                    self.on_frame_end(span, d);
+                }
+            }
+        }
+        self.framer_at = Some(self.deadline.now());
+    }
+
+    pub(super) fn route_chain(&mut self, mut out: ChainOut) {
+        loop {
+            match out {
+                ChainOut::None => return,
+                ChainOut::Wait(t) => {
+                    // A wait tick already reached needs no scheduling round
+                    // trip: consume the slot in place (high-baud grids and
+                    // backlog replies are past-due by sequencing time, and
+                    // an expired reclaim window is a reclaim by definition).
+                    let now = self.deadline.now();
+                    if !tick_reached(now, t) {
+                        self.chain_at = Some(t);
+                        return;
+                    }
+                    out = self.chain.on_deadline(now);
+                }
+                ChainOut::Trigger { predecessor_silent } => {
+                    let over = predecessor_silent.then_some(ResultCode::PredecessorSilent);
+                    self.tx.trigger(&mut self.crc, over);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Frame end (deadline B): a pending frame gets its verdict; anything else
+    /// is a complete frame entering the spine ([`Self::route_frame`]).
+    fn on_frame_end<D: Dispatch>(&mut self, span: FrameSpan, d: &mut D) {
+        match self.pending.take() {
+            Some(p) if p.anchor == span.anchor && p.footprint == span.footprint => {
+                self.verify(p, d);
+            }
+            Some(_) => {
+                // Defensive: a pending frame that isn't this one -- drop it. Any
+                // dangling staged write is reclaimed by the dispatcher
+                // auto-revert on the next dispatch.
+                self.drop_staged();
+                self.route_frame(span, true, d);
+            }
+            None => self.route_frame(span, true, d),
+        }
+    }
+
+    /// The spine: dispatch a frame ahead of its CRC verdict when its effects
+    /// can stage (sec 4). `complete` distinguishes a whole frame (backlog / fast
+    /// path -- every byte incl. the CRC is ringed, so the verdict fires now)
+    /// from a frontier frame at its covered checkpoint (the two CRC bytes still
+    /// inbound -- the verdict is deferred to the frame end). A stageable op
+    /// (ping/read/gread/write/gwrite) dispatches inline with the CRC feed
+    /// chewing underneath; the verdict gates its effects -- SEND/DON'T-SEND of a
+    /// staged reply, COMMIT/REVERT of a staged write. Verdict-first ops
+    /// (COMMIT/MGMT, effects unstageable) and any frame overlapping a live
+    /// reply pipeline check the CRC first, then dispatch. A frontier frame that
+    /// lands in the verdict-first path just defers -- its frame end arrives here
+    /// `complete`.
+    fn route_frame<D: Dispatch>(&mut self, span: FrameSpan, complete: bool, d: &mut D) {
+        let anchor = span.anchor;
+        let footprint = span.footprint;
+        let packet_end = span.packet_end;
+        // Status frames only advance the snoop chain (sec 6) -- framing-level
+        // truth, NO validation: the chain consumes nothing from the body, and
+        // skipping the CRC keeps the snapshot buffer free while our own reply
+        // streams from it. A frontier status defers to its frame end.
+        if self.ring_inst(anchor).is_status() {
+            if complete {
+                let out = self.chain.on_status_end(packet_end);
+                self.route_chain(out);
+            }
+            return;
+        }
+        // The spine runs only from an idle reply pipeline: superseding a live
+        // chain or staged reply belongs AFTER the CRC gate (a garbled frame
+        // must touch nothing, sec 5.3 L1), so those overlaps fall to verdict-first
+        // below. The guard also keeps the CRC engine free through a pending
+        // window -- chain/tx activate only at a verdict, so no trigger reset
+        // can clobber a fed span.
+        if !self.chain.active() && !self.tx.busy() && !self.verdict_first(anchor) {
+            // Feed first so the engine chews the covered span under the
+            // dispatch body; the verdict then finds it settled.
+            self.crc_feed(anchor, footprint);
+            let (staged, slot, table) =
+                match self
+                    .dispatch_decoded(anchor, footprint, |req, ctx, h| d.dispatch(req, ctx, h))
+                {
+                    Some((staged, slot, out)) => (staged, slot, matches!(out, Dispatched::Pending)),
+                    // Skip (a group op not listing us): a bare verdict moves the
+                    // ladder (complete); the frame end does it for a frontier.
+                    None if complete => (false, 0, false),
+                    None => return,
+                };
+            let p = Pending {
+                anchor,
+                footprint,
+                packet_end,
+                slot,
+                staged,
+                table,
+            };
+            if complete {
+                self.verify(p, d);
+            } else {
+                self.pending = Some(p);
+            }
+            return;
+        }
+        // Verdict-first (only meaningful complete -- a frontier defers): the CRC
+        // is checked before any effect. COMMIT/MGMT (unstageable), and frames
+        // overlapping a live reply pipeline. A fail drops silently (sec 5.3 L1),
+        // the hunt resuming one byte in (sec 3.3).
+        if !complete {
+            return;
+        }
+        if !self.crc_ok(anchor, footprint) {
+            if !self.framer.probing() {
+                self.crc_fails = self.crc_fails.wrapping_add(1);
+            }
+            let len = self.ring.bytes().len();
+            self.framer.on_frame_rejected(anchor, len);
+            return;
+        }
+        self.framer.on_frame_verified();
+        self.drift_note_verified(anchor, footprint);
+        // A fresh instruction supersedes any stale, not-yet-streaming reply --
+        // post-verdict, so a garbled frame touched nothing.
+        self.chain.reset();
+        self.chain_at = None;
+        if self.tx.staged() {
+            self.tx.abort();
+        }
+        // Dispatch inline -- the CRC already passed, so a staged table effect
+        // commits directly and any reply sequences from the packet end. A frame
+        // that decodes as another servo's touches nothing.
+        let Some((staged, slot, out)) =
+            self.dispatch_decoded(anchor, footprint, |req, ctx, h| d.dispatch(req, ctx, h))
+        else {
+            return;
+        };
+        if matches!(out, Dispatched::Pending) {
+            let mut handle = self.reply_handle();
+            d.commit(&mut handle);
+        }
+        if staged && self.tx.staged() {
+            self.sequence_reply(slot, packet_end);
+        }
+    }
+
+    /// Verify a pending frame's CRC and resolve the verdict. Pass -> commit a
+    /// staged table effect (COMMIT) and sequence a staged reply (SEND); fail
+    /// (or spin miss) -> revert the write (REVERT), drop the reply
+    /// (DON'T-SEND), count, and rewind the ladder (sec 5.3 L1).
+    #[cfg_attr(target_os = "none", unsafe(link_section = ".highcode"))]
+    #[cfg_attr(target_os = "none", inline(never))]
+    fn verify<D: Dispatch>(&mut self, p: Pending, d: &mut D) {
+        if !self.crc_verify(p.anchor, p.footprint) {
+            if p.table {
+                d.revert();
+            }
+            self.drop_staged();
+            if !self.framer.probing() {
+                self.crc_fails = self.crc_fails.wrapping_add(1);
+            }
+            let len = self.ring.bytes().len();
+            self.framer.on_frame_rejected(p.anchor, len);
+            return;
+        }
+        self.framer.on_frame_verified();
+        self.drift_note_verified(p.anchor, p.footprint);
+        if p.table {
+            let mut handle = self.reply_handle();
+            d.commit(&mut handle);
+        }
+        // Sequence from the ENGINE's state, not the recorded flag: any path
+        // that reclaimed the staged reply between dispatch and here would
+        // otherwise arm the chain over an empty engine (ghost trigger).
+        if p.staged && self.tx.staged() {
+            self.sequence_reply(p.slot, p.packet_end);
+        }
+    }
+
+    /// Sequence a staged reply onto the snoop chain. reply gap is a wire gap
+    /// measured from the packet end (sec 7), not from this (later) verify wake --
+    /// the estimate is the framer's, conservative by the drift adder.
+    fn sequence_reply(&mut self, slot: u8, packet_end: u32) {
+        // sec 9.2 slot delay: a collision-tolerant reply offsets its trigger by
+        // (key ^ tick) & (SLOTS-1) byte-times. Twin matchers run
+        // cycle-identical firmware and otherwise answer in unison -- and a
+        // sub-bit-aligned superposition of near-equal frames reads back as
+        // ONE clean frame instead of collision garble. The tick term re-draws
+        // every exchange, so equal keys never stick.
+        let gap = match self.tx.slot_key() {
+            Some(key) => {
+                let draw = (key ^ self.deadline.now() as u8) & (ENUM_REPLY_SLOTS - 1);
+                self.reply_gap().wrapping_add(draw as u32 * self.tpb)
+            }
+            None => self.reply_gap(),
+        };
+        let out = self.chain.on_reply_staged(
+            slot,
+            packet_end,
+            gap,
+            self.reclaim(),
+            self.frame_allowance(),
+        );
+        self.route_chain(out);
+    }
+
+    /// Drop a not-yet-streaming staged reply and any chain sequencing it began.
+    fn drop_staged(&mut self) {
+        if self.tx.staged() {
+            self.tx.abort();
+        }
+        self.chain.reset();
+        self.chain_at = None;
+    }
+
+    /// View the frame as up to two ring segments (one span unless it wraps the
+    /// seam), decode, and run `f` over disjoint borrows (driver-pattern sec 4.3):
+    /// the decoded request borrows the ring while `f` stages a reply through the
+    /// [`ReplyHandle`]. Returns `(staged, slot, f-result)`, or `None` for a frame
+    /// that isn't ours.
+    fn dispatch_decoded<T>(
+        &mut self,
+        anchor: u16,
+        footprint: u16,
+        f: impl FnOnce(Request<'_>, RequestCtx, &mut ReplyHandle<'_, P::Tx, P::Crc>) -> T,
+    ) -> Option<(bool, u8, T)> {
+        let frame = frame_view(self.ring.bytes(), anchor, footprint);
+        let (req, ctx, slot) = match decode(frame, self.id) {
+            Decoded::Own(req, ctx, slot) => (req, ctx, slot),
+            _ => return None,
+        };
+        // sec 9.2: an ENUM reply's staged wire effect is collision-tolerant --
+        // its job is to collide with peer matchers (the on_break kill site
+        // skips it, and staging keys its slot delay off the UID payload).
+        let tolerant = matches!(req, Request::Enumerate { .. });
+        // Disjoint field borrows: `frame`/`req` hold `&self.ring`; the handle
+        // takes the reply-staging fields mutably.
+        let mut handle = ReplyHandle {
+            tx: &mut self.tx,
+            crc: &mut self.crc,
+            id: &mut self.id,
+            pending_id: &mut self.pending_id,
+            pending_baud: &mut self.pending_baud,
+            pending_reboot: &mut self.pending_reboot,
+            pending_cal: &mut self.clock.pending_cal,
+            response_deadline_us: &mut self.response_deadline_us,
+            staged: false,
+            tolerant,
+        };
+        let out = f(req, ctx, &mut handle);
+        Some((handle.staged, slot, out))
+    }
+}

--- a/firmware/lib/drivers/src/bus/servo_bus/tests.rs
+++ b/firmware/lib/drivers/src/bus/servo_bus/tests.rs
@@ -1,0 +1,862 @@
+//! Composite spec tests: real byte frames laid into the ring, driven through
+//! `on_break`/`on_deadline` against the real core dispatcher, asserting on the
+//! recorded wire bytes. The fakes advance `now` by reading the armed tick, so
+//! every deadline the mux computes is exercised end to end.
+
+use osc_core::regions::CONTROL_BASE_ADDR;
+use osc_core::regions::config::addr::comms::ID as ID_ADDR;
+use osc_core::{BaudRate, Dispatch, RegionStorage, Session, Shared};
+use osc_protocol::reply::FrameBuf;
+use osc_protocol::wire::{self, Id, Inst, MgmtOp, Opcode, ResultCode};
+
+use crate::mocks::bus::{FakeWire, Harness, RING_LEN, WireEvent};
+
+const ID: u8 = 7;
+const RATE: BaudRate = BaudRate::B1000000;
+const TPB: u32 = 10; // TICKS_PER_US(1) * 1e7 / 1e6
+// REPLY_GAP_US x TestProviders TICKS_PER_US(1).
+const REPLY_GAP: u32 = 12;
+
+fn shared_seeded() -> Shared {
+    let shared = Shared::new();
+    shared.table.with_mut(|t| {
+        t.config.identity.model_number = 0x1234;
+        t.config.identity.firmware_version = 0x56;
+    });
+    shared
+}
+
+// --- frame builders -------------------------------------------------------
+
+fn instruction(id: u8, op: Opcode, flags: u8, payload: &[u8]) -> std::vec::Vec<u8> {
+    let mut b = FrameBuf::<64>::new();
+    b.start(Id::new(id), Inst::instruction(op, flags));
+    b.payload_mut()[..payload.len()].copy_from_slice(payload);
+    b.finish(payload.len() as u8);
+    b.seal().to_vec()
+}
+
+fn status(id: u8, result: ResultCode, data: &[u8]) -> std::vec::Vec<u8> {
+    let mut b = FrameBuf::<64>::new();
+    b.start(Id::new(id), Inst::status(result, false));
+    b.payload_mut()[..data.len()].copy_from_slice(data);
+    b.finish(data.len() as u8);
+    b.seal().to_vec()
+}
+
+// --- drivers --------------------------------------------------------------
+
+/// Deliver a whole frame: break, then the header deadline with the covered
+/// span already ringed (Covered emits and dispatch runs from that wake),
+/// then the end deadline (the verdict). Timing is ring-cadence (time derived
+/// from the stream): every aim projects `now + missing byte-times` from live
+/// ring state, so the wakes land deterministically for any footprint.
+/// Returns the frozen packet-end estimate the reply's reply gap is measured
+/// from: the covered wake + the 2-byte CRC tail at wire pace.
+fn deliver<D: Dispatch>(
+    bus: &mut crate::bus::ServoBus<crate::mocks::bus::TestProviders>,
+    h: &Harness,
+    anchor: usize,
+    frame: &[u8],
+    now0: u32,
+    d: &mut D,
+) -> u32 {
+    h.ring.place(anchor, frame);
+    let fp = frame.len();
+    // The ladder reaches `anchor` through prior traffic in production; the
+    // harness fabricates positions, so bootstrap it explicitly.
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(now0);
+    h.ring.set_cursor(((anchor + 1) % RING_LEN) as u16);
+    bus.on_break(d);
+
+    // Deadline A: the header locks, and with the covered span ringed the
+    // covered checkpoint fires from this same wake -- the dispatch point.
+    let a = h.deadline.armed().expect("deadline A");
+    h.deadline.set_now(a);
+    h.ring.set_cursor(((anchor + fp - 2) % RING_LEN) as u16);
+    bus.on_deadline(d);
+
+    // The frozen ring-cadence estimate (missing = the 2 CRC bytes; the
+    // drift adder is zero at these spans on the test clock).
+    let end = a.wrapping_add(2 * TPB);
+
+    // Deadline B (end_due): the whole frame is in -- verdict + sequencing.
+    let b = h.deadline.armed().expect("deadline B");
+    h.deadline.set_now(b);
+    h.ring.set_cursor(((anchor + fp) % RING_LEN) as u16);
+    bus.on_deadline(d);
+    end
+}
+
+fn fire<D: Dispatch>(
+    bus: &mut crate::bus::ServoBus<crate::mocks::bus::TestProviders>,
+    h: &Harness,
+    d: &mut D,
+) {
+    let at = h.deadline.armed().expect("a deadline is armed");
+    h.deadline.set_now(at);
+    bus.on_deadline(d);
+}
+
+/// Pump arm-completions until the reply drains: the CRC ships as its own final
+/// arm, so a full reply now spans more than one TC.
+fn drain_tx(bus: &mut crate::bus::ServoBus<crate::mocks::bus::TestProviders>, h: &Harness) {
+    loop {
+        bus.on_tx_complete();
+        if matches!(h.wire.log().last(), Some(WireEvent::Release)) {
+            break;
+        }
+    }
+}
+
+/// Parse the most recent reply frame from the wire log into (id, inst, payload).
+fn last_reply(wire: &FakeWire) -> (u8, Inst, std::vec::Vec<u8>) {
+    let log = wire.log();
+    let start = log
+        .iter()
+        .rposition(|e| *e == WireEvent::Start)
+        .expect("a reply started");
+    let mut bytes = std::vec::Vec::new();
+    for e in &log[start + 1..] {
+        match e {
+            WireEvent::Send(v) => bytes.extend_from_slice(v),
+            WireEvent::Release => break,
+            WireEvent::Start => {}
+        }
+    }
+    let id = bytes[0];
+    let len = bytes[1];
+    let inst = Inst(bytes[2]);
+    let p = wire::payload_len(len) as usize;
+    (id, inst, bytes[3..3 + p].to_vec())
+}
+
+// --- scenarios ------------------------------------------------------------
+
+#[test]
+fn s1_ping_round_trip() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let frame = instruction(ID, Opcode::Ping, 0, &[]);
+    let end = deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+
+    // Reply is staged but not on the wire until the reply gap deadline.
+    assert!(!h.wire.started());
+    assert_eq!(h.deadline.armed(), Some(end + REPLY_GAP));
+
+    fire(&mut bus, &h, &mut d);
+    assert!(h.wire.started());
+    drain_tx(&mut bus, &h);
+
+    // Exact bytes: sealed status(model, fw), valid CRC.
+    let reference = status(ID, ResultCode::Ok, &[0x34, 0x12, 0x56]);
+    assert_eq!(h.wire.sent(), reference[1..]);
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert!(inst.is_status());
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(data, &[0x34, 0x12, 0x56]);
+}
+
+#[test]
+fn s2_read_returns_table_bytes() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // READ addr 0 (even) count 4.
+    let frame = instruction(ID, Opcode::Read, 0, &[0, 0, 4, 0]);
+    deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+
+    let (_, inst, data) = last_reply(&h.wire);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(data.len(), 4);
+    assert_eq!(&data[..2], &[0x34, 0x12]); // model number, LE
+}
+
+#[test]
+fn s3_write_acks_then_noreply_is_silent() {
+    // WRITE torque_enable=1 -> ack, table mutated.
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = Shared::new();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let addr = CONTROL_BASE_ADDR.to_le_bytes();
+    let frame = instruction(ID, Opcode::Write, 0, &[addr[0], addr[1], 1]);
+    deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    let (_, inst, data) = last_reply(&h.wire);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(data.is_empty());
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+
+    // WRITE with NOREPLY: applied, no wire activity.
+    let h2 = Harness::new();
+    let mut bus2 = h2.build(ID, RATE, 60);
+    let shared2 = Shared::new();
+    let mut session2 = Session::new();
+    let mut d2 = session2.dispatcher(&shared2);
+    let frame2 = instruction(
+        ID,
+        Opcode::Write,
+        Inst::FLAG_NOREPLY,
+        &[addr[0], addr[1], 1],
+    );
+    deliver(&mut bus2, &h2, 100, &frame2, 1000, &mut d2);
+    assert!(!h2.wire.started());
+    assert_eq!(h2.deadline.armed(), None); // no chain armed
+    assert!(shared2.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+#[test]
+fn s4_write_id_acks_from_old_id_then_applies() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let addr = ID_ADDR.to_le_bytes();
+    let frame = instruction(ID, Opcode::Write, 0, &[addr[0], addr[1], 42]);
+    deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+    fire(&mut bus, &h, &mut d);
+
+    // Ack leaves from the OLD id; new id not yet applied.
+    let (id, _, _) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+
+    // TX drains -> deferred id apply. A ping to 42 now replies.
+    drain_tx(&mut bus, &h);
+    let ping = instruction(42, Opcode::Ping, 0, &[]);
+    deliver(&mut bus, &h, 200, &ping, 5000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id2, inst2, _) = last_reply(&h.wire);
+    assert_eq!(id2, 42);
+    assert!(inst2.is_status());
+}
+
+#[test]
+fn s5_gread_slot1_waits_for_predecessor() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 600);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // Uniform GREAD addr 0 count 4, ids [5, 7] -> we are slot 1.
+    let gread = instruction(ID, Opcode::Gread, 0, &[0, 0, 4, 0, 5, ID]);
+    let gread = broadcast_id(gread);
+    let end = deliver(&mut bus, &h, 100, &gread, 1000, &mut d);
+    // Armed at end + reply gap + reclaim; not yet triggerable.
+    assert_eq!(h.deadline.armed(), Some(end + REPLY_GAP + 600));
+    assert!(!h.wire.started());
+
+    // Predecessor (id 5) status frame -> our slot pends.
+    let pre = status(5, ResultCode::Ok, &[0xAA, 0xBB]);
+    deliver(&mut bus, &h, 200, &pre, end + 2, &mut d);
+    assert!(!h.wire.started());
+
+    // Now the reply gap deadline triggers our reply, not silent.
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, _) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+#[test]
+fn s6_gread_slot1_reclaim_marks_predecessor_silent() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 600);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let gread = broadcast_id(instruction(ID, Opcode::Gread, 0, &[0, 0, 4, 0, 5, ID]));
+    deliver(&mut bus, &h, 100, &gread, 1000, &mut d);
+    // No predecessor: the reclaim window expires and we take the slot.
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, _) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::PredecessorSilent));
+}
+
+#[test]
+fn s7_corrupt_crc_drops_with_no_reply() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let mut frame = instruction(ID, Opcode::Ping, 0, &[]);
+    let covered = frame.len() - 2;
+    frame[covered] ^= 0xFF; // corrupt the CRC-lo byte
+    deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+
+    assert!(!h.wire.started());
+    assert_eq!(h.deadline.armed(), None);
+    assert_eq!(bus.diag().crc_fail_count, 1);
+}
+
+#[test]
+fn s8_odd_anchor_round_trips() {
+    // Anchor parity is irrelevant (sec 3.2 self-aligning feed): an odd-anchored
+    // frame validates and replies like any other.
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let frame = instruction(ID, Opcode::Ping, 0, &[]);
+    deliver(&mut bus, &h, 101, &frame, 1000, &mut d); // odd anchor
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert!(inst.is_status());
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(data, &[0x34, 0x12, 0x56]);
+    assert_eq!(bus.diag().framing_drop_count, 0);
+}
+
+#[test]
+fn s9_frame_wrapping_ring_boundary_decodes() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // Ping footprint 6 at anchor 508 wraps 508..512, 0, 1.
+    let frame = instruction(ID, Opcode::Ping, 0, &[]);
+    deliver(&mut bus, &h, RING_LEN - 4, &frame, 1000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert!(inst.is_status());
+    assert_eq!(data, &[0x34, 0x12, 0x56]);
+}
+
+#[test]
+fn s12_write_wrapping_ring_boundary_mutates_and_acks() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = Shared::new();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // WRITE torque_enable=1 (footprint 10) placed so its payload wraps the seam:
+    // anchor 506 lays header+addr at 506..512, the data byte + CRC at 0..4.
+    let addr = CONTROL_BASE_ADDR.to_le_bytes();
+    let frame = instruction(ID, Opcode::Write, 0, &[addr[0], addr[1], 1]);
+    deliver(&mut bus, &h, RING_LEN - 6, &frame, 1000, &mut d);
+    fire(&mut bus, &h, &mut d);
+
+    let (_, inst, data) = last_reply(&h.wire);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(data.is_empty());
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+/// sec 9.1 rescue is a chip-side declaration now (the main-loop line sampler --
+/// the break detector latches only at a span's END, so no wake can see a
+/// pulse in progress; the sampler's NDTR-frozen window is the phantom-alias
+/// veto the old two-sample confirm provided). The driver's part is the
+/// event: switch to the rescue rate and resync at the provably-still cursor.
+#[test]
+fn s10_rescue_break_switches_to_500k_and_resyncs() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+
+    h.deadline.set_now(1000);
+    h.ring.set_cursor(1); // the pulse's ringed 0x00 at index 0
+    bus.on_rescue_break();
+
+    let applied = h.baud.applied();
+    assert_eq!(applied.first(), Some(&RATE)); // new() applied the configured rate
+    assert_eq!(applied.last(), Some(&BaudRate::B500000));
+    // Every transport slot cleared: nothing armed until the host talks.
+    assert_eq!(h.deadline.armed(), None);
+}
+
+#[test]
+fn s11_break_after_covered_kills_staged_reply() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // Drive a READ up to its covered checkpoint: the reply is front-loaded
+    // (dispatched + staged) but not yet on the wire.
+    let frame = instruction(ID, Opcode::Read, 0, &[0, 0, 4, 0]);
+    let anchor = 100usize;
+    let fp = frame.len();
+    h.ring.place(anchor, &frame);
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    h.ring.set_cursor(((anchor + 1) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+    let a = h.deadline.armed().expect("deadline A");
+    h.deadline.set_now(a);
+    h.ring.set_cursor(((anchor + 4) % RING_LEN) as u16);
+    bus.on_deadline(&mut d);
+    let c = h.deadline.armed().expect("covered deadline");
+    h.deadline.set_now(c);
+    h.ring.set_cursor(((anchor + fp - 2) % RING_LEN) as u16);
+    bus.on_deadline(&mut d);
+    assert!(!h.wire.started(), "reply is staged, not yet triggered");
+
+    // A fresh break lands before the end deadline. Data-first: the READ is
+    // complete in the ring, so it resolves and its reply stages -- and the
+    // break then kills the staged-not-streaming reply (the host moved on):
+    // no phantom read reply reaches the wire.
+    let m = 300usize; // ring[m] defaults to 0x00 -> a real break
+    h.deadline.set_now(c + 1);
+    h.ring.set_cursor(((m + 1) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+    assert!(!h.wire.started(), "staged reply killed by the break");
+
+    // Drain whatever the new break armed (a starving header): still silent.
+    if h.deadline.armed().is_some() {
+        fire(&mut bus, &h, &mut d);
+    }
+    assert!(!h.wire.started(), "the cancelled reply never fires");
+
+    // The following read exchange still works.
+    let next = instruction(ID, Opcode::Read, 0, &[0, 0, 4, 0]);
+    deliver(&mut bus, &h, 100, &next, c + 5000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(&data[..2], &[0x34, 0x12]);
+}
+
+/// sec 9.2 exemption to s11's wire-safety kill: a broadcast-ENUM reply's job is
+/// to collide -- a peer matcher's leading break (its 0x00 ringing right
+/// behind our frame, exactly the s11 kill evidence) must NOT kill the staged
+/// reply, or the wire carries one clean frame, the walk records a unique
+/// match, and the laggard's whole subtree goes invisible.
+#[test]
+fn enum_reply_survives_a_peer_matchers_break() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // Broadcast ENUM, empty prefix: every servo matches (the tree root).
+    // Verdict-first, so the reply stages at the frame end with its trigger
+    // armed one reply gap out.
+    let frame = instruction(
+        Id::BROADCAST.as_byte(),
+        Opcode::Mgmt,
+        0,
+        &[MgmtOp::Enum as u8, 0],
+    );
+    let end = deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+    assert!(!h.wire.started(), "reply staged, trigger one reply gap out");
+
+    // The peer matcher's break lands inside the reply gap.
+    let m = 300usize; // ring[m] defaults to 0x00 -> a real break
+    h.deadline.set_now(end + 2);
+    h.ring.set_cursor(((m + 1) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+
+    // The staged reply survives and fires -- colliding energy on a real
+    // wire, the signal the walk descends on. The trigger sits up to
+    // SLOTS-1 byte-times out (sec 9.2 slot draw), behind the peer break's
+    // starving-header rechecks -- drain generously.
+    let mut guard = 0;
+    while !h.wire.started() && h.deadline.armed().is_some() && guard < 64 {
+        fire(&mut bus, &h, &mut d);
+        guard += 1;
+    }
+    assert!(
+        h.wire.started(),
+        "the ENUM reply must not yield to the break"
+    );
+    drain_tx(&mut bus, &h);
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(data.len(), 16, "the full UID ships");
+}
+
+/// sec 9.2 slot delay: an ENUM reply's trigger rides reply gap + a slot draw --
+/// `(folded uid CRC ^ tick) & (SLOTS-1)` byte-times -- so cycle-identical
+/// twin matchers can't answer in unison (a sub-bit-aligned superposition of
+/// near-equal frames reads back as ONE clean frame). The default
+/// all-zero UID folds to key 0, so the draw here is the tick's low bits.
+/// Plain replies keep the bare grid (s1 pins that side).
+#[test]
+fn enum_reply_draws_its_slot_delay() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let frame = instruction(
+        Id::BROADCAST.as_byte(),
+        Opcode::Mgmt,
+        0,
+        &[MgmtOp::Enum as u8, 0],
+    );
+    let anchor = 100usize;
+    let fp = frame.len();
+    h.ring.place(anchor, &frame);
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    h.ring.set_cursor(((anchor + 1) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+
+    let a = h.deadline.armed().expect("deadline A");
+    h.deadline.set_now(a);
+    h.ring.set_cursor(((anchor + fp - 2) % RING_LEN) as u16);
+    bus.on_deadline(&mut d);
+    let end = a.wrapping_add(2 * TPB);
+
+    // Verdict-first: dispatch + sequencing run at deadline B, so the slot
+    // draw reads the clock at exactly `b`.
+    let b = h.deadline.armed().expect("deadline B");
+    h.deadline.set_now(b);
+    h.ring.set_cursor(((anchor + fp) % RING_LEN) as u16);
+    bus.on_deadline(&mut d);
+
+    let draw = (b as u8 & (wire::ENUM_REPLY_SLOTS - 1)) as u32;
+    assert_eq!(
+        h.deadline.armed(),
+        Some(end + REPLY_GAP + draw * TPB),
+        "trigger = reply gap + slot draw"
+    );
+
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (_, inst, data) = last_reply(&h.wire);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(data.len(), 16);
+}
+
+#[test]
+fn s13_frontier_write_stages_at_covered_commits_at_verdict() {
+    // A WRITE dispatches inline at covered-complete (the spine: the CRC feed
+    // chews the covered span under the dispatch body). The write stages; the
+    // table stays untouched and nothing reaches the wire until the verdict at
+    // frame end commits and sequences.
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = Shared::new();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let addr = CONTROL_BASE_ADDR.to_le_bytes();
+    let frame = instruction(ID, Opcode::Write, 0, &[addr[0], addr[1], 1]);
+    let anchor = 100usize;
+    let fp = frame.len();
+    h.ring.place(anchor, &frame);
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    h.ring.set_cursor(((anchor + 1) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+    let a = h.deadline.armed().expect("deadline A");
+    h.deadline.set_now(a);
+    h.ring.set_cursor(((anchor + 4) % RING_LEN) as u16);
+    bus.on_deadline(&mut d);
+
+    // Covered checkpoint (two byte-times short of the end): the job is
+    // published -- before the frame has even ended -- and nothing is applied.
+    let c = h.deadline.armed().expect("covered deadline");
+    h.deadline.set_now(c);
+    h.ring.set_cursor(((anchor + fp - 2) % RING_LEN) as u16);
+    bus.on_deadline(&mut d);
+    // The write dispatched inline at covered -- staged while the CRC tail is
+    // still inbound; the table stays untouched until the verdict.
+    assert!(
+        !shared.table.with(|t| t.control.lifecycle.torque_enable),
+        "a pending write is staged, not yet committed"
+    );
+    assert!(!h.wire.started());
+
+    // Frame end delivers the verdict's other half: commit + sequence.
+    h.ring.set_cursor(((anchor + fp) % RING_LEN) as u16);
+    fire(&mut bus, &h, &mut d);
+    assert!(
+        shared.table.with(|t| t.control.lifecycle.torque_enable),
+        "the CRC-verified write is committed"
+    );
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+
+    let reference = status(ID, ResultCode::Ok, &[]);
+    assert_eq!(h.wire.sent(), reference[1..]);
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(data.is_empty());
+    assert_eq!(bus.diag().crc_fail_count, 0);
+}
+
+#[test]
+fn s14_corrupt_write_leaves_table_and_reverts() {
+    // A WRITE whose covered span is intact but whose trailing CRC is corrupted:
+    // front-loaded (staged) at covered, then the frame-end CRC check fails ->
+    // the staged write is reverted and the table is byte-identical.
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = Shared::new();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let addr = CONTROL_BASE_ADDR.to_le_bytes();
+    let mut frame = instruction(ID, Opcode::Write, 0, &[addr[0], addr[1], 1]);
+    let last = frame.len() - 1;
+    frame[last] ^= 0xFF; // corrupt CRC-hi; the covered span stays valid
+    deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+
+    assert!(!h.wire.started());
+    assert_eq!(bus.diag().crc_fail_count, 1);
+    assert!(
+        !shared.table.with(|t| t.control.lifecycle.torque_enable),
+        "a bad-CRC write must not mutate the table"
+    );
+
+    // The staged write was reverted -- a following clean write applies.
+    let next = instruction(ID, Opcode::Write, 0, &[addr[0], addr[1], 1]);
+    deliver(&mut bus, &h, 100, &next, 5000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    let (_, inst, _) = last_reply(&h.wire);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(shared.table.with(|t| t.control.lifecycle.torque_enable));
+}
+
+/// Rewrite a frame's ID field to broadcast (group ops address via their list).
+fn broadcast_id(mut frame: std::vec::Vec<u8>) -> std::vec::Vec<u8> {
+    // Re-seal after changing the ID: [0x00][ID][LEN][INST]...
+    frame[1] = Id::BROADCAST.as_byte();
+    let covered = frame.len() - 2;
+    let crc = osc_protocol::crc::osc_crc(&frame[..covered]);
+    frame[covered..].copy_from_slice(&crc.to_le_bytes());
+    frame
+}
+
+// A COMMIT + MGMT smoke to keep the decode arms exercised alongside the wire
+// scenarios (broadcast COMMIT applies silently; MGMT REBOOT defers a reboot).
+#[test]
+fn commit_and_reboot_paths() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    // MGMT REBOOT (unicast) acks then stages a reboot honored on poll --
+    // withheld while the ack drains (a reset mid-frame truncates the ack on
+    // the wire; bench-caught), taken once the TX released.
+    let frame = instruction(ID, Opcode::Mgmt, 0, &[MgmtOp::Reboot as u8]);
+    deliver(&mut bus, &h, 100, &frame, 1000, &mut d);
+    fire(&mut bus, &h, &mut d);
+    let (_, inst, _) = last_reply(&h.wire);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(bus.take_reboot().is_none(), "withheld while the ack drains");
+    drain_tx(&mut bus, &h);
+    assert!(bus.take_reboot().is_some());
+    assert!(bus.take_reboot().is_none());
+}
+
+/// A complete frame (READ) dispatches inline at HIGH and its reply sequences
+/// straight from the resolve wake -- no deferral to a later verdict.
+#[test]
+fn complete_read_dispatches_inline() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let frame = instruction(ID, Opcode::Read, 0, &[0, 0, 4, 0]);
+    let anchor = 100usize;
+    h.ring.place(anchor, &frame);
+    bus.framer.resync(anchor as u16);
+    // The whole frame is already ringed when the (lagged) break delivers:
+    // the fast path resolves it in this one wake.
+    h.deadline.set_now(1000);
+    h.ring
+        .set_cursor(((anchor + frame.len()) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(&data[..2], &[0x34, 0x12]);
+}
+
+/// Ordering across a backlog: a WRITE(NOREPLY) resolves and commits before the
+/// READ behind it dispatches -- drive_framer resolves each complete frame and
+/// runs its verdict fully before resolving the next, so effects land in wire
+/// order.
+#[test]
+fn backlog_write_then_read_processes_in_order() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let addr = CONTROL_BASE_ADDR.to_le_bytes();
+    let write = instruction(
+        ID,
+        Opcode::Write,
+        Inst::FLAG_NOREPLY,
+        &[addr[0], addr[1], 1],
+    );
+    let read = instruction(ID, Opcode::Read, 0, &[0, 0, 4, 0]);
+    let anchor = 100usize;
+    h.ring.place(anchor, &write);
+    h.ring.place(anchor + write.len(), &read);
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    h.ring
+        .set_cursor(((anchor + write.len() + read.len()) % RING_LEN) as u16);
+    bus.on_break(&mut d);
+
+    // Both complete frames resolve in this one wake: the NOREPLY write commits
+    // inline, then the read dispatches behind it -- effects in wire order. The
+    // read's reply is staged (not yet fired), its chain armed.
+    assert!(
+        shared.table.with(|t| t.control.lifecycle.torque_enable),
+        "the backlog write committed before the read dispatched"
+    );
+    assert!(!h.wire.started());
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, data) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(&data[..2], &[0x34, 0x12]);
+}
+
+/// A wire-fault wake whose evidence hasn't ringed yet (the drain a beat
+/// behind ISR entry -- or the FE consumed by a garble-latched flag's SR-DR
+/// pair, so this wake is the LAST one the frame gets) must leave a framer
+/// recheck armed: one byte-time later the ring tells the truth and the
+/// frame resolves by data. Without it the frame sat complete-but-unresolved
+/// until unrelated traffic (the post-garble one-instruction-late residue,
+/// bench-caught).
+#[test]
+fn break_service_before_drain_rechecks_and_answers() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let anchor = 100usize;
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    // FE serviced with the cursor still AT the anchor: nothing new ringed.
+    h.ring.set_cursor(anchor as u16);
+    bus.on_break(&mut d);
+    let recheck = h.deadline.armed().expect("recheck armed on empty evidence");
+    assert_eq!(recheck, 1000 + TPB);
+
+    // By the recheck the whole ping has ringed (no further FE ever fires).
+    let frame = instruction(ID, Opcode::Ping, 0, &[]);
+    h.ring.place(anchor, &frame);
+    h.ring
+        .set_cursor(((anchor + frame.len()) % RING_LEN) as u16);
+    h.deadline.set_now(recheck);
+    bus.on_deadline(&mut d);
+
+    // Resolved from ring data alone: the reply stages and fires.
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, _) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+/// sec 3.4 spurious wake (a coalesced or lagged break service -- the FE-era
+/// level-pend re-fires produced the same shape): a wake with zero ring
+/// progress arms only the one-byte-time recheck, and evidence landing
+/// within that byte-time resolves by data -- live traffic never pays for
+/// the spurious entry (bench: an eager verdict here cost hot chains
+/// 95% -> 83%).
+#[test]
+fn spurious_wake_arms_recheck_and_resolves_by_data() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let anchor = 100usize;
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    h.ring.set_cursor(anchor as u16);
+    // Spurious entry: zero progress at service time -- the only trace is
+    // the one-byte-time recheck.
+    bus.on_break(&mut d);
+    assert_eq!(h.deadline.armed(), Some(1000 + TPB));
+
+    // The next frame's bytes land before the recheck (zero-gap burst): the
+    // recheck resolves the frame from ring data.
+    let frame = instruction(ID, Opcode::Ping, 0, &[]);
+    h.ring.place(anchor, &frame);
+    h.ring
+        .set_cursor(((anchor + frame.len()) % RING_LEN) as u16);
+    h.deadline.set_now(1000 + TPB);
+    bus.on_deadline(&mut d);
+
+    fire(&mut bus, &h, &mut d);
+    drain_tx(&mut bus, &h);
+    let (id, inst, _) = last_reply(&h.wire);
+    assert_eq!(id, ID);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+/// The quiet twin: a spurious wake on a genuinely idle wire costs exactly
+/// one empty recheck -- after it, no deadline is armed at all (the next
+/// break wakes the driver; there is no wake to mute and no poll to keep
+/// alive -- errors never interrupt, the wake is LBD-only, transport sec 7).
+#[test]
+fn spurious_wake_on_quiet_wire_costs_one_recheck() {
+    let h = Harness::new();
+    let mut bus = h.build(ID, RATE, 60);
+    let shared = shared_seeded();
+    let mut session = Session::new();
+    let mut d = session.dispatcher(&shared);
+
+    let anchor = 100usize;
+    bus.framer.resync(anchor as u16);
+    h.deadline.set_now(1000);
+    h.ring.set_cursor(anchor as u16);
+    bus.on_break(&mut d);
+    assert_eq!(h.deadline.armed(), Some(1000 + TPB));
+
+    h.deadline.set_now(1000 + TPB);
+    bus.on_deadline(&mut d);
+    assert_eq!(h.deadline.armed(), None, "idle again: nothing to poll");
+}

--- a/firmware/lib/drivers/src/bus/trim.rs
+++ b/firmware/lib/drivers/src/bus/trim.rs
@@ -1,0 +1,227 @@
+//! Clock-trim controller (`docs/osc-native-protocol.md` sec 9.3): folds
+//! windowed cadence error into chip trim steps. One rule covers both phases
+//! -- `steps = round(err / step_effect)` -- so the first window after boot
+//! takes a multi-step jump while steady-state windows round to zero:
+//! round-to-nearest IS the deadband, half a step wide, which is the physical
+//! optimum a stepped trim can hold.
+//!
+//! The step effect is SELF-MEASURED: chip trim steps are nonuniform per chip
+//! (bench: 1.4-3.2k ppm/step against the 2.5k nominal), and a fixed deadband
+//! either limit-cycles on coarse-step chips or under-trims fine-step ones.
+//! Every applied correction is a free plant measurement -- the next window's
+//! error shift, divided by the steps taken -- so the deadband scales itself
+//! to THIS chip within one correction.
+//!
+//! CONTRACT (chip-independent): the output is signed trim steps from the
+//! chip's factory default where **positive slows the oscillator**. The chip
+//! adapter owns the mapping to its trim register's direction and never leaks
+//! it upward -- V006 HSITRIM runs higher = faster, so its adapter negates
+//! (`hal::rcc::apply_clock_trim`); a same-sign mapping turns this loop's
+//! negative feedback positive and rails the chip in `STEPS_MAX` clamps
+//! (the trim-runaway probe pins this).
+
+/// Self-measured step-effect acceptance band, ppm per step. A window
+/// polluted by traffic noise or a thermal shift between sparse windows can
+/// imply an absurd plant gain; readings outside the band are discarded and
+/// the previous estimate kept.
+const STEP_PPM_MIN: i32 = 800;
+const STEP_PPM_MAX: i32 = 4000;
+
+/// Largest correction one window may take. Bounds a garbage window's damage
+/// to something the next window walks back, and keeps any single over-the-air
+/// rate jump well inside UART framing tolerance.
+const STEPS_MAX: i32 = 4;
+
+/// Accumulated-trim rail, steps from the factory default (the chip register
+/// clamps harder; this keeps the controller's own state windup-free).
+const TOTAL_MAX: i32 = 15;
+
+pub struct TrimLoop {
+    /// Applied trim, in chip steps from the factory default.
+    total: i8,
+    /// Plant gain: ppm of clock shift per trim step, seeded at the chip's
+    /// nominal and replaced by measurement after the first correction.
+    step_ppm: i32,
+    /// Previous window's error and the correction it drew -- the pair the
+    /// next window turns into a step-effect measurement.
+    last_ppm: i32,
+    last_steps: i32,
+}
+
+impl TrimLoop {
+    pub const fn new(step_ppm_nominal: u32) -> Self {
+        Self {
+            total: 0,
+            step_ppm: step_ppm_nominal as i32,
+            last_ppm: 0,
+            last_steps: 0,
+        }
+    }
+
+    /// One measurement window: `err_ticks` of local-clock excess over
+    /// `span_ticks` of nominal wire-byte span (positive = local clock fast).
+    /// Returns the new trim total when it changed -- the caller applies it to
+    /// the oscillator (positive = slower).
+    pub fn on_window(&mut self, err_ticks: i32, span_ticks: u32) -> Option<i8> {
+        if span_ticks == 0 {
+            return None; // defensive: no span, no reading
+        }
+        let ppm = ((err_ticks as i64 * 1_000_000) / span_ticks as i64) as i32;
+        if self.last_steps != 0 {
+            let observed = (self.last_ppm - ppm) / self.last_steps;
+            if (STEP_PPM_MIN..=STEP_PPM_MAX).contains(&observed) {
+                self.step_ppm = observed;
+            }
+        }
+        let steps = round_div(ppm, self.step_ppm).clamp(-STEPS_MAX, STEPS_MAX);
+        let total = (self.total as i32 + steps).clamp(-TOTAL_MAX, TOTAL_MAX);
+        // Record what was APPLIED, not what was asked: at the rail the plant
+        // moved less than `steps`, and the step-effect division must match.
+        let applied = total - self.total as i32;
+        crate::bench::trim_probe(|p| {
+            p.windows += 1;
+            p.tw_ppm = ppm;
+            p.tw_effect = self.step_ppm;
+            p.tw_applied = applied;
+            p.tw_total = total;
+        });
+        self.last_ppm = ppm;
+        self.last_steps = applied;
+        if applied == 0 {
+            return None;
+        }
+        self.total = total as i8;
+        Some(self.total)
+    }
+}
+
+/// Round-to-nearest signed division, divisor positive.
+fn round_div(n: i32, d: i32) -> i32 {
+    let half = d / 2;
+    if n >= 0 {
+        (n + half) / d
+    } else {
+        (n - half) / d
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Closed-loop plant: a chip with a true clock offset and a true (possibly
+    /// off-nominal) step effect, measured through noiseless windows.
+    struct Plant {
+        offset_ppm: i32,
+        step_ppm: i32,
+        trim: TrimLoop,
+        applied: i32,
+    }
+
+    impl Plant {
+        fn new(offset_ppm: i32, step_ppm: i32) -> Self {
+            Self {
+                offset_ppm,
+                step_ppm,
+                trim: TrimLoop::new(2500),
+                applied: 0,
+            }
+        }
+
+        fn residual(&self) -> i32 {
+            self.offset_ppm - self.applied * self.step_ppm
+        }
+
+        fn window(&mut self) -> Option<i8> {
+            let span = 1_000_000u32;
+            let err = self.residual(); // err_ticks == ppm at this span
+            let out = self.trim.on_window(err, span);
+            if let Some(total) = out {
+                self.applied = total as i32;
+            }
+            out
+        }
+    }
+
+    #[test]
+    fn first_window_takes_the_acquire_jump() {
+        let mut p = Plant::new(5200, 2500);
+        assert_eq!(p.window(), Some(2));
+        assert_eq!(p.residual(), 200);
+    }
+
+    #[test]
+    fn steady_state_rounds_to_zero_inside_half_a_step() {
+        let mut p = Plant::new(1200, 2500);
+        assert_eq!(p.window(), None);
+        assert_eq!(p.window(), None);
+    }
+
+    #[test]
+    fn coarse_step_chip_locks_without_limit_cycling() {
+        // 3.2k-ppm steps under the 2.5k seed: one overshoot, then the
+        // measured gain widens the deadband and the loop holds.
+        let mut p = Plant::new(1700, 3200);
+        assert_eq!(p.window(), Some(1));
+        assert_eq!(p.residual(), -1500);
+        for _ in 0..8 {
+            assert_eq!(p.window(), None);
+        }
+        assert_eq!(p.trim.step_ppm, 3200);
+    }
+
+    #[test]
+    fn fine_step_chip_converges_to_its_own_optimum() {
+        let mut p = Plant::new(5000, 1400);
+        p.window(); // acquire on the nominal seed
+        for _ in 0..8 {
+            p.window();
+        }
+        assert_eq!(p.trim.step_ppm, 1400);
+        assert!(p.residual().abs() <= 700, "residual {}", p.residual());
+        for _ in 0..8 {
+            assert_eq!(p.window(), None);
+        }
+    }
+
+    #[test]
+    fn negative_offset_converges_symmetrically() {
+        let mut p = Plant::new(-5000, 1400);
+        for _ in 0..8 {
+            p.window();
+        }
+        assert!(p.residual().abs() <= 700, "residual {}", p.residual());
+        assert!(p.applied < 0);
+    }
+
+    #[test]
+    fn rail_pins_without_windup() {
+        // An offset past the throw: the total pins at the rail and stays
+        // responsive (backs off immediately once the sign flips).
+        let mut p = Plant::new(60_000, 2500);
+        for _ in 0..12 {
+            p.window();
+        }
+        assert_eq!(p.applied, 15);
+        assert_eq!(p.window(), None); // at the rail: applied == 0, no windup
+        p.offset_ppm = 0;
+        let out = p.window();
+        assert!(out.is_some() && p.applied < 15, "applied {}", p.applied);
+    }
+
+    #[test]
+    fn absurd_gain_readings_are_rejected() {
+        let mut p = Plant::new(5000, 2500);
+        p.window();
+        // Pollute the next window: a thermal jump mimics a huge plant gain.
+        p.offset_ppm -= 9000;
+        p.window();
+        assert_eq!(p.trim.step_ppm, 2500, "seed survives the outlier");
+    }
+
+    #[test]
+    fn zero_span_reads_nothing() {
+        let mut t = TrimLoop::new(2500);
+        assert_eq!(t.on_window(1000, 0), None);
+    }
+}

--- a/firmware/lib/drivers/src/bus/tx.rs
+++ b/firmware/lib/drivers/src/bus/tx.rs
@@ -1,0 +1,379 @@
+//! Status-reply TX engine (`docs/osc-native-protocol.md` sec 4.2): stage a frame
+//! layout, then trigger -- break + up to four DMA arms, the last always the
+//! 2-byte CRC. The wire starts before the CRC is known; the hardware engine
+//! chews the covered span in parallel and the value is patched into that final
+//! arm at the boundary before it (the engine outruns the wire 8:1, F6, and DMA
+//! fetches just-in-time, so the patch beats the read).
+
+use crate::traits::bus::{CrcEngine, TxWire};
+use osc_core::traits::SendError;
+use osc_protocol::crc::osc_crc_continue;
+use osc_protocol::reply::FrameBuf;
+use osc_protocol::wire::{self, Id, Inst, ResultCode};
+
+/// Staging buffer size. Payloads stream from the engine's snapshot (sec 4.2), so
+/// the buffer holds only the header and CRC tail plus the <=
+/// [`SMALL_COPY_MAX`] copy path.
+pub const REPLY_BUF: usize = 16;
+
+/// Payloads at or below this are copied into the staging buffer. Kept minimal:
+/// the copy costs ~0.3 us/byte of turnaround (bench-measured at 3M), so
+/// anything the DMA can stream in place should stream. The floor exists
+/// because an odd payload donates its last byte to the tail arm -- at p = 1
+/// that would leave a zero-length DMA arm.
+const SMALL_COPY_MAX: usize = 2;
+
+/// Outcome of an arm-completion event.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum TxOut {
+    Armed,
+    Released,
+}
+
+/// One DMA arm (or CRC feed) as a descriptor -- resolved to a slice only at
+/// send time, so the engine never holds self-referential borrows.
+#[derive(Copy, Clone)]
+enum Arm {
+    // len is u16: the odd-pointer copy path can arm up to footprint-1 = 257
+    // bytes (a 251-byte payload from an odd table address). off is u16 too:
+    // the CRC tail of that same maximal frame sits at offset 256.
+    Buf { off: u16, len: u16 },
+    Ext { ptr: *const u8, len: u16 },
+}
+
+const NO_ARM: Arm = Arm::Buf { off: 0, len: 0 };
+
+enum State {
+    Idle,
+    /// `slot_key` is present on collision-tolerant replies: broadcast-ENUM
+    /// replies' sec 9.2 job is to collide, so the composite's break-wake kill
+    /// skips them, and the key (folded UID CRC) draws the reply's slot
+    /// delay -- cycle-identical twin matchers otherwise answer in unison,
+    /// and a sub-bit-aligned superposition of near-equal frames reads back
+    /// as one clean frame, hiding the loser's subtree from the walk.
+    Staged {
+        slot_key: Option<u8>,
+    },
+    Streaming {
+        next: u8,
+    },
+}
+
+pub struct TxEngine<W: TxWire> {
+    wire: W,
+    buf: FrameBuf<REPLY_BUF>,
+    // The CRC tail is always the final arm (index `n_feeds`); the `n_feeds`
+    // arms before it map 1:1 to feed spans, fed one per arm boundary.
+    arms: [Arm; 4],
+    n_arms: u8,
+    feeds: [Arm; 3],
+    n_feeds: u8,
+    /// Buffer offset of the CRC tail slot (zeroed at stage as the placeholder).
+    crc_off: u16,
+    state: State,
+    result: ResultCode,
+    /// The covered byte the even-bulk feeds leave un-fed when the span is odd
+    /// (sec 3.2): read and folded into the engine result at patch time (the
+    /// pointer targets engine-stable storage -- buffer or snapshot).
+    tail: Option<*const u8>,
+    alert: bool,
+    crc_misses: u32,
+}
+
+impl<W: TxWire> TxEngine<W> {
+    pub fn new(wire: W) -> Self {
+        Self {
+            wire,
+            buf: FrameBuf::new(),
+            arms: [NO_ARM; 4],
+            n_arms: 0,
+            feeds: [NO_ARM; 3],
+            n_feeds: 0,
+            crc_off: 0,
+            state: State::Idle,
+            result: ResultCode::Ok,
+            tail: None,
+            alert: false,
+            crc_misses: 0,
+        }
+    }
+
+    pub fn busy(&self) -> bool {
+        !matches!(self.state, State::Idle)
+    }
+
+    /// A frame is staged but not yet triggered -- safe to abort (a fresh
+    /// instruction supersedes it). Streaming frames must not be aborted.
+    pub fn staged(&self) -> bool {
+        matches!(self.state, State::Staged { .. })
+    }
+
+    /// The staged reply is exempt from the break-wake kill (sec 9.2 ENUM).
+    pub fn collision_tolerant(&self) -> bool {
+        self.slot_key().is_some()
+    }
+
+    /// A collision-tolerant staged reply's slot-delay key (sec 9.2), else None.
+    pub fn slot_key(&self) -> Option<u8> {
+        match self.state {
+            State::Staged { slot_key } => slot_key,
+            _ => None,
+        }
+    }
+
+    /// Mark the staged reply collision-tolerant with its slot-delay key
+    /// (sec 9.2: an ENUM reply's job is to collide with peer matchers, offset
+    /// by its slot). No-op unless a frame is staged.
+    pub fn mark_collision_tolerant(&mut self, key: u8) {
+        if let State::Staged { slot_key } = &mut self.state {
+            *slot_key = Some(key);
+        }
+    }
+
+    /// Arms are on the wire -- the servo owns the line until the final TC.
+    pub fn streaming(&self) -> bool {
+        matches!(self.state, State::Streaming { .. })
+    }
+
+    /// Build the frame layout for a status reply; touches no wire state
+    /// (enable-when-ready is [`trigger`](Self::trigger), sec 4.2).
+    pub fn stage<C: CrcEngine>(
+        &mut self,
+        crc: &mut C,
+        id: u8,
+        result: ResultCode,
+        alert: bool,
+        data: &[u8],
+    ) -> Result<(), SendError> {
+        self.stage_gather(crc, id, result, alert, &[data])
+    }
+
+    /// Gathered form of [`stage`](Self::stage): the payload is `spans`
+    /// concatenated in order (sec 5.2 profile reads; a plain reply is the
+    /// one-span case). Payload totals above [`SMALL_COPY_MAX`] are
+    /// snapshotted through the CRC engine's stable buffer at cumulative
+    /// offsets -- wire and CRC both stream the one contiguous snapshot, so a
+    /// scattered read costs the same single copy as a plain read (sec 4.2).
+    pub fn stage_gather<C: CrcEngine>(
+        &mut self,
+        crc: &mut C,
+        id: u8,
+        result: ResultCode,
+        alert: bool,
+        spans: &[&[u8]],
+    ) -> Result<(), SendError> {
+        if self.busy() {
+            return Err(SendError::Busy);
+        }
+        let total: usize = spans.iter().map(|s| s.len()).sum();
+        if total > wire::MAX_PAYLOAD as usize {
+            return Err(SendError::Overflow);
+        }
+        let p = total as u8;
+        let inst = Inst::status(result, alert);
+        // Small payloads are cheaper to copy than to arm. An odd covered span
+        // feeds its even bulk and leaves the last byte for the software fold
+        // at patch (sec 3.2); odd POINTERS are the CRC provider's concern (it
+        // stages them through its copy channel, sec 5).
+        if total <= SMALL_COPY_MAX {
+            self.buf.start(Id::new(id), inst);
+            let pay = self.buf.payload_mut();
+            let mut at = 0;
+            for s in spans {
+                pay[at..at + s.len()].copy_from_slice(s);
+                at += s.len();
+            }
+            self.buf.finish(p);
+            let len = wire::len_for(p);
+            let cov = wire::covered_len(len);
+            let bulk = cov & !1;
+            // Header + payload, then the 2 CRC bytes as their own arm.
+            self.arms[0] = Arm::Buf {
+                off: 1,
+                len: (cov - 1) as u16,
+            };
+            self.arms[1] = Arm::Buf {
+                off: cov as u16,
+                len: 2,
+            };
+            self.n_arms = 2;
+            self.feeds[0] = Arm::Buf {
+                off: 0,
+                len: bulk as u16,
+            };
+            self.n_feeds = 1;
+            self.tail = if cov & 1 == 1 {
+                Some(&raw const self.buf.bytes()[cov - 1])
+            } else {
+                None
+            };
+            self.crc_off = cov as u16;
+        } else {
+            // Snapshot reads (sec 4.2): the payload is copied ONCE into the
+            // engine's stable snapshot buffer -- each span at its cumulative
+            // offset -- and both the wire arms and the CRC feeds stream the
+            // snapshot: the CRC provably covers the transmitted bytes, and
+            // the reply carries an atomic point-in-time image (`stage` runs
+            // kernel-exclusive; the provider orders the copies ahead of both
+            // consumers).
+            let b = self.buf.bytes_mut();
+            b[0] = wire::ALIGN_BYTE;
+            b[1] = id;
+            b[2] = wire::len_for(p);
+            b[3] = inst.0;
+            let mut ptr: *const u8 = core::ptr::null();
+            let mut off: u16 = 0;
+            for s in spans {
+                if s.is_empty() {
+                    continue;
+                }
+                let dst = crc.snapshot(off, s);
+                if off == 0 {
+                    ptr = dst;
+                }
+                off += s.len() as u16;
+            }
+            self.arms[0] = Arm::Buf { off: 1, len: 3 };
+            self.arms[1] = Arm::Ext { ptr, len: p as u16 };
+            // The buffer's bytes 4..6 double as the CRC tail arm.
+            self.arms[2] = Arm::Buf { off: 4, len: 2 };
+            self.n_arms = 3;
+            self.feeds[0] = Arm::Buf { off: 0, len: 4 };
+            self.feeds[1] = Arm::Ext {
+                ptr,
+                len: (p & !1) as u16,
+            };
+            self.n_feeds = 2;
+            // The fold byte is read at patch time, not here: the snapshot is
+            // best-effort asynchronous and may still be streaming -- by the
+            // patch boundary the copy has long completed (sec 4.2).
+            self.tail = if p & 1 == 1 {
+                Some(unsafe { ptr.add(p as usize - 1) })
+            } else {
+                None
+            };
+            self.crc_off = 4;
+        }
+        // Placeholder CRC: what ships if the patch window is missed.
+        let off = self.crc_off as usize;
+        self.buf.bytes_mut()[off..off + 2].copy_from_slice(&[0, 0]);
+        self.result = result;
+        self.alert = alert;
+        self.state = State::Staged { slot_key: None };
+        Ok(())
+    }
+
+    /// Finalize and start: optional result override (chain reclaim's
+    /// predecessor-silent, sec 6) rewrites INST, then break + first arm with the
+    /// first CRC feed armed behind it. The CRC value lands later, at the
+    /// boundary before its own trailing arm ([`on_arm_complete`]) -- the wire
+    /// starts before the CRC is known so the engine chews in parallel (sec 4.2).
+    pub fn trigger<C: CrcEngine>(&mut self, crc: &mut C, over: Option<ResultCode>) {
+        if !matches!(self.state, State::Staged { .. }) {
+            debug_assert!(false, "trigger without a staged frame");
+            return;
+        }
+        self.buf.bytes_mut()[3] = Inst::status(over.unwrap_or(self.result), self.alert).0;
+        crc.reset();
+        self.wire.start_frame();
+        self.wire.send(resolve(&self.buf, self.arms[0]));
+        crc.feed(resolve(&self.buf, self.feeds[0]));
+        self.state = State::Streaming { next: 1 };
+    }
+
+    /// Per-arm DMA TC. Feeds the next CRC span and streams the next arm; before
+    /// the final CRC arm, patches the computed CRC into the buffer; after the
+    /// last arm, releases the wire (caller then applies deferred config).
+    pub fn on_arm_complete<C: CrcEngine>(&mut self, crc: &mut C) -> TxOut {
+        match self.state {
+            State::Streaming { next } if next < self.n_arms => {
+                let i = next as usize;
+                if i < self.n_feeds as usize {
+                    // Arm the next feed span. A full arm's wire-time has elapsed
+                    // since the previous feed, so the chip drain-spin is a no-op.
+                    crc.feed(resolve(&self.buf, self.feeds[i]));
+                } else {
+                    // Next arm is the CRC tail: land the value before the DMA
+                    // reaches it.
+                    self.patch_crc(crc);
+                }
+                self.wire.send(resolve(&self.buf, self.arms[i]));
+                self.state = State::Streaming { next: next + 1 };
+                TxOut::Armed
+            }
+            State::Streaming { .. } => {
+                self.wire.release();
+                self.state = State::Idle;
+                TxOut::Released
+            }
+            // Spurious TC: the wire is already released, don't touch it.
+            _ => {
+                debug_assert!(false, "arm completion while idle");
+                TxOut::Released
+            }
+        }
+    }
+
+    /// Poll the CRC and patch the trailing 2 bytes. Called at the boundary
+    /// before the CRC arm: the DMA is physically reading the buffer as we
+    /// write here -- by design. The CRC arm is last (>= header's worth of head
+    /// start) and the engine runs ~8x wire speed (F6), so the patch wins.
+    fn patch_crc<C: CrcEngine>(&mut self, crc: &mut C) {
+        // Every feed was armed at least one arm's wire-time ago, so `result()`
+        // is Some on the first poll in any healthy exchange; the fixed bound
+        // only guards a sick engine (placeholder zeros ship, host retries).
+        let mut budget = super::SPIN_PER_BYTE;
+        let value = loop {
+            if let Some(v) = crc.result() {
+                break Some(v);
+            }
+            if budget == 0 {
+                break None;
+            }
+            budget -= 1;
+            core::hint::spin_loop();
+        };
+        match value {
+            Some(v) => {
+                // Fold the un-fed trailing covered byte, if the span was odd
+                // (sec 3.2) -- the only software CRC on the servo. SAFETY: the
+                // pointer targets the frame buffer or the engine's snapshot,
+                // both stable for this exchange; any snapshot copy completed
+                // arms ago (transfer ordering).
+                let v = match self.tail {
+                    Some(b) => osc_crc_continue(v, &[unsafe { *b }]),
+                    None => v,
+                };
+                let off = self.crc_off as usize;
+                self.buf.bytes_mut()[off..off + 2].copy_from_slice(&v.to_le_bytes());
+            }
+            None => self.crc_misses = self.crc_misses.wrapping_add(1),
+        }
+    }
+
+    /// Drop anything staged or streaming and release the wire.
+    pub fn abort(&mut self) {
+        if self.busy() {
+            self.wire.release();
+            self.state = State::Idle;
+        }
+    }
+
+    /// CRC-engine patch-window misses (placeholder CRC shipped), monotonic.
+    pub fn crc_misses(&self) -> u32 {
+        self.crc_misses
+    }
+}
+
+fn resolve(buf: &FrameBuf<REPLY_BUF>, arm: Arm) -> &[u8] {
+    match arm {
+        Arm::Buf { off, len } => &buf.bytes()[off as usize..off as usize + len as usize],
+        // SAFETY: `Ext` descriptors exist only between `stage` and the final
+        // arm completion (or `abort`), and `stage`'s contract requires the
+        // referent to outlive the transmission (static control-table storage).
+        Arm::Ext { ptr, len } => unsafe { core::slice::from_raw_parts(ptr, len as usize) },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/firmware/lib/drivers/src/bus/tx/tests.rs
+++ b/firmware/lib/drivers/src/bus/tx/tests.rs
@@ -1,0 +1,359 @@
+//! TX engine spec tests: staged layouts driven to completion against fake
+//! wire/CRC, asserting the streamed bytes match a software-sealed reference.
+
+use super::*;
+use osc_protocol::crc::{osc_crc, osc_crc_continue};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::vec;
+use std::vec::Vec;
+
+struct FakeCrc {
+    state: u16,
+    snap: Vec<u8>,
+}
+
+impl FakeCrc {
+    fn new() -> Self {
+        FakeCrc {
+            state: 0,
+            snap: Vec::new(),
+        }
+    }
+}
+
+impl CrcEngine for FakeCrc {
+    fn reset(&mut self) {
+        self.state = 0;
+    }
+    fn feed(&mut self, span: &[u8]) {
+        assert_eq!(span.len() % 2, 0, "CRC feed must be even-length (F12)");
+        // Odd ADDRESSES are legal: the chip provider stages them (sec 5).
+        self.state = osc_crc_continue(self.state, span);
+    }
+    fn snapshot(&mut self, off: u16, src: &[u8]) -> *const u8 {
+        let off = off as usize;
+        if self.snap.len() < off + src.len() {
+            self.snap.resize(off + src.len(), 0);
+        }
+        self.snap[off..off + src.len()].copy_from_slice(src);
+        unsafe { self.snap.as_ptr().add(off) }
+    }
+    fn result(&mut self) -> Option<u16> {
+        Some(self.state)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Event {
+    Start,
+    Send(Vec<u8>),
+    Release,
+}
+
+#[derive(Clone, Default)]
+struct FakeWire(Rc<RefCell<Vec<Event>>>);
+
+impl TxWire for FakeWire {
+    fn start_frame(&mut self) {
+        self.0.borrow_mut().push(Event::Start);
+    }
+    fn send(&mut self, span: &[u8]) {
+        self.0.borrow_mut().push(Event::Send(span.to_vec()));
+    }
+    fn release(&mut self) {
+        self.0.borrow_mut().push(Event::Release);
+    }
+}
+
+fn engine() -> (TxEngine<FakeWire>, Rc<RefCell<Vec<Event>>>) {
+    let wire = FakeWire::default();
+    let log = wire.0.clone();
+    (TxEngine::new(wire), log)
+}
+
+/// Software-sealed frame for the same reply, including the 0x00 prefix.
+/// Built in its own full-size buffer -- REPLY_BUF only fits streamed
+/// layouts, and the reference is a whole linearized frame.
+fn reference(id: u8, result: ResultCode, alert: bool, data: &[u8]) -> Vec<u8> {
+    let mut b = FrameBuf::<64>::new();
+    b.start(Id::new(id), Inst::status(result, alert));
+    b.payload_mut()[..data.len()].copy_from_slice(data);
+    b.finish(data.len() as u8);
+    b.seal().to_vec()
+}
+
+/// Drive a staged frame to completion, returning the arm outcomes. The one
+/// CRC engine spans trigger and every arm boundary, as on the chip.
+/// Drive a staged frame to completion with the SAME engine handle used at
+/// stage (the snapshot lives in it, as on the chip).
+fn run(eng: &mut TxEngine<FakeWire>, crc: &mut FakeCrc, over: Option<ResultCode>) -> Vec<TxOut> {
+    eng.trigger(crc, over);
+    let mut outs = Vec::new();
+    loop {
+        let out = eng.on_arm_complete(crc);
+        outs.push(out);
+        if out == TxOut::Released {
+            return outs;
+        }
+    }
+}
+
+fn sends(log: &[Event]) -> Vec<Vec<u8>> {
+    log.iter()
+        .filter_map(|e| match e {
+            Event::Send(v) => Some(v.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn wire_bytes(log: &[Event]) -> Vec<u8> {
+    sends(log).concat()
+}
+
+#[repr(align(2))]
+struct Aligned<const N: usize>([u8; N]);
+
+#[test]
+fn empty_ack_matches_sealed_reference() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    eng.stage(&mut crc, 7, ResultCode::Ok, false, &[]).unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let reference = reference(7, ResultCode::Ok, false, &[]);
+    assert_eq!(log[0], Event::Start);
+    let s = sends(&log);
+    // Header arm, then the CRC as its own final 2-byte arm, patched to
+    // the same value the single-shot software seal produces.
+    assert_eq!(s.iter().map(Vec::len).collect::<Vec<_>>(), vec![3, 2]);
+    assert_eq!(*s.last().unwrap(), reference[reference.len() - 2..]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+    assert_eq!(*log.last().unwrap(), Event::Release);
+    // Empty payload: status bit set, no flags.
+    assert_eq!(wire_bytes(&log)[2], 0x80);
+}
+
+#[test]
+fn small_copy_reply_matches_sealed_reference() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    // 2 bytes <= SMALL_COPY_MAX -> the copy path, even payload.
+    let data = [0xDE, 0xAD];
+    eng.stage(&mut crc, 1, ResultCode::Ok, true, &data).unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let reference = reference(1, ResultCode::Ok, true, &data);
+    let s = sends(&log);
+    // Header + payload, then the CRC tail as its own final arm.
+    assert_eq!(s.iter().map(Vec::len).collect::<Vec<_>>(), vec![5, 2]);
+    assert_eq!(*s.last().unwrap(), reference[reference.len() - 2..]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+    let inst = Inst(wire_bytes(&log)[2]);
+    assert!(inst.is_status());
+    assert!(inst.alert());
+}
+
+#[test]
+fn small_odd_zero_copy_streams_whole_payload() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    // 3 even-addressed bytes: above SMALL_COPY_MAX -> zero-copy; the odd
+    // last byte is folded into the CRC in software (sec 3.2), not moved into
+    // a tail arm.
+    let data = Aligned([0xDE, 0xAD, 0xBE, 0]);
+    eng.stage(&mut crc, 1, ResultCode::Ok, true, &data.0[..3])
+        .unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let reference = reference(1, ResultCode::Ok, true, &data.0[..3]);
+    let s = sends(&log);
+    // Header, whole streamed payload, CRC.
+    assert_eq!(s.iter().map(Vec::len).collect::<Vec<_>>(), vec![3, 3, 2]);
+    assert_eq!(*s.last().unwrap(), reference[reference.len() - 2..]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+    let inst = Inst(wire_bytes(&log)[2]);
+    assert!(inst.is_status());
+    assert!(inst.alert());
+}
+
+#[test]
+fn odd_pointer_streams_zero_copy() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    // Odd-addressed source above SMALL_COPY_MAX: streamed zero-copy like
+    // any other span -- the chip CRC provider stages odd pointers through
+    // its copy channel (sec 5); the engine is parity-blind.
+    let backing = Aligned([0u8, 0xDE, 0xAD, 0xBE]);
+    let data = &backing.0[1..4];
+    eng.stage(&mut crc, 1, ResultCode::Ok, true, data).unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let reference = reference(1, ResultCode::Ok, true, data);
+    let s = sends(&log);
+    // Header, streamed payload, CRC.
+    assert_eq!(s.iter().map(Vec::len).collect::<Vec<_>>(), vec![3, 3, 2]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+}
+
+#[test]
+fn zero_copy_even_streams_three_arms() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    let data = Aligned(core::array::from_fn::<u8, 40, _>(|i| i as u8));
+    eng.stage(&mut crc, 9, ResultCode::Ok, false, &data.0)
+        .unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let s = sends(&log);
+    // Header, Ext payload, then the CRC as its own final 2-byte arm.
+    assert_eq!(s.iter().map(Vec::len).collect::<Vec<_>>(), vec![3, 40, 2]);
+    let reference = reference(9, ResultCode::Ok, false, &data.0);
+    assert_eq!(*s.last().unwrap(), reference[reference.len() - 2..]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+    // CRC over the covered span matches the reference flavor (the leading
+    // alignment byte is a no-op, sec 3.2).
+    let covered_len = wire::covered_len(wire::len_for(40));
+    let crc = u16::from_le_bytes([s[2][0], s[2][1]]);
+    assert_eq!(osc_crc(&reference[..covered_len]), crc);
+}
+
+#[test]
+fn zero_copy_odd_streams_whole_payload() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    let data = Aligned(core::array::from_fn::<u8, 41, _>(|i| !(i as u8)));
+    eng.stage(&mut crc, 5, ResultCode::Ok, false, &data.0)
+        .unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let s = sends(&log);
+    // Odd payload streams whole; its last byte reaches the CRC via the
+    // software fold at patch time (sec 3.2), so the wire CRC still matches
+    // the byte-wise reference.
+    assert_eq!(s.iter().map(Vec::len).collect::<Vec<_>>(), vec![3, 41, 2]);
+    let reference = reference(5, ResultCode::Ok, false, &data.0);
+    assert_eq!(*s.last().unwrap(), reference[reference.len() - 2..]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+}
+
+#[test]
+fn gather_matches_sealed_reference_of_concat() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    // Three spans, odd interior lengths (no parity constraint, sec 5.2): the
+    // wire must carry exactly the concatenation.
+    let a = Aligned([0x10, 0x11, 0x12, 0]);
+    let b = Aligned([0x20, 0]);
+    let c = Aligned([0x30, 0x31, 0x32, 0x33]);
+    let spans: [&[u8]; 3] = [&a.0[..3], &b.0[..1], &c.0];
+    let concat: Vec<u8> = spans.concat();
+    eng.stage_gather(&mut crc, 3, ResultCode::Ok, false, &spans)
+        .unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let reference = reference(3, ResultCode::Ok, false, &concat);
+    let s = sends(&log);
+    // Header, one contiguous snapshot arm, CRC -- same shape as a plain
+    // zero-copy read (the gather is invisible to the wire).
+    assert_eq!(
+        s.iter().map(Vec::len).collect::<Vec<_>>(),
+        vec![3, concat.len(), 2]
+    );
+    assert_eq!(wire_bytes(&log), reference[1..]);
+    assert_eq!(*s.last().unwrap(), reference[reference.len() - 2..]);
+}
+
+#[test]
+fn gather_tiny_total_takes_copy_path() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    // Two 1-byte spans: total 2 <= SMALL_COPY_MAX -- buffer copy, no
+    // snapshot involved.
+    let spans: [&[u8]; 2] = [&[0xAA], &[0xBB]];
+    eng.stage_gather(&mut crc, 4, ResultCode::Ok, false, &spans)
+        .unwrap();
+    run(&mut eng, &mut crc, None);
+    let log = log.borrow();
+    let reference = reference(4, ResultCode::Ok, false, &[0xAA, 0xBB]);
+    assert_eq!(wire_bytes(&log), reference[1..]);
+    assert!(crc.snap.is_empty());
+}
+
+#[test]
+fn gather_overflow_rejected() {
+    let (mut eng, _log) = engine();
+    let mut crc = FakeCrc::new();
+    let big = [0u8; 130];
+    let spans: [&[u8]; 2] = [&big, &big];
+    assert_eq!(
+        eng.stage_gather(&mut crc, 1, ResultCode::Ok, false, &spans),
+        Err(SendError::Overflow)
+    );
+    assert!(!eng.busy());
+}
+
+#[test]
+fn override_rewrites_inst_and_crc_still_validates() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    let data = Aligned(core::array::from_fn::<u8, 40, _>(|i| i as u8));
+    eng.stage(&mut crc, 9, ResultCode::Ok, false, &data.0)
+        .unwrap();
+    run(&mut eng, &mut crc, Some(ResultCode::PredecessorSilent));
+    let log = log.borrow();
+    let wire_out = wire_bytes(&log);
+    let inst = Inst(wire_out[2]);
+    assert_eq!(inst.result(), Some(ResultCode::PredecessorSilent));
+    let covered_len = wire::covered_len(wire::len_for(40));
+    let crc = u16::from_le_bytes([wire_out[covered_len - 1], wire_out[covered_len]]);
+    assert_eq!(osc_crc(&wire_out[..covered_len - 1]), crc);
+}
+
+#[test]
+fn double_stage_is_busy_and_overflow_rejected() {
+    let (mut eng, _log) = engine();
+    let mut crc = FakeCrc::new();
+    eng.stage(&mut crc, 1, ResultCode::Ok, false, &[]).unwrap();
+    assert!(eng.busy());
+    assert_eq!(
+        eng.stage(&mut crc, 2, ResultCode::Ok, false, &[]),
+        Err(SendError::Busy)
+    );
+    let big = [0u8; 253];
+    let (mut eng2, _log2) = engine();
+    assert_eq!(
+        eng2.stage(&mut crc, 1, ResultCode::Ok, false, &big),
+        Err(SendError::Overflow)
+    );
+    assert!(!eng2.busy());
+}
+
+#[test]
+fn abort_releases_and_unblocks_stage() {
+    let (mut eng, log) = engine();
+    let mut crc = FakeCrc::new();
+    eng.stage(&mut crc, 1, ResultCode::Ok, false, &[]).unwrap();
+    eng.abort();
+    assert_eq!(*log.borrow(), vec![Event::Release]);
+    assert!(!eng.busy());
+    eng.stage(&mut crc, 2, ResultCode::Ok, false, &[]).unwrap();
+    // Aborting mid-stream also releases.
+    eng.trigger(&mut crc, None);
+    eng.abort();
+    assert_eq!(*log.borrow().last().unwrap(), Event::Release);
+    assert!(!eng.busy());
+}
+
+#[test]
+fn arm_sequencing_ends_in_released_exactly_once() {
+    let (mut eng, _log) = engine();
+    let mut crc = FakeCrc::new();
+    let data = Aligned(core::array::from_fn::<u8, 40, _>(|i| i as u8));
+    eng.stage(&mut crc, 9, ResultCode::Ok, false, &data.0)
+        .unwrap();
+    let outs = run(&mut eng, &mut crc, None);
+    assert_eq!(outs, vec![TxOut::Armed, TxOut::Armed, TxOut::Released]);
+    assert!(!eng.busy());
+}

--- a/firmware/lib/drivers/src/led.rs
+++ b/firmware/lib/drivers/src/led.rs
@@ -1,0 +1,182 @@
+//! Generic LED driver -- drives a single output pin in one of a few
+//! patterns. Mechanism only; no knowledge of *what* signals it represents.
+//!
+//! Callers set the pattern with [`Led::set_pattern`] when their model
+//! changes; the main loop calls [`Led::poll`] every iteration to advance
+//! the pin level by elapsed time.
+
+use crate::traits::{DigitalOut, Level, Monotonic};
+
+/// What the LED should be doing.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum Pattern {
+    SolidOn,
+    SolidOff,
+    /// Symmetric 50%-duty blink at the given full-cycle period.
+    Blink {
+        period_us: u32,
+    },
+}
+
+pub struct Led<P: DigitalOut, M: Monotonic> {
+    pin: P,
+    clock: M,
+    pattern: Pattern,
+    phase_tick: u32,
+    on: bool,
+}
+
+impl<P: DigitalOut, M: Monotonic> Led<P, M> {
+    pub fn new(pin: P, clock: M) -> Self {
+        Self {
+            pin,
+            clock,
+            pattern: Pattern::SolidOn,
+            phase_tick: 0,
+            on: true,
+        }
+    }
+
+    /// Change the pattern. Resets the phase so the new pattern's first
+    /// half-cycle starts now; a no-op if the pattern is already current.
+    pub fn set_pattern(&mut self, pattern: Pattern) {
+        if self.pattern != pattern {
+            self.pattern = pattern;
+            self.phase_tick = self.clock.ticks();
+        }
+    }
+
+    /// Main-loop tick. Updates the pin level if the current pattern + elapsed
+    /// time call for a transition; cheap no-op otherwise.
+    pub fn poll(&mut self) {
+        let now = self.clock.ticks();
+        let target_on = match self.pattern {
+            Pattern::SolidOn => true,
+            Pattern::SolidOff => false,
+            Pattern::Blink { period_us } => {
+                let half_period_ticks = (period_us / 2) * M::TICKS_PER_US;
+                if now.wrapping_sub(self.phase_tick) >= half_period_ticks {
+                    self.phase_tick = now;
+                    !self.on
+                } else {
+                    self.on
+                }
+            }
+        };
+        if target_on != self.on {
+            self.pin
+                .set(if target_on { Level::High } else { Level::Low });
+            self.on = target_on;
+        }
+    }
+}
+
+#[cfg(test)]
+impl<P: DigitalOut, M: Monotonic> Led<P, M> {
+    pub(crate) fn phase_tick_for_test(&self) -> u32 {
+        self.phase_tick
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+    use crate::mocks::{MockDigitalOut, MockMonotonic};
+    use alloc::vec::Vec;
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    // MockMonotonic uses 1 tick = 1 us, so test arithmetic stays in us.
+
+    #[derive(Clone, Default)]
+    struct PinState {
+        log: Rc<RefCell<Vec<Level>>>,
+    }
+    impl PinState {
+        fn log(&self) -> Vec<Level> {
+            self.log.borrow().clone()
+        }
+    }
+    fn mk_pin() -> (MockDigitalOut, PinState) {
+        let state = PinState::default();
+        let mut m = MockDigitalOut::new();
+        {
+            let log = state.log.clone();
+            m.expect_set()
+                .returning_st(move |lv| log.borrow_mut().push(lv));
+        }
+        (m, state)
+    }
+
+    #[derive(Clone, Default)]
+    struct ClockState {
+        now: Rc<Cell<u32>>,
+    }
+    impl ClockState {
+        fn set_now(&self, v: u32) {
+            self.now.set(v);
+        }
+    }
+    fn mk_clock() -> (MockMonotonic, ClockState) {
+        let state = ClockState::default();
+        let mut m = MockMonotonic::new();
+        {
+            let n = state.now.clone();
+            m.expect_ticks().returning_st(move || n.get());
+        }
+        (m, state)
+    }
+
+    fn led_with(pattern: Pattern) -> (Led<MockDigitalOut, MockMonotonic>, PinState, ClockState) {
+        let (pin, pin_state) = mk_pin();
+        let (clock, clock_state) = mk_clock();
+        let mut led = Led::new(pin, clock);
+        led.set_pattern(pattern);
+        (led, pin_state, clock_state)
+    }
+
+    #[test]
+    fn solid_off_drives_pin_low_on_first_poll() {
+        let (mut led, pin, _clock) = led_with(Pattern::SolidOff);
+        led.poll();
+        assert_eq!(pin.log(), [Level::Low]);
+    }
+
+    #[test]
+    fn solid_on_holds_pin_high_no_writes() {
+        let (mut led, pin, _clock) = led_with(Pattern::SolidOn);
+        led.poll();
+        // Constructor initial state is `on = true`; no transition expected.
+        assert!(pin.log().is_empty());
+    }
+
+    #[test]
+    fn blink_toggles_after_half_period() {
+        let period_us = 100;
+        let half = period_us / 2;
+        let (mut led, pin, clock) = led_with(Pattern::Blink { period_us });
+        // Just before half period: no toggle yet.
+        clock.set_now(half - 1);
+        led.poll();
+        assert!(pin.log().is_empty());
+        // At the boundary: toggle Low.
+        clock.set_now(half);
+        led.poll();
+        assert_eq!(pin.log(), [Level::Low]);
+        // Second half later: toggle back High.
+        clock.set_now(2 * half);
+        led.poll();
+        assert_eq!(pin.log(), [Level::Low, Level::High]);
+    }
+
+    #[test]
+    fn set_pattern_same_value_is_noop() {
+        let (mut led, _pin, clock) = led_with(Pattern::SolidOn);
+        clock.set_now(12345);
+        let phase_before = led.phase_tick_for_test();
+        led.set_pattern(Pattern::SolidOn);
+        assert_eq!(led.phase_tick_for_test(), phase_before);
+    }
+}

--- a/firmware/lib/drivers/src/lib.rs
+++ b/firmware/lib/drivers/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+pub mod bench;
+pub mod bus;
+pub mod led;
+pub mod log;
+pub mod traits;
+
+#[cfg(any(test, feature = "mocks"))]
+extern crate std;
+
+#[cfg(any(test, feature = "mocks"))]
+pub mod mocks;
+
+pub use traits::Level;

--- a/firmware/lib/drivers/src/log.rs
+++ b/firmware/lib/drivers/src/log.rs
@@ -1,0 +1,4 @@
+//! Logging facade -- forwards to `defmt`/`log`/no-op via the shared `osc-log`
+//! crate; re-exported here so call sites keep using `crate::log::*`.
+
+pub use osc_log::{debug, error, info, trace, warn};

--- a/firmware/lib/drivers/src/mocks/bus.rs
+++ b/firmware/lib/drivers/src/mocks/bus.rs
@@ -1,0 +1,303 @@
+//! Hand-rolled fake providers for the `ServoBus` composite. Not mockall:
+//! `RxRing::bytes(&self) -> &[u8]` and the stateful cursor fight mockall's
+//! lifetime model, so these follow the state-companion spirit -- cloneable
+//! `Rc` handles the test configures and inspects, one of which is moved into
+//! the driver.
+
+use core::cell::{Cell, UnsafeCell};
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+use osc_core::BaudRate;
+use osc_protocol::crc::osc_crc_continue;
+
+use crate::bus::ServoBus;
+use crate::traits::bus::{CrcEngine, Deadline, Providers, RxRing, TxWire, UsartBaud};
+
+/// Ring length -- even and larger than `FRAME_MAX` (matches the V006 512 B ring).
+pub const RING_LEN: usize = 512;
+
+#[repr(align(2))]
+struct RingBuf([u8; RING_LEN]);
+
+struct RingState {
+    buf: UnsafeCell<RingBuf>,
+    cursor: Cell<u16>,
+}
+
+/// Counted RX ring backed by a halfword-aligned buffer.
+#[derive(Clone)]
+pub struct FakeRing(Rc<RingState>);
+
+impl FakeRing {
+    pub fn new() -> Self {
+        FakeRing(Rc::new(RingState {
+            buf: UnsafeCell::new(RingBuf([0; RING_LEN])),
+            cursor: Cell::new(0),
+        }))
+    }
+
+    /// Lay bytes into the ring at `at` (wrapping), before any event fires.
+    pub fn place(&self, at: usize, bytes: &[u8]) {
+        // SAFETY: test-only, single-threaded; scenarios never call `place`
+        // while a `bytes()` slice is live.
+        let buf = unsafe { &mut (*self.0.buf.get()).0 };
+        for (i, &b) in bytes.iter().enumerate() {
+            buf[(at + i) % RING_LEN] = b;
+        }
+    }
+
+    pub fn set_cursor(&self, c: u16) {
+        self.0.cursor.set(c);
+    }
+}
+
+impl Default for FakeRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RxRing for FakeRing {
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: test-only aliasing; the buffer is never mutated while a
+        // returned slice is live (see `place`).
+        let arr: &[u8; RING_LEN] = unsafe { &(*self.0.buf.get()).0 };
+        &arr[..]
+    }
+
+    fn cursor(&self) -> u16 {
+        self.0.cursor.get()
+    }
+}
+
+struct DeadlineState {
+    now: Cell<u32>,
+    armed: Cell<Option<u32>>,
+    cancels: Cell<u32>,
+}
+
+/// One-shot compare with a settable `now` and a record of the armed tick.
+#[derive(Clone)]
+pub struct FakeDeadline(Rc<DeadlineState>);
+
+impl FakeDeadline {
+    pub fn new() -> Self {
+        FakeDeadline(Rc::new(DeadlineState {
+            now: Cell::new(0),
+            armed: Cell::new(None),
+            cancels: Cell::new(0),
+        }))
+    }
+
+    pub fn set_now(&self, n: u32) {
+        self.0.now.set(n);
+    }
+
+    pub fn armed(&self) -> Option<u32> {
+        self.0.armed.get()
+    }
+
+    pub fn cancels(&self) -> u32 {
+        self.0.cancels.get()
+    }
+}
+
+impl Default for FakeDeadline {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deadline for FakeDeadline {
+    const TICKS_PER_US: u32 = 1;
+    const CLOCK_TRIM_STEP_PPM: u32 = 2500;
+
+    fn now(&self) -> u32 {
+        self.0.now.get()
+    }
+
+    fn set(&mut self, at: u32) {
+        self.0.armed.set(Some(at));
+    }
+
+    fn cancel(&mut self) {
+        self.0.armed.set(None);
+        self.0.cancels.set(self.0.cancels.get() + 1);
+    }
+}
+
+/// Software osc-CRC accumulator with an immediate result -- asserts even feeds
+/// (F12) exactly like the `tx` engine tests.
+pub struct FakeCrc {
+    state: u16,
+    snap: Vec<u8>,
+}
+
+impl FakeCrc {
+    pub fn new() -> Self {
+        FakeCrc {
+            state: 0,
+            snap: Vec::new(),
+        }
+    }
+}
+
+impl Default for FakeCrc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CrcEngine for FakeCrc {
+    fn reset(&mut self) {
+        self.state = 0;
+    }
+
+    fn feed(&mut self, span: &[u8]) {
+        assert_eq!(span.len() % 2, 0, "CRC feed must be even-length (F12)");
+        self.state = osc_crc_continue(self.state, span);
+    }
+
+    fn snapshot(&mut self, off: u16, src: &[u8]) -> *const u8 {
+        let off = off as usize;
+        if self.snap.len() < off + src.len() {
+            self.snap.resize(off + src.len(), 0);
+        }
+        self.snap[off..off + src.len()].copy_from_slice(src);
+        // SAFETY-adjacent note: tests never grow the Vec between a snapshot
+        // and its consumption, so the pointer stays stable like the chip's
+        // static buffer.
+        unsafe { self.snap.as_ptr().add(off) }
+    }
+
+    fn result(&mut self) -> Option<u16> {
+        Some(self.state)
+    }
+}
+
+/// One recorded TX-wire operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireEvent {
+    Start,
+    Send(Vec<u8>),
+    Release,
+}
+
+/// Half-duplex TX wire recording break/arm/release into a shared log.
+#[derive(Clone, Default)]
+pub struct FakeWire(Rc<RefCell<Vec<WireEvent>>>);
+
+impl FakeWire {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn log(&self) -> Vec<WireEvent> {
+        self.0.borrow().clone()
+    }
+
+    pub fn started(&self) -> bool {
+        self.0.borrow().contains(&WireEvent::Start)
+    }
+
+    /// Concatenated `Send` bytes -- the reply frame minus its `0x00` prefix.
+    pub fn sent(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        for e in self.0.borrow().iter() {
+            if let WireEvent::Send(v) = e {
+                out.extend_from_slice(v);
+            }
+        }
+        out
+    }
+}
+
+impl TxWire for FakeWire {
+    fn start_frame(&mut self) {
+        self.0.borrow_mut().push(WireEvent::Start);
+    }
+
+    fn send(&mut self, span: &[u8]) {
+        self.0.borrow_mut().push(WireEvent::Send(span.to_vec()));
+    }
+
+    fn release(&mut self) {
+        self.0.borrow_mut().push(WireEvent::Release);
+    }
+}
+
+/// USART baud control recording each applied rate.
+#[derive(Clone, Default)]
+pub struct FakeBaud(Rc<RefCell<Vec<BaudRate>>>);
+
+impl FakeBaud {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn applied(&self) -> Vec<BaudRate> {
+        self.0.borrow().clone()
+    }
+}
+
+impl UsartBaud for FakeBaud {
+    fn apply(&mut self, baud: BaudRate) {
+        self.0.borrow_mut().push(baud);
+    }
+}
+
+/// ZST binding each role to its fake (driver-pattern sec 5.4).
+pub struct TestProviders;
+
+impl Providers for TestProviders {
+    type Ring = FakeRing;
+    type Deadline = FakeDeadline;
+    type Crc = FakeCrc;
+    type Tx = FakeWire;
+    type Baud = FakeBaud;
+}
+
+/// Owns the shared fake state and builds a `ServoBus` over it.
+pub struct Harness {
+    pub ring: FakeRing,
+    pub deadline: FakeDeadline,
+    pub wire: FakeWire,
+    pub baud: FakeBaud,
+}
+
+impl Harness {
+    pub fn new() -> Self {
+        Harness {
+            ring: FakeRing::new(),
+            deadline: FakeDeadline::new(),
+            wire: FakeWire::new(),
+            baud: FakeBaud::new(),
+        }
+    }
+
+    pub fn build(
+        &self,
+        id: u8,
+        rate: BaudRate,
+        response_deadline_us: u16,
+    ) -> ServoBus<TestProviders> {
+        ServoBus::new(
+            self.ring.clone(),
+            self.deadline.clone(),
+            FakeCrc::new(),
+            self.wire.clone(),
+            self.baud.clone(),
+            id,
+            rate,
+            response_deadline_us,
+        )
+    }
+}
+
+impl Default for Harness {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/firmware/lib/drivers/src/mocks/digital_out.rs
+++ b/firmware/lib/drivers/src/mocks/digital_out.rs
@@ -1,0 +1,10 @@
+use mockall::mock;
+
+use crate::traits::{DigitalOut, Level};
+
+mock! {
+    pub DigitalOut {}
+    impl DigitalOut for DigitalOut {
+        fn set(&mut self, level: Level);
+    }
+}

--- a/firmware/lib/drivers/src/mocks/mod.rs
+++ b/firmware/lib/drivers/src/mocks/mod.rs
@@ -1,0 +1,16 @@
+//! Test doubles for the driver-owned interfaces. Most are mockall-generated
+//! (one per-role child module per trait file, mirroring `traits/`, each with
+//! one `mock!` block and consts set inside the impl block per mockall syntax).
+//! The `bus` composite's providers are hand-rolled instead -- their stateful
+//! cursor and borrow-returning `bytes()` fight mockall's lifetime model.
+//!
+//! `std` is pulled into the crate root behind the same cfg gate that
+//! guards this module (see `lib.rs`), so submodules can use `std`-backed
+//! types without making the whole crate `std`-bound.
+
+pub mod bus;
+pub mod digital_out;
+pub mod monotonic;
+
+pub use digital_out::MockDigitalOut;
+pub use monotonic::MockMonotonic;

--- a/firmware/lib/drivers/src/mocks/monotonic.rs
+++ b/firmware/lib/drivers/src/mocks/monotonic.rs
@@ -1,0 +1,13 @@
+use mockall::mock;
+
+use crate::traits::Monotonic;
+
+mock! {
+    pub Monotonic {}
+    impl Monotonic for Monotonic {
+        // TICKS_PER_US is 1 so test arithmetic stays in us without scaling.
+        const TICKS_PER_US: u32 = 1;
+
+        fn ticks(&self) -> u32;
+    }
+}

--- a/firmware/lib/drivers/src/traits/bus.rs
+++ b/firmware/lib/drivers/src/traits/bus.rs
@@ -1,0 +1,86 @@
+//! osc-native transport interfaces (`docs/osc-native-protocol.md` sec 4, sec 10).
+//! Owned by the bus driver; chip-side providers implement these over real
+//! peripherals (production) or recording mocks (tests).
+
+use osc_core::BaudRate;
+
+/// Counted circular RX DMA ring, armed once at boot (sec 4.1). The driver reads
+/// the cursor and ring bytes in place; it never drains, and never reloads
+/// except through [`Self::rearm`].
+pub trait RxRing {
+    /// The ring storage. Length must exceed the largest legal frame
+    /// ([`crate::bus::FRAME_MAX`]) with lap margin -- 512 on V006 (sec 11).
+    fn bytes(&self) -> &[u8];
+    /// Index where the next received byte will land (`LEN - NDTR`).
+    fn cursor(&self) -> u16;
+}
+
+/// One-shot compare on the transport tick domain. `set` arms the compare;
+/// the chip ISR it fires calls back into the driver's `on_deadline`.
+pub trait Deadline {
+    const TICKS_PER_US: u32;
+    /// Nominal clock shift per oscillator trim step, ppm -- the trim loop's
+    /// plant-gain seed (sec 9.3). The true per-chip value is nonuniform; the
+    /// loop measures and replaces it after its first correction.
+    const CLOCK_TRIM_STEP_PPM: u32;
+    fn now(&self) -> u32;
+    fn set(&mut self, at: u32);
+    fn cancel(&mut self);
+}
+
+/// Hardware CRC engine, DMA-fed -- zero CPU per byte (sec 3.2, F6). Feed spans
+/// must be even-LENGTH (the sec 3.2 fold covers trailing odd bytes) and
+/// even-ADDRESSED (F12) -- which every source satisfies by construction: the
+/// reply buffer head and the snapshot buffer are halfword-aligned, and
+/// arbitrary-parity spans reach the engine through [`Self::snapshot`]. Feeds
+/// accumulate across calls until [`Self::reset`].
+pub trait CrcEngine {
+    fn reset(&mut self);
+    fn feed(&mut self, span: &[u8]);
+    /// Stream `src` into the engine's stable snapshot buffer at byte offset
+    /// `off` and return the copy's address. Best-effort and asynchronous:
+    /// the copy may still be in flight on return -- the engine's transfer
+    /// ordering guarantees no downstream consumer (CRC feed, wire arm)
+    /// overtakes it. Both the wire and the CRC consume the snapshot, so a
+    /// reply's CRC always covers exactly the transmitted bytes (sec 4.2);
+    /// offsets let a caller linearize a ring-wrapped span. Contents stay
+    /// valid until the next `snapshot` call over the same range.
+    fn snapshot(&mut self, off: u16, src: &[u8]) -> *const u8;
+    /// The CRC over everything fed since reset, once the engine has drained
+    /// the fed spans; `None` while still busy.
+    fn result(&mut self) -> Option<u16>;
+}
+
+/// TX side of the half-duplex wire (sec 4.2): drive discipline + break + one
+/// DMA arm at a time. Arm completion surfaces as the chip TC ISR calling
+/// the driver's `on_tx_complete`.
+pub trait TxWire {
+    /// Claim the wire: push-pull drive, then send the break (SBK).
+    fn start_frame(&mut self);
+    /// Stream one DMA arm. Called once per arm; the next arm is queued from
+    /// `on_tx_complete`. UART bytes tolerate the us-scale re-arm gap (sec 4.2).
+    fn send(&mut self, span: &[u8]);
+    /// Release the wire: open-drain, TX DMA off.
+    fn release(&mut self);
+}
+
+/// Single-channel USART baud control; also the rescue-rate entry (sec 9.1 --
+/// volatile, config register untouched).
+pub trait UsartBaud {
+    fn apply(&mut self, baud: BaudRate);
+}
+
+/// Role bundle for the `ServoBus` composite (driver-pattern sec 5.4).
+pub trait Providers {
+    type Ring: RxRing;
+    type Deadline: Deadline;
+    type Crc: CrcEngine;
+    type Tx: TxWire;
+    type Baud: UsartBaud;
+}
+
+/// Wrap-aware "`a` is at or after `b`" on the u32 tick domain.
+#[inline]
+pub const fn tick_reached(a: u32, b: u32) -> bool {
+    a.wrapping_sub(b) < u32::MAX / 2
+}

--- a/firmware/lib/drivers/src/traits/digital_out.rs
+++ b/firmware/lib/drivers/src/traits/digital_out.rs
@@ -1,0 +1,13 @@
+/// Two-state digital line level. Shared across driver trait surfaces
+/// ([`DigitalOut::set`], LED patterns, board wiring active-level).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Level {
+    Low,
+    High,
+}
+
+/// Drive a single digital output. Owned by the adapter; the driver holds
+/// one `P: DigitalOut` and calls `set` to change the wire state.
+pub trait DigitalOut {
+    fn set(&mut self, level: Level);
+}

--- a/firmware/lib/drivers/src/traits/mod.rs
+++ b/firmware/lib/drivers/src/traits/mod.rs
@@ -1,0 +1,14 @@
+//! Driver-owned interfaces. Drivers declare what they need from their
+//! environment; chip-side adapters implement these over real HAL peripherals
+//! (production) or recording mocks (tests).
+//!
+//! Transport-shaped traits live under [`bus`]; the root holds only
+//! cross-driver primitives ([`DigitalOut`], [`Monotonic`]).
+
+mod digital_out;
+mod monotonic;
+
+pub mod bus;
+
+pub use digital_out::{DigitalOut, Level};
+pub use monotonic::Monotonic;

--- a/firmware/lib/drivers/src/traits/monotonic.rs
+++ b/firmware/lib/drivers/src/traits/monotonic.rs
@@ -1,0 +1,7 @@
+/// Free-running monotonic tick counter, used by drivers that schedule by
+/// elapsed time. `TICKS_PER_US` describes the rate so the driver can
+/// convert us <-> ticks without importing chip constants.
+pub trait Monotonic {
+    const TICKS_PER_US: u32;
+    fn ticks(&self) -> u32;
+}


### PR DESCRIPTION
The chip-agnostic bus driver family, from #20's tip.

`ServoBus` is a composite of four sub-driver state machines: `Framer` (stream-continuity RX resolver — position derived from ring data, never from ISR-entry evidence), `Chain` (status-chain sequencing with reclaim), `TxEngine` (copy-once reply pipeline, hardware-CRC-fed), and `ClockTracker` (CAL ruler + differential drift tracker feeding the trim loop). Every sub-driver is generic over provider traits the crate defines itself, so all the FSM logic unit-tests on the host with recording fakes — no chip, no simulator.

No chip types appear anywhere in the crate; the crate boundary enforces it, not review discipline. 56 tests. CI picks up feature checks for `mocks` and the `bench` probe counters.
