### PR TITLE
firmware: DES integration suite

### DIFF
--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["control-table", "control-table-derive", "core", "drivers", "log", "osc-protocol", "units"]
+members = ["control-table", "control-table-derive", "core", "drivers", "integration", "log", "osc-protocol", "units"]
 
 [workspace.package]
 edition = "2024"

--- a/firmware/lib/integration/Cargo.toml
+++ b/firmware/lib/integration/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name    = "osc-integration"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+osc-core     = { workspace = true, features = ["log"] }
+osc-drivers  = { workspace = true, features = ["log"] }
+osc-protocol = { workspace = true, features = ["software-crc"] }
+control-table.workspace = true
+log = "0.4"
+
+[dev-dependencies]
+env_logger   = "0.11"
+rstest       = "0.23"
+rstest_reuse = "0.7"
+test-log     = "0.2"
+
+[[test]]
+name = "protocol"
+path = "tests/protocol.rs"
+
+[[test]]
+name = "chains"
+path = "tests/chains.rs"
+
+[[test]]
+name = "resilience"
+path = "tests/resilience.rs"
+
+[[test]]
+name = "timing"
+path = "tests/timing.rs"

--- a/firmware/lib/integration/src/lib.rs
+++ b/firmware/lib/integration/src/lib.rs
@@ -1,0 +1,9 @@
+//! Spec-driven black-box integration tests for the OpenServoCore osc-native
+//! stack (`docs/osc-native-protocol.md`). The [`sim`] module is a
+//! discrete-event simulator with wire-event fidelity derived from the measured
+//! silicon facts (sec 12): breaks, framing errors, byte ring timing, drive
+//! discipline. Tests run the REAL `osc_drivers::bus::ServoBus` and REAL
+//! `osc_core` dispatch against simulated providers -- the same code the chip
+//! band will wire to hardware.
+
+pub mod sim;

--- a/firmware/lib/integration/src/sim/core.rs
+++ b/firmware/lib/integration/src/sim/core.rs
@@ -1,0 +1,289 @@
+//! Discrete-event core: the time domain, the event heap, and the single
+//! half-duplex wire model (`docs/osc-native-protocol.md` sec 2). Everything that
+//! is *not* per-servo state lives here; the [`super::Sim`] facade owns this
+//! behind an `Rc<RefCell<_>>` so every provider can schedule into one queue.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use osc_core::BaudRate;
+
+use super::{Source, WireFrame};
+
+/// Transport tick domain (transport sec 1): 48 ticks/us makes every bit-time
+/// integral at all four rates (3M=16, 2M=24, 1M=48, 0.5M=96 ticks/bit).
+pub const TICKS_PER_US: u64 = 48;
+
+/// 10 bit-times per UART character (8N1) -- the byte and break unit (sec 2).
+const BITS_PER_BYTE: u64 = 10;
+
+/// SBK break length; measured ~14 bit-times, zero variance [F5]. The ring
+/// byte and `on_break` are delivered at the break's *end* -- where the
+/// detector latches (silicon: LBD sets at the rising edge that ends the span;
+/// == bit 10 for the 10-bit law break).
+const BREAK_BITS: u64 = 14;
+
+/// Runaway guards: a wedged scenario must fail loudly, not spin forever.
+const MAX_EVENTS: u64 = 10_000_000;
+const MAX_SIM_TICKS: u64 = 60 * 1_000_000 * TICKS_PER_US;
+
+/// Ticks for one bit / byte / break at `baud` -- integral by TICKS_PER_US choice.
+#[inline]
+pub fn bit_ticks(baud: BaudRate) -> u64 {
+    TICKS_PER_US * 1_000_000 / baud.as_hz() as u64
+}
+#[inline]
+pub fn byte_ticks(baud: BaudRate) -> u64 {
+    bit_ticks(baud) * BITS_PER_BYTE
+}
+#[inline]
+pub fn break_ticks(baud: BaudRate) -> u64 {
+    bit_ticks(baud) * BREAK_BITS
+}
+
+/// Who is driving the wire (sec 2 drive discipline). `Host` schedules the bus;
+/// `Servo(index)` is a replying node -- index, not id, so the F8 assert names
+/// an unambiguous node even mid-id-change.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Talker {
+    Host,
+    Servo(usize),
+}
+
+/// A scheduled wire/servo event. Ordered by `(time, seq)` for FIFO tie-breaks.
+pub enum Event {
+    /// Break-detect point: ring one byte at every listener and wake the
+    /// receivers whose rate qualifies the span (sec 3.4: the detector is
+    /// length-qualified -- >=10 of the RECEIVER's bit-times -- so a break
+    /// wakes only servos at or above `baud`). `break_start` is the
+    /// recorded frame's `at`; delivery is at break end.
+    WireBreak {
+        talker: Talker,
+        baud: BaudRate,
+        break_start: u64,
+    },
+    /// One data byte at its stop-bit sample point. A listener whose baud
+    /// differs from `baud` rings it garbled and is never woken (sec 3.4:
+    /// errors don't interrupt; sub-10-bit lows are invisible to the
+    /// detector).
+    WireData {
+        talker: Talker,
+        byte: u8,
+        baud: BaudRate,
+    },
+    /// A lone noise byte, no frame around it (line noise, F4): rings, never
+    /// wakes.
+    WireGarble { byte: u8 },
+    /// Test-injected foreign break dropped into another talker's window:
+    /// rings a 0x00 and wakes qualified receivers, invisible to the frame
+    /// recorder (noise, not traffic).
+    StrayBreak { baud: BaudRate },
+    /// A rescue pulse crossed the sampler threshold (sec 9.1): every servo's
+    /// main-loop sampler has seen >= RESCUE_LOW_US of continuous low with the
+    /// ring frozen -- deliver `on_rescue_break` (a thread-level event, not a
+    /// vector; the pulse still holds the line). The pulse's END additionally
+    /// fires an ordinary break wake ([`Event::StrayBreak`]).
+    RescueDeclare,
+    /// The host's frame drained -- finalize the recorded frame.
+    HostFrameEnd,
+    /// A servo's tick-compare fired; `generation` guards against a cancelled/re-armed
+    /// deadline (stale generations are dropped on delivery).
+    Compare { servo: usize, generation: u64 },
+    /// Test-injected oscillator drift (sec 9.3): servo `servo`'s clock RATE
+    /// becomes `ppm` here, continuously -- re-anchored, the reading never
+    /// steps (thermal drift as the tracker sees it).
+    SkewChange { servo: usize, ppm: i32 },
+    /// Test-injected spurious wake: the break vector re-enters with NO new
+    /// wire byte (a coalesced or lagged break service -- sec 3.4's reason to
+    /// demand idempotence).
+    WakeRefire { servo: usize },
+    /// A servo TX DMA arm completed -- drive `on_tx_complete`.
+    TxArmDone { servo: usize },
+    /// A servo's handler body ended (`super::cpu`): deliver one pended vector.
+    CpuFree { servo: usize },
+}
+
+struct Scheduled {
+    time: u64,
+    seq: u64,
+    event: Event,
+}
+
+impl PartialEq for Scheduled {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time && self.seq == other.seq
+    }
+}
+impl Eq for Scheduled {}
+impl Ord for Scheduled {
+    // Reversed: `BinaryHeap` is a max-heap, we want the earliest `(time, seq)`.
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .time
+            .cmp(&self.time)
+            .then_with(|| other.seq.cmp(&self.seq))
+    }
+}
+impl PartialOrd for Scheduled {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A frame being assembled on the wire (half-duplex -> at most one live).
+struct PendingFrame {
+    at: u64,
+    end: u64,
+    talker: Talker,
+    bytes: Vec<u8>,
+    collided: bool,
+}
+
+pub struct Core {
+    heap: BinaryHeap<Scheduled>,
+    seq: u64,
+    now: u64,
+    processed: u64,
+    // Drive discipline: the current owner and how far its claim reaches.
+    busy: Option<(Talker, u64)>,
+    pending: Option<PendingFrame>,
+    recorded: Vec<WireFrame>,
+}
+
+impl Core {
+    pub fn new() -> Self {
+        Self {
+            heap: BinaryHeap::new(),
+            seq: 0,
+            now: 0,
+            processed: 0,
+            busy: None,
+            pending: None,
+            recorded: Vec::new(),
+        }
+    }
+
+    pub fn now(&self) -> u64 {
+        self.now
+    }
+
+    /// Queue `event` at absolute tick `time`; FIFO among equal times.
+    pub fn schedule(&mut self, event: Event, time: u64) {
+        let seq = self.seq;
+        self.seq += 1;
+        self.heap.push(Scheduled { time, seq, event });
+    }
+
+    /// Pop the earliest event, advancing the clock and tripping the runaway
+    /// guards. Returns `None` when the queue drains.
+    pub fn pop(&mut self) -> Option<Event> {
+        let Scheduled { time, event, .. } = self.heap.pop()?;
+        // DES invariant: the clock never rewinds. Every scheduler clamps to
+        // `now` (the CPU occupancy model reads busy-windows against it).
+        assert!(
+            time >= self.now,
+            "sim clock rewind: event at t={time} after now={}",
+            self.now
+        );
+        self.now = time;
+        self.processed += 1;
+        assert!(
+            self.processed <= MAX_EVENTS,
+            "sim runaway: >{MAX_EVENTS} events"
+        );
+        assert!(self.now <= MAX_SIM_TICKS, "sim runaway: >60 s of sim time");
+        Some(event)
+    }
+
+    // --- wire drive discipline (sec 2, F8) -----------------------------------
+
+    /// Claim the wire for `talker` over `[start, end)`. A different talker
+    /// overlapping an existing claim is the reply gap regression -- panic
+    /// loudly -- EXCEPT servo-vs-servo: simultaneous ENUM matchers collide by
+    /// sec 9.2 contract ("garbage IS the collision signal"), so that overlap is
+    /// recorded on the live frame instead. Host overlap stays the F8 panic.
+    pub fn claim(&mut self, talker: Talker, start: u64, end: u64) {
+        if let Some((owner, owner_end)) = self.busy
+            && owner != talker
+            && start < owner_end
+        {
+            if matches!(owner, Talker::Servo(_)) && matches!(talker, Talker::Servo(_)) {
+                if let Some(p) = self.pending.as_mut() {
+                    p.collided = true;
+                }
+                self.busy = Some((owner, owner_end.max(end)));
+                return;
+            }
+            panic!(
+                "drive discipline (F8): {talker:?} claims the wire at t={start} \
+                 while {owner:?} holds it until t={owner_end}"
+            );
+        }
+        let reach = match self.busy {
+            Some((owner, owner_end)) if owner == talker => owner_end.max(end),
+            _ => end,
+        };
+        self.busy = Some((talker, reach));
+    }
+
+    // --- wire recorder ----------------------------------------------------
+
+    /// Begin the frame a break opens; its ring image starts with the 0x00
+    /// break byte (sec 3.2 prefix). A servo break landing inside another
+    /// servo's frame is the sanctioned sec 9.2 collision: fold it into the live
+    /// frame's record -- the wire carries one span of colliding energy, not
+    /// two frames. Any host-involved overlap is a harness invariant break.
+    pub fn begin_frame(&mut self, at: u64, talker: Talker) {
+        if let Some(p) = self.pending.as_mut() {
+            if matches!(p.talker, Talker::Servo(_)) && matches!(talker, Talker::Servo(_)) {
+                p.collided = true;
+                p.bytes.push(0x00);
+                p.end = self.now;
+                return;
+            }
+            panic!(
+                "wire recorder: frame began mid-frame -- pending at={} end={} talker={:?} bytes={:02X?} new_at={} now={}",
+                p.at, p.end, p.talker, p.bytes, at, self.now
+            );
+        }
+        self.pending = Some(PendingFrame {
+            at,
+            end: self.now,
+            talker,
+            bytes: vec![0x00],
+            collided: false,
+        });
+    }
+
+    pub fn append_byte(&mut self, byte: u8, at: u64) {
+        if let Some(p) = self.pending.as_mut() {
+            p.bytes.push(byte);
+            p.end = at;
+        }
+    }
+
+    pub fn finalize_frame(&mut self) {
+        let Some(p) = self.pending.take() else {
+            return;
+        };
+        let from = match p.talker {
+            Talker::Host => Source::Host,
+            // The servo encodes its live id into byte 1 -- id-at-send-time.
+            Talker::Servo(_) => Source::Servo(p.bytes.get(1).copied().unwrap_or(0)),
+        };
+        self.recorded.push(WireFrame {
+            at: p.at,
+            end: p.end,
+            from,
+            bytes: p.bytes,
+            collided: p.collided,
+        });
+    }
+
+    /// Drain every frame recorded since the last drain, in wire order.
+    pub fn take_recorded(&mut self) -> Vec<WireFrame> {
+        let mut out = std::mem::take(&mut self.recorded);
+        out.sort_by_key(|f| f.at);
+        out
+    }
+}

--- a/firmware/lib/integration/src/sim/cpu.rs
+++ b/firmware/lib/integration/src/sim/cpu.rs
@@ -1,0 +1,98 @@
+//! Per-servo PFIC occupancy model. The transport vectors share PFIC HIGH on
+//! the chip, so a handler body occupies the CPU and every event landing
+//! meanwhile *pends* -- a flag per vector, not a queue -- and a burst of same-
+//! vector events coalesces into one late delivery, exactly as pended IRQs do
+//! on silicon. Ring bytes are DMA and always land at their wire tick; only
+//! handler invocations defer. Handler effects land at entry: the model
+//! charges occupancy, not intra-body effect timing.
+
+use super::core::TICKS_PER_US;
+
+/// Sim-time cost of each `ServoBus` handler body, us. Zero (the default)
+/// delivers every event at its wire tick -- the ideal-CPU model the logical
+/// suites pin.
+#[derive(Copy, Clone, Default)]
+pub struct HandlerCost {
+    pub on_break_us: u32,
+    pub on_deadline_us: u32,
+    pub on_tx_complete_us: u32,
+}
+
+/// The transport vectors, in same-priority arbitration order (lowest
+/// interrupt number delivers first: SysTick, then USART1 -- whose real body
+/// drains RX errors before TC).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Vector {
+    Compare,
+    Break,
+    TxDone,
+}
+
+#[derive(Default)]
+pub struct Cpu {
+    pub cost: HandlerCost,
+    busy_until: u64,
+    pend_compare: bool,
+    pend_break: bool,
+    pend_tx: bool,
+    /// A `CpuFree` wake is in flight; at most one outstanding per servo.
+    pub free_scheduled: bool,
+    delivered_breaks: u64,
+}
+
+impl Cpu {
+    pub fn busy(&self, now: u64) -> bool {
+        now < self.busy_until
+    }
+
+    pub fn busy_until(&self) -> u64 {
+        self.busy_until
+    }
+
+    pub fn pend(&mut self, v: Vector) {
+        match v {
+            Vector::Compare => self.pend_compare = true,
+            Vector::Break => self.pend_break = true,
+            Vector::TxDone => self.pend_tx = true,
+        }
+    }
+
+    pub fn any_pend(&self) -> bool {
+        self.pend_compare || self.pend_break || self.pend_tx
+    }
+
+    /// Pop the highest-arbitration pended vector, if any.
+    pub fn take_pend(&mut self) -> Option<Vector> {
+        if self.pend_compare {
+            self.pend_compare = false;
+            Some(Vector::Compare)
+        } else if self.pend_break {
+            self.pend_break = false;
+            Some(Vector::Break)
+        } else if self.pend_tx {
+            self.pend_tx = false;
+            Some(Vector::TxDone)
+        } else {
+            None
+        }
+    }
+
+    /// Occupy the CPU with `v`'s body starting at `now`.
+    pub fn charge(&mut self, now: u64, v: Vector) {
+        let us = match v {
+            Vector::Compare => self.cost.on_deadline_us,
+            Vector::Break => {
+                self.delivered_breaks += 1;
+                self.cost.on_break_us
+            }
+            Vector::TxDone => self.cost.on_tx_complete_us,
+        };
+        self.busy_until = now + us as u64 * TICKS_PER_US;
+    }
+
+    /// `on_break` invocations actually delivered -- the coalescing observable
+    /// (wire FE events minus this = pends that merged).
+    pub fn delivered_breaks(&self) -> u64 {
+        self.delivered_breaks
+    }
+}

--- a/firmware/lib/integration/src/sim/mod.rs
+++ b/firmware/lib/integration/src/sim/mod.rs
@@ -1,0 +1,532 @@
+//! Discrete-event simulator for the osc-native bus. A single `Sim` owns the
+//! event queue, the shared half-duplex wire, and a set of boxed `SimServo`s
+//! (real `ServoBus` + real `osc_core` dispatch over sim providers). The wire
+//! model is derived from the measured silicon facts (sec 12): break framing, one
+//! FE per break, DMA-ringed bytes, drive discipline. Handler invocations
+//! route through a per-servo PFIC occupancy model (`cpu`): with nonzero
+//! [`HandlerCost`], events landing mid-body pend and coalesce as on silicon.
+//! See the module docs of `core`, `cpu`, `providers`, and `servo` for the
+//! moving parts.
+
+mod core;
+mod cpu;
+mod providers;
+mod servo;
+mod store;
+mod support;
+
+#[cfg(test)]
+mod tests;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use osc_core::regions::config::DEFAULT_RESPONSE_DEADLINE_US;
+use osc_core::{BaudRate, BootMode, ControlTable};
+use osc_drivers::bus::LinkDiag;
+use osc_drivers::bus::RESCUE_LOW_US;
+
+use self::core::{Core, Event, TICKS_PER_US, Talker, break_ticks, byte_ticks};
+use self::cpu::{Cpu, Vector};
+use self::providers::Handles;
+use self::servo::SimServo;
+
+pub use self::cpu::HandlerCost;
+pub use self::store::RamStore;
+
+/// XOR mask applied to bytes ringed at a baud-mismatched receiver: arbitrary
+/// but nonzero, so mismatched data never survives as valid content.
+const MISMATCH_GARBLE: u8 = 0xA5;
+
+pub use self::support::{assert_valid, instruction, status};
+
+/// Who put a frame on the wire, as recorded.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Source {
+    Host,
+    Servo(u8),
+}
+
+/// One frame observed on the wire, as the ring would image it.
+#[derive(Clone, Debug)]
+pub struct WireFrame {
+    /// Break start, ticks.
+    pub at: u64,
+    /// Last byte's end, ticks.
+    pub end: u64,
+    pub from: Source,
+    /// The ring image: 0x00 break byte, then ID..CRC.
+    pub bytes: Vec<u8>,
+    /// Another servo transmitted into this frame (sec 9.2 ENUM collision):
+    /// `bytes` interleaves both talkers' spans -- garbage, as on the wire.
+    pub collided: bool,
+}
+
+pub struct Sim {
+    core: Rc<RefCell<Core>>,
+    // Box is load-bearing: a `SimServo`'s address must be stable while the TX
+    // engine streams a read reply zero-copy (raw pointers into its control
+    // table, sec 4.2). `Vec<SimServo>` would move elements on realloc.
+    #[allow(clippy::vec_box)]
+    servos: Vec<Box<SimServo>>,
+    handles: Vec<Handles>,
+    cpus: Vec<Cpu>,
+    rate: BaudRate,
+    /// The scheduling host queues each frame after its own prior traffic.
+    host_free_at: u64,
+}
+
+impl Sim {
+    pub fn new(rate: BaudRate) -> Self {
+        Self {
+            core: Rc::new(RefCell::new(Core::new())),
+            servos: Vec::new(),
+            handles: Vec::new(),
+            cpus: Vec::new(),
+            rate,
+            host_free_at: 0,
+        }
+    }
+
+    /// Add a servo with the default table seed at this id; returns its index.
+    pub fn add_servo(&mut self, id: u8) -> usize {
+        self.add_servo_full(id, 0, DEFAULT_RESPONSE_DEADLINE_US, None)
+    }
+
+    pub fn add_servo_with(&mut self, id: u8, skew_ppm: i32, response_deadline_us: u16) -> usize {
+        self.add_servo_full(id, skew_ppm, response_deadline_us, None)
+    }
+
+    /// Add a servo with a persistence store: its boot overlay runs against
+    /// the store's slots (sec 9.4), so a saved image's comms block wins over
+    /// `id` -- sharing one leaked store across `Sim` instances models a
+    /// reboot with flash intact.
+    pub fn add_servo_with_store(&mut self, id: u8, store: &'static RamStore) -> usize {
+        self.add_servo_full(id, 0, DEFAULT_RESPONSE_DEADLINE_US, Some(store))
+    }
+
+    fn add_servo_full(
+        &mut self,
+        id: u8,
+        skew_ppm: i32,
+        response_deadline_us: u16,
+        store: Option<&'static RamStore>,
+    ) -> usize {
+        let idx = self.servos.len();
+        let (servo, handles) = SimServo::build(
+            &self.core,
+            idx,
+            id,
+            self.rate,
+            skew_ppm,
+            response_deadline_us,
+            store,
+        );
+        self.servos.push(servo);
+        self.handles.push(handles);
+        self.cpus.push(Cpu::default());
+        idx
+    }
+
+    /// Give servo `i`'s handler bodies sim-time cost (`cpu` module): events
+    /// landing while a body runs pend and coalesce as on silicon. Zero-cost
+    /// (the default) is the ideal-CPU model.
+    pub fn set_handler_cost(&mut self, i: usize, cost: HandlerCost) {
+        self.cpus[i].cost = cost;
+    }
+
+    /// `on_break` invocations delivered to servo `i` -- wire break events
+    /// minus this counts pends that coalesced.
+    pub fn delivered_breaks(&self, i: usize) -> u64 {
+        self.cpus[i].delivered_breaks()
+    }
+
+    /// Inspect a servo's live control table.
+    pub fn servo_table<R>(&self, i: usize, f: impl FnOnce(&ControlTable) -> R) -> R {
+        self.servos[i].with_table(f)
+    }
+
+    /// Chip-side mutation of a servo's table (fault flags, telemetry) -- the
+    /// sim's stand-in for the control/fault ISRs the chip band will own.
+    pub fn servo_table_mut<R>(&self, i: usize, f: impl FnOnce(&mut ControlTable) -> R) -> R {
+        self.servos[i].with_table_mut(f)
+    }
+
+    pub fn servo_diag(&self, i: usize) -> LinkDiag {
+        self.servos[i].diag()
+    }
+
+    /// The chip main loop's trim poll (sec 9.3), between exchanges.
+    pub fn poll_clock_trim(&mut self, i: usize) -> Option<i8> {
+        self.servos[i].poll_clock_trim()
+    }
+
+    pub fn take_reboot(&mut self, i: usize) -> Option<BootMode> {
+        self.servos[i].take_reboot()
+    }
+
+    /// Replace servo `i`'s factory UID (the chip band seeds it from ESIG at
+    /// bringup; tests seed it before traffic for controlled ENUM prefixes).
+    pub fn seed_servo_uid(&self, i: usize, uid: [u8; 16]) {
+        self.servos[i].seed_uid(uid);
+    }
+
+    pub fn servo_uid(&self, i: usize) -> [u8; 16] {
+        self.servos[i].uid()
+    }
+
+    /// Queue a host frame starting when the wire is free of host traffic.
+    pub fn host_send(&mut self, frame: &[u8]) {
+        let start = self.host_free_at.max(self.core.borrow().now());
+        self.queue_host_frame(start, frame);
+    }
+
+    /// Sim time is monotonic: an `at_us` the drained queue has already passed
+    /// starts as soon as prior activity quiesced instead of rewinding the
+    /// clock (the `cpu` occupancy model depends on pops never running
+    /// backwards; zero-cost handlers merely never noticed the rewind).
+    fn clamp_at(&self, at_us: u64) -> u64 {
+        (at_us * TICKS_PER_US).max(self.core.borrow().now())
+    }
+
+    /// Serialized against the host's own prior traffic: one transmitter
+    /// cannot overlap itself, so a clamped `at_us` queues after
+    /// `host_free_at` instead of colliding on the wire.
+    pub fn host_send_at(&mut self, at_us: u64, frame: &[u8]) {
+        let start = self.clamp_at(at_us).max(self.host_free_at);
+        self.queue_host_frame(start, frame);
+    }
+
+    /// A bare break at `at_us` -- the MGMT CAL train's ruler mark (sec 9.3):
+    /// one FE at every listener, no data bytes. Successive calls with exact
+    /// `at_us` spacing model a host whose timer paces the train.
+    pub fn host_send_break_at(&mut self, at_us: u64) {
+        let start = self.clamp_at(at_us).max(self.host_free_at);
+        let baud = self.rate;
+        let break_end = start + break_ticks(baud);
+        let mut c = self.core.borrow_mut();
+        c.claim(Talker::Host, start, break_end);
+        c.schedule(
+            Event::WireBreak {
+                talker: Talker::Host,
+                baud,
+                break_start: start,
+            },
+            break_end,
+        );
+        c.schedule(Event::HostFrameEnd, break_end);
+        drop(c);
+        self.host_free_at = break_end;
+    }
+
+    /// Servo `i`'s oscillator rate becomes `ppm` at `at_us` -- thermal drift
+    /// as the drift tracker sees it: the rate changes, the clock never steps.
+    pub fn set_servo_skew_at(&mut self, at_us: u64, i: usize, ppm: i32) {
+        let at = self.clamp_at(at_us);
+        self.core
+            .borrow_mut()
+            .schedule(Event::SkewChange { servo: i, ppm }, at);
+    }
+
+    /// Inject a spurious break wake at servo `i`: the break vector
+    /// re-enters with NO new wire byte -- a coalesced or lagged service
+    /// (sec 3.4: breaks are not countable events; wakes carry no position and
+    /// no time, and any code deriving either from them kills live frames --
+    /// bench-caught twice: the fence, then the tracker starvation).
+    pub fn inject_wake_refire_at(&mut self, at_us: u64, i: usize) {
+        let at = self.clamp_at(at_us);
+        self.core
+            .borrow_mut()
+            .schedule(Event::WakeRefire { servo: i }, at);
+    }
+
+    /// Queue a host frame whose transmitter stalls mid-frame: bytes
+    /// `..split` stream normally, then the wire idles high for `stall_us`,
+    /// then the rest streams. Models the pirate's TXE-poll bubbles (bench:
+    /// 58-94-bit pauses INSIDE frames on failing plain-burst cycles) -- a
+    /// legal wire per sec 4.1 (nothing times on idle), and the
+    /// stress that parks the frontier at the starvation horizon.
+    pub fn host_send_stalled(&mut self, frame: &[u8], split: usize, stall_us: u64) {
+        let start = self.host_free_at.max(self.core.borrow().now());
+        let baud = self.rate;
+        let bt = byte_ticks(baud);
+        let break_end = start + break_ticks(baud);
+        let n = frame.len() as u64 - 1;
+        let split = split.clamp(1, frame.len() - 1) as u64;
+        let stall = stall_us * TICKS_PER_US;
+        let end = break_end + n * bt + stall;
+
+        let mut c = self.core.borrow_mut();
+        c.claim(Talker::Host, start, end);
+        c.schedule(
+            Event::WireBreak {
+                talker: Talker::Host,
+                baud,
+                break_start: start,
+            },
+            break_end,
+        );
+        for (k, &b) in frame[1..].iter().enumerate() {
+            let mut t = break_end + (k as u64 + 1) * bt;
+            if (k as u64) >= split {
+                t += stall;
+            }
+            c.schedule(
+                Event::WireData {
+                    talker: Talker::Host,
+                    byte: b,
+                    baud,
+                },
+                t,
+            );
+        }
+        c.schedule(Event::HostFrameEnd, end);
+        drop(c);
+        self.host_free_at = end;
+    }
+
+    /// One lone noise byte on the wire (line noise, F4): rings at every
+    /// servo, wakes nothing (sec 3.4 -- errors never interrupt).
+    pub fn inject_garble_at(&mut self, at_us: u64, b: u8) {
+        let at = self.clamp_at(at_us);
+        self.core
+            .borrow_mut()
+            .schedule(Event::WireGarble { byte: b }, at);
+    }
+
+    /// A foreign break dropped onto the wire at `at_us`, bypassing host
+    /// serialization (a break can land inside another talker's window --
+    /// collision, glitch): rings a 0x00 and wakes qualified receivers.
+    pub fn inject_break_at(&mut self, at_us: u64) {
+        let at = self.clamp_at(at_us);
+        let baud = self.rate;
+        self.core
+            .borrow_mut()
+            .schedule(Event::StrayBreak { baud }, at);
+    }
+
+    /// Rescue pulse: line dominant for `us` (sec 9.1). Two modeled effects:
+    /// each servo's main-loop sampler declares once >= RESCUE_LOW_US of
+    /// frozen-ring low has elapsed (measured from the pulse's ringed 0x00,
+    /// ~a byte-time in), and the pulse's END fires an ordinary break wake --
+    /// the detector latches only at the rising edge (silicon).
+    /// A pulse too short to cross the threshold delivers only the end wake.
+    pub fn hold_line_low_at(&mut self, at_us: u64, us: u64) {
+        let start = self.clamp_at(at_us);
+        let dur = us * TICKS_PER_US;
+        let baud = self.rate;
+        let mut c = self.core.borrow_mut();
+        let declare = start + byte_ticks(baud) + RESCUE_LOW_US as u64 * TICKS_PER_US;
+        if declare < start + dur {
+            c.schedule(Event::RescueDeclare, declare);
+        }
+        c.schedule(Event::StrayBreak { baud }, start + dur);
+    }
+
+    pub fn set_host_baud(&mut self, rate: BaudRate) {
+        self.rate = rate;
+    }
+
+    /// Drain the event queue; return every frame observed since the last call.
+    pub fn run(&mut self) -> Vec<WireFrame> {
+        loop {
+            let ev = self.core.borrow_mut().pop();
+            let Some(ev) = ev else { break };
+            self.dispatch(ev);
+        }
+        self.core.borrow_mut().take_recorded()
+    }
+
+    pub fn now_us(&self) -> u64 {
+        self.core.borrow().now() / TICKS_PER_US
+    }
+
+    // --- internals --------------------------------------------------------
+
+    fn queue_host_frame(&mut self, start: u64, frame: &[u8]) {
+        let baud = self.rate;
+        let bt = byte_ticks(baud);
+        let break_end = start + break_ticks(baud);
+        let n = frame.len() as u64 - 1; // data bytes (0x00 prefix stays a break)
+        let end = break_end + n * bt;
+
+        let mut c = self.core.borrow_mut();
+        c.claim(Talker::Host, start, end);
+        c.schedule(
+            Event::WireBreak {
+                talker: Talker::Host,
+                baud,
+                break_start: start,
+            },
+            break_end,
+        );
+        for (k, &b) in frame[1..].iter().enumerate() {
+            let t = break_end + (k as u64 + 1) * bt;
+            c.schedule(
+                Event::WireData {
+                    talker: Talker::Host,
+                    byte: b,
+                    baud,
+                },
+                t,
+            );
+        }
+        c.schedule(Event::HostFrameEnd, end);
+        drop(c);
+        self.host_free_at = end;
+    }
+
+    fn dispatch(&mut self, ev: Event) {
+        match ev {
+            Event::WireBreak {
+                talker,
+                baud,
+                break_start,
+            } => self.deliver_break(talker, baud, break_start),
+            Event::WireData { talker, byte, baud } => self.deliver_data(talker, byte, baud),
+            Event::WireGarble { byte } => self.deliver_garble(byte),
+            Event::StrayBreak { baud } => self.deliver_stray_break(baud),
+            Event::RescueDeclare => self.deliver_rescue_declare(),
+            Event::SkewChange { servo, ppm } => {
+                let now = self.core.borrow().now();
+                self.handles[servo].deadline.set_skew(now, ppm);
+            }
+            Event::HostFrameEnd => self.core.borrow_mut().finalize_frame(),
+            Event::Compare { servo, generation } => {
+                // The generation gate is checked at the match instant only: a
+                // deadline re-aimed before its match never fires, but once
+                // matched the pend survives any re-aim (PFIC semantics) and
+                // the handler sorts out staleness itself.
+                if self.handles[servo].deadline.generation() == generation {
+                    self.deliver(servo, Vector::Compare);
+                }
+            }
+            Event::TxArmDone { servo } => self.deliver(servo, Vector::TxDone),
+            Event::CpuFree { servo } => self.cpu_free(servo),
+            Event::WakeRefire { servo } => self.deliver(servo, Vector::Break),
+        }
+    }
+
+    /// Run `v`'s handler on servo `j` now, or pend it if a body is running.
+    fn deliver(&mut self, j: usize, v: Vector) {
+        let now = self.core.borrow().now();
+        if self.cpus[j].busy(now) {
+            self.cpus[j].pend(v);
+            self.schedule_free(j);
+        } else {
+            self.run_vector(j, v);
+        }
+    }
+
+    fn run_vector(&mut self, j: usize, v: Vector) {
+        let now = self.core.borrow().now();
+        self.cpus[j].charge(now, v);
+        match v {
+            Vector::Compare => self.servos[j].on_deadline(),
+            Vector::Break => self.servos[j].on_break(),
+            Vector::TxDone => self.servos[j].on_tx_complete(),
+        }
+    }
+
+    fn schedule_free(&mut self, j: usize) {
+        if !self.cpus[j].free_scheduled {
+            self.cpus[j].free_scheduled = true;
+            let at = self.cpus[j].busy_until();
+            self.core
+                .borrow_mut()
+                .schedule(Event::CpuFree { servo: j }, at);
+        }
+    }
+
+    /// A handler body ended: deliver ONE pended vector (highest arbitration
+    /// first), then re-arm for the rest -- each delivery is its own event so
+    /// every handler reads the clock at its true entry tick.
+    fn cpu_free(&mut self, j: usize) {
+        self.cpus[j].free_scheduled = false;
+        let now = self.core.borrow().now();
+        if self.cpus[j].busy(now) {
+            // A same-tick wire event beat this wake and re-occupied the CPU.
+            if self.cpus[j].any_pend() {
+                self.schedule_free(j);
+            }
+            return;
+        }
+        if let Some(v) = self.cpus[j].take_pend() {
+            self.run_vector(j, v);
+            if self.cpus[j].any_pend() {
+                self.schedule_free(j);
+            }
+        }
+    }
+
+    fn deliver_break(&mut self, talker: Talker, baud: BaudRate, break_start: u64) {
+        self.core.borrow_mut().begin_frame(break_start, talker);
+        for j in 0..self.servos.len() {
+            if talker == Talker::Servo(j) {
+                continue; // no own-TX echo (F9)
+            }
+            self.deliver_break_to(j, baud);
+        }
+    }
+
+    /// Length-qualified break delivery (sec 3.4): the 10-bit span covers >=10 of
+    /// the receiver's bit-times only at receivers at or above the talker's
+    /// rate -- those decode the all-zeros character and wake. A slower
+    /// receiver hears a sub-character low: compressed junk, no wake.
+    fn deliver_break_to(&mut self, j: usize, baud: BaudRate) {
+        if self.handles[j].baud.current().as_hz() >= baud.as_hz() {
+            self.handles[j].ring.push(0x00);
+            self.deliver(j, Vector::Break);
+        } else {
+            self.handles[j].ring.push(MISMATCH_GARBLE);
+        }
+    }
+
+    fn deliver_data(&mut self, talker: Talker, byte: u8, baud: BaudRate) {
+        let now = self.core.borrow().now();
+        self.core.borrow_mut().append_byte(byte, now);
+        for j in 0..self.servos.len() {
+            if talker == Talker::Servo(j) {
+                continue;
+            }
+            let matched = self.handles[j].baud.current() == baud;
+            if matched {
+                self.handles[j].ring.push(byte);
+            } else {
+                // A baud mismatch garbles both value and framing (sec 2
+                // approximation): the sampled bits are wrong-rate noise, so
+                // the ringed byte must not survive as valid data at either a
+                // faster or slower receiver. No wake (sec 3.4): a data byte's
+                // dominant runs stay under the detector's 10-bit bar in this
+                // model (silicon: rare slower-baud bytes do qualify -- leg D
+                // of the lbd_wake spike -- but the wake-into-junk exposure is
+                // already carried by the slower talker's breaks).
+                self.handles[j].ring.push(byte ^ MISMATCH_GARBLE);
+            }
+        }
+    }
+
+    fn deliver_garble(&mut self, byte: u8) {
+        for j in 0..self.servos.len() {
+            self.handles[j].ring.push(byte);
+        }
+    }
+
+    fn deliver_stray_break(&mut self, baud: BaudRate) {
+        for j in 0..self.servos.len() {
+            self.deliver_break_to(j, baud);
+        }
+    }
+
+    fn deliver_rescue_declare(&mut self) {
+        // Every servo's sampler crosses the threshold together (the low is
+        // baud-agnostic); the declaration is thread-level -- no vector, no
+        // CPU pend, mirroring the chip's main-loop + critical-section path.
+        // The pulse's own ringed 0x00 lands here (it rang a byte-time in;
+        // the model folds it into the declaration instant).
+        for j in 0..self.servos.len() {
+            self.handles[j].ring.push(0x00);
+            self.servos[j].on_rescue();
+        }
+    }
+}

--- a/firmware/lib/integration/src/sim/providers.rs
+++ b/firmware/lib/integration/src/sim/providers.rs
@@ -1,0 +1,363 @@
+//! The six `osc_drivers::traits::bus` providers over per-servo shared state
+//! (`docs/osc-native-protocol.md` sec 4, 10). Each provider is a thin view onto
+//! `Rc`-shared cells the [`super::Sim`] also holds a handle to, so wire
+//! deliveries and the driver see one ring, one clock, one baud.
+
+use std::cell::{Cell, RefCell, UnsafeCell};
+use std::rc::Rc;
+
+use osc_core::BaudRate;
+use osc_drivers::traits::bus::{
+    CrcEngine, Deadline, Providers, RxRing, TxWire, UsartBaud, tick_reached,
+};
+use osc_protocol::crc::osc_crc_continue;
+
+use super::core::{Core, Event, Talker, break_ticks, byte_ticks};
+
+/// Ring length (sec 11): even and larger than the 258 B max frame, matching V006.
+pub const RING_LEN: usize = 512;
+
+// --- shared per-servo state -------------------------------------------------
+
+#[repr(align(2))]
+struct RingBuf([u8; RING_LEN]);
+
+pub struct RingState {
+    buf: UnsafeCell<RingBuf>,
+    cursor: Cell<u16>,
+}
+
+impl RingState {
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self {
+            buf: UnsafeCell::new(RingBuf([0; RING_LEN])),
+            cursor: Cell::new(0),
+        })
+    }
+
+    /// Land one received byte at the cursor and advance it -- the DMA write the
+    /// wire model performs before any `on_break` (the pinned provider contract:
+    /// the ring byte precedes the ISR).
+    pub fn push(&self, b: u8) {
+        let i = self.cursor.get() as usize;
+        // SAFETY: single-threaded harness; the Sim only pushes between driver
+        // calls, never while a `bytes()` slice is live (see `RxRing::bytes`).
+        unsafe { (*self.buf.get()).0[i] = b };
+        self.cursor.set(((i + 1) % RING_LEN) as u16);
+    }
+}
+
+pub struct DeadlineState {
+    /// Bumped on every set/cancel; a `Compare` event fires only if its `generation`
+    /// still matches -- stale (superseded) compares are dropped.
+    generation: Cell<u64>,
+    armed: Cell<Option<u32>>,
+    /// Piecewise-linear skewed clock (sec 9.3): `local = anchor_local +
+    /// (sim - anchor_sim) * (1 + skew)`. Re-anchoring at a skew change keeps
+    /// the local clock continuous -- real oscillators drift, they never step.
+    skew_ppm: Cell<i32>,
+    anchor_sim: Cell<u64>,
+    anchor_local: Cell<u64>,
+}
+
+impl DeadlineState {
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self {
+            generation: Cell::new(0),
+            armed: Cell::new(None),
+            skew_ppm: Cell::new(0),
+            anchor_sim: Cell::new(0),
+            anchor_local: Cell::new(0),
+        })
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation.get()
+    }
+
+    /// The servo's local clock at `sim_now`, unwrapped.
+    fn local_u64(&self, sim_now: u64) -> u64 {
+        let d = (sim_now - self.anchor_sim.get()) as i128;
+        let scaled = d * (1_000_000 + self.skew_ppm.get() as i128) / 1_000_000;
+        self.anchor_local.get() + scaled as u64
+    }
+
+    /// Injected drift: the rate changes at `sim_now`, the reading does not.
+    pub fn set_skew(&self, sim_now: u64, ppm: i32) {
+        self.anchor_local.set(self.local_u64(sim_now));
+        self.anchor_sim.set(sim_now);
+        self.skew_ppm.set(ppm);
+    }
+}
+
+pub struct BaudState {
+    applied: RefCell<Vec<BaudRate>>,
+    current: Cell<BaudRate>,
+}
+
+impl BaudState {
+    pub fn new(initial: BaudRate) -> Rc<Self> {
+        Rc::new(Self {
+            applied: RefCell::new(Vec::new()),
+            current: Cell::new(initial),
+        })
+    }
+
+    /// The servo's live operational baud -- the wire matches reception against
+    /// it and the TX side times bytes from it.
+    pub fn current(&self) -> BaudRate {
+        self.current.get()
+    }
+
+    /// Applied-baud log -- a harness inspection hook for the rescue suite (sec 9.1
+    /// verifies the volatile switch to the 0.5 M rescue rate).
+    #[allow(dead_code)]
+    pub fn applied(&self) -> Vec<BaudRate> {
+        self.applied.borrow().clone()
+    }
+}
+
+/// Handles the Sim keeps to reach into one servo's state during delivery.
+pub struct Handles {
+    pub ring: Rc<RingState>,
+    pub deadline: Rc<DeadlineState>,
+    pub baud: Rc<BaudState>,
+}
+
+// --- providers --------------------------------------------------------------
+
+pub struct SimRing(Rc<RingState>);
+
+impl SimRing {
+    pub fn new(state: Rc<RingState>) -> Self {
+        Self(state)
+    }
+}
+
+impl RxRing for SimRing {
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: test-only aliasing (mirrors mocks::bus::FakeRing); the buffer
+        // is never mutated while a returned slice is live -- the Sim pushes only
+        // between driver calls.
+        let arr: &[u8; RING_LEN] = unsafe { &(*self.0.buf.get()).0 };
+        &arr[..]
+    }
+
+    fn cursor(&self) -> u16 {
+        self.0.cursor.get()
+    }
+}
+
+pub struct SimDeadline {
+    core: Rc<RefCell<Core>>,
+    state: Rc<DeadlineState>,
+    idx: usize,
+}
+
+impl SimDeadline {
+    pub fn new(
+        core: Rc<RefCell<Core>>,
+        state: Rc<DeadlineState>,
+        idx: usize,
+        skew_ppm: i32,
+    ) -> Self {
+        state.skew_ppm.set(skew_ppm);
+        Self { core, state, idx }
+    }
+}
+
+/// Invert the skew to find how much *sim* time a `delta` of skewed ticks spans.
+fn unskew(delta: u64, skew_ppm: i32) -> u64 {
+    if skew_ppm == 0 {
+        return delta;
+    }
+    (delta as i128 * 1_000_000 / (1_000_000 + skew_ppm as i128)) as u64
+}
+
+impl Deadline for SimDeadline {
+    const TICKS_PER_US: u32 = super::core::TICKS_PER_US as u32;
+    const CLOCK_TRIM_STEP_PPM: u32 = 2500;
+
+    fn now(&self) -> u32 {
+        self.state.local_u64(self.core.borrow().now()) as u32
+    }
+
+    fn set(&mut self, at: u32) {
+        let generation = self.state.generation.get() + 1;
+        self.state.generation.set(generation);
+        self.state.armed.set(Some(at));
+
+        let sim_now = self.core.borrow().now();
+        let now_sk = self.state.local_u64(sim_now) as u32;
+        // A past `at` fires immediately -- the chip provider pends reached
+        // deadlines rather than waiting out the u32 wrap (deadline-mux
+        // contract; ISR bodies legitimately overrun pending deadlines).
+        let delta_sk = at.wrapping_sub(now_sk);
+        let delta_sk = if delta_sk > i32::MAX as u32 {
+            0
+        } else {
+            delta_sk as u64
+        };
+        let mut fire = sim_now + unskew(delta_sk, self.state.skew_ppm.get());
+        // Rounding must never land the wake *before* `at` (the driver's `due`
+        // check is a >= test) -- nudge forward until the skewed clock reaches it.
+        let mut guard = 0;
+        while !tick_reached(self.state.local_u64(fire) as u32, at) && guard < 64 {
+            fire += 1;
+            guard += 1;
+        }
+        self.core.borrow_mut().schedule(
+            Event::Compare {
+                servo: self.idx,
+                generation,
+            },
+            fire,
+        );
+    }
+
+    fn cancel(&mut self) {
+        self.state.generation.set(self.state.generation.get() + 1);
+        self.state.armed.set(None);
+    }
+}
+
+/// Software osc-CRC accumulator with an immediate result (sec 3.2, F6 modelled as
+/// instantaneous). Even-length feeds are asserted (F12); the even-*address*
+/// half of F12 is not -- heap-backed test buffers give no absolute-parity
+/// guarantee even where the driver's offsets are correct.
+#[derive(Default)]
+pub struct SimCrc {
+    state: u16,
+    snap: Vec<u8>,
+}
+
+impl SimCrc {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CrcEngine for SimCrc {
+    fn reset(&mut self) {
+        self.state = 0;
+    }
+
+    fn feed(&mut self, span: &[u8]) {
+        assert_eq!(span.len() % 2, 0, "osc-CRC feed must be even-length (F12)");
+        self.state = osc_crc_continue(self.state, span);
+    }
+
+    fn snapshot(&mut self, off: u16, src: &[u8]) -> *const u8 {
+        let off = off as usize;
+        if self.snap.len() < off + src.len() {
+            self.snap.resize(off + src.len(), 0);
+        }
+        self.snap[off..off + src.len()].copy_from_slice(src);
+        // SAFETY-adjacent note: tests never grow the Vec between a snapshot
+        // and its consumption, so the pointer stays stable like the chip's
+        // static buffer.
+        unsafe { self.snap.as_ptr().add(off) }
+    }
+
+    fn result(&mut self) -> Option<u16> {
+        Some(self.state)
+    }
+}
+
+pub struct SimWire {
+    core: Rc<RefCell<Core>>,
+    baud: Rc<BaudState>,
+    idx: usize,
+    /// End tick of the last-scheduled byte -- the next arm streams from here so
+    /// arms sit back-to-back on the wire (sec 4.2 tolerates the re-arm gap).
+    tx_cursor: Cell<u64>,
+}
+
+impl SimWire {
+    pub fn new(core: Rc<RefCell<Core>>, baud: Rc<BaudState>, idx: usize) -> Self {
+        Self {
+            core,
+            baud,
+            idx,
+            tx_cursor: Cell::new(0),
+        }
+    }
+}
+
+impl TxWire for SimWire {
+    fn start_frame(&mut self) {
+        let baud = self.baud.current();
+        let brk = break_ticks(baud);
+        let mut c = self.core.borrow_mut();
+        let start = c.now();
+        let break_end = start + brk;
+        c.claim(Talker::Servo(self.idx), start, break_end);
+        c.schedule(
+            Event::WireBreak {
+                talker: Talker::Servo(self.idx),
+                baud,
+                break_start: start,
+            },
+            break_end,
+        );
+        self.tx_cursor.set(break_end);
+    }
+
+    fn send(&mut self, span: &[u8]) {
+        let baud = self.baud.current();
+        let bt = byte_ticks(baud);
+        let mut c = self.core.borrow_mut();
+        // A late TC delivery (busy CPU) arms the next span after the previous
+        // one drained: on silicon that is an inter-byte gap on the wire
+        // (legal -- nothing times on idle, sec 4.2). Clamp so the DES clock never
+        // rewinds.
+        let start = self.tx_cursor.get().max(c.now());
+        for (k, &b) in span.iter().enumerate() {
+            let t = start + (k as u64 + 1) * bt;
+            c.schedule(
+                Event::WireData {
+                    talker: Talker::Servo(self.idx),
+                    byte: b,
+                    baud,
+                },
+                t,
+            );
+        }
+        let end = start + span.len() as u64 * bt;
+        c.claim(Talker::Servo(self.idx), start, end);
+        c.schedule(Event::TxArmDone { servo: self.idx }, end);
+        self.tx_cursor.set(end);
+    }
+
+    fn release(&mut self) {
+        self.core.borrow_mut().finalize_frame();
+    }
+}
+
+pub struct SimBaud {
+    state: Rc<BaudState>,
+}
+
+impl SimBaud {
+    pub fn new(state: Rc<BaudState>) -> Self {
+        Self { state }
+    }
+}
+
+impl UsartBaud for SimBaud {
+    fn apply(&mut self, baud: BaudRate) {
+        self.state.applied.borrow_mut().push(baud);
+        self.state.current.set(baud);
+    }
+}
+
+/// ZST binding each provider role for the `ServoBus` composite.
+pub struct SimProviders;
+
+impl Providers for SimProviders {
+    type Ring = SimRing;
+    type Deadline = SimDeadline;
+    type Crc = SimCrc;
+    type Tx = SimWire;
+    type Baud = SimBaud;
+}

--- a/firmware/lib/integration/src/sim/servo.rs
+++ b/firmware/lib/integration/src/sim/servo.rs
@@ -1,0 +1,156 @@
+//! A simulated servo: the real `ServoBus` + real `osc_core` dispatch over the
+//! sim providers, boxed for a stable address (the TX zero-copy path holds raw
+//! pointers into the control table while streaming a read reply, sec 4.2).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use osc_core::{BaudRate, BootMode, ConfigDefaults, ControlTable, RegionStorage, Session, Shared};
+use osc_drivers::bus::{LinkDiag, ServoBus};
+
+use super::core::Core;
+use super::providers::{
+    BaudState, DeadlineState, Handles, RingState, SimBaud, SimCrc, SimDeadline, SimProviders,
+    SimRing, SimWire,
+};
+use super::store::RamStore;
+
+/// Default identity a fresh sim servo answers PING with (model + fw).
+pub const DEFAULT_MODEL: u16 = 0x1234;
+pub const DEFAULT_FIRMWARE: u8 = 0x56;
+
+pub struct SimServo {
+    shared: Shared,
+    session: Session,
+    bus: ServoBus<SimProviders>,
+}
+
+impl SimServo {
+    /// Build a servo at `idx`, seed its table, and wire the providers to the
+    /// shared core + returned handles. A `store` mirrors the chip bringup:
+    /// boot overlay after the default seed, and the bus comes up on the
+    /// table's effective comms block (a saved id/baud is what answers).
+    pub fn build(
+        core: &Rc<RefCell<Core>>,
+        idx: usize,
+        id: u8,
+        rate: BaudRate,
+        skew_ppm: i32,
+        response_deadline_us: u16,
+        store: Option<&'static RamStore>,
+    ) -> (Box<SimServo>, Handles) {
+        let ring = RingState::new();
+        let deadline = DeadlineState::new();
+
+        let shared = Shared::new();
+        shared.table.seed_config_defaults(&ConfigDefaults {
+            id,
+            baud: rate,
+            response_deadline_us,
+            ..Default::default()
+        });
+        if let Some(store) = store {
+            store.boot_load(&shared.table);
+            shared.seed_store(store);
+        }
+        // Default UID: the id repeated -- distinct per servo, predictable for
+        // ENUM tests; override via `seed_uid` where prefix structure matters.
+        shared.seed_uid([id; 16]);
+        // model/fw are read-only identity fields, seeded directly (not part of
+        // ConfigDefaults) so PING has something to answer with.
+        shared.table.with_mut(|t| {
+            t.config.identity.model_number = DEFAULT_MODEL;
+            t.config.identity.firmware_version = DEFAULT_FIRMWARE;
+        });
+
+        // The table is the comms authority (registry `Drivers::install` does
+        // the same read on the chip).
+        let (id, rate, response_deadline_us) = shared.table.with(|t| {
+            (
+                t.config.comms.id,
+                t.config.comms.baud_rate_idx,
+                t.config.comms.response_deadline_us,
+            )
+        });
+        let baud = BaudState::new(rate);
+
+        let bus = ServoBus::new(
+            SimRing::new(ring.clone()),
+            SimDeadline::new(core.clone(), deadline.clone(), idx, skew_ppm),
+            SimCrc::new(),
+            SimWire::new(core.clone(), baud.clone(), idx),
+            SimBaud::new(baud.clone()),
+            id,
+            rate,
+            response_deadline_us,
+        );
+
+        let servo = Box::new(SimServo {
+            shared,
+            session: Session::new(),
+            bus,
+        });
+        let handles = Handles {
+            ring,
+            deadline,
+            baud,
+        };
+        (servo, handles)
+    }
+
+    /// sec 9.1: the chip main-loop sampler's declaration (thread-level, not a
+    /// vector -- the sim delivers it directly at the modeled threshold tick).
+    pub fn on_rescue(&mut self) {
+        self.bus.on_rescue_break();
+    }
+
+    pub fn on_break(&mut self) {
+        // Position from the stream: the break handler resolves complete frames
+        // from ring data in place, so it dispatches -- build the dispatcher
+        // like on_deadline.
+        let mut dispatcher = self.session.dispatcher(&self.shared);
+        self.bus.on_break(&mut dispatcher);
+    }
+
+    pub fn on_deadline(&mut self) {
+        let mut dispatcher = self.session.dispatcher(&self.shared);
+        self.bus.on_deadline(&mut dispatcher);
+    }
+
+    pub fn on_tx_complete(&mut self) {
+        self.bus.on_tx_complete();
+    }
+
+    pub fn take_reboot(&mut self) -> Option<BootMode> {
+        self.bus.take_reboot()
+    }
+
+    /// Replace the ESIG-stand-in UID (pre-traffic, like the chip's bringup).
+    pub fn seed_uid(&self, uid: [u8; 16]) {
+        self.shared.seed_uid(uid);
+    }
+
+    pub fn uid(&self) -> [u8; 16] {
+        *self.shared.uid()
+    }
+
+    pub fn diag(&self) -> LinkDiag {
+        self.bus.diag()
+    }
+
+    /// The chip main loop's trim poll (sec 9.3) -- tests model the loop by
+    /// calling it between exchanges.
+    pub fn poll_clock_trim(&mut self) -> Option<i8> {
+        self.bus.poll_clock_trim()
+    }
+
+    pub fn with_table<R>(&self, f: impl FnOnce(&ControlTable) -> R) -> R {
+        self.shared.table.with(f)
+    }
+
+    /// Chip-side table mutation (e.g. a fault ISR raising `fault_flags`) --
+    /// state the wire cannot set on a read-only field.
+    pub fn with_table_mut<R>(&self, f: impl FnOnce(&mut ControlTable) -> R) -> R {
+        self.shared.table.with_mut(f)
+    }
+}

--- a/firmware/lib/integration/src/sim/store.rs
+++ b/firmware/lib/integration/src/sim/store.rs
@@ -1,0 +1,109 @@
+//! RAM-backed [`ConfigStore`] fake: two page-sized slots holding real images
+//! through the core codec, so a rebuilt servo's boot overlay exercises the
+//! same parse/pick path the chip takes. `Shared::seed_store` wants
+//! `&'static`, so tests obtain instances via [`RamStore::leak`]; the interior
+//! `Mutex` keeps the same reference inspectable (and shareable across a
+//! rebuilt `Sim`, modeling a reboot with flash intact).
+
+use std::sync::Mutex;
+
+use osc_core::persist::{self, CONFIG_LEN, IMAGE_LEN, PROFILE_LEN, Slot, StoreError};
+use osc_core::{ConfigStore, ControlTableCell};
+
+const ERASED: [u8; IMAGE_LEN] = [0xFF; IMAGE_LEN];
+
+fn idx(slot: Slot) -> usize {
+    match slot {
+        Slot::A => 0,
+        Slot::B => 1,
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    slots: [Option<[u8; IMAGE_LEN]>; 2],
+    next_slot: usize,
+    next_seq: u16,
+    fail: bool,
+    saves: usize,
+    wipes: usize,
+}
+
+pub struct RamStore {
+    inner: Mutex<Inner>,
+}
+
+impl RamStore {
+    pub fn leak() -> &'static RamStore {
+        Box::leak(Box::new(RamStore {
+            inner: Mutex::new(Inner {
+                next_seq: 1,
+                ..Inner::default()
+            }),
+        }))
+    }
+
+    /// Boot-time load, mirroring the chip provider: overlay the newest valid
+    /// image and prime the A/B state. Called by `SimServo::build` before the
+    /// bus reads the table's comms block.
+    pub fn boot_load(&self, table: &ControlTableCell) {
+        let mut g = self.inner.lock().unwrap();
+        let a = g.slots[0].unwrap_or(ERASED);
+        let b = g.slots[1].unwrap_or(ERASED);
+        let pick = persist::boot_overlay(table, &a, &b);
+        g.next_slot = idx(pick.next_slot);
+        g.next_seq = pick.next_seq;
+    }
+
+    /// Arm every subsequent save/wipe to fail (the chip's readback-verify
+    /// miss).
+    pub fn set_fail(&self, fail: bool) {
+        self.inner.lock().unwrap().fail = fail;
+    }
+
+    pub fn saves(&self) -> usize {
+        self.inner.lock().unwrap().saves
+    }
+
+    pub fn wipes(&self) -> usize {
+        self.inner.lock().unwrap().wipes
+    }
+
+    /// The slot's stored image, if any (a copy -- tests parse it at leisure).
+    pub fn slot(&self, slot: Slot) -> Option<[u8; IMAGE_LEN]> {
+        self.inner.lock().unwrap().slots[idx(slot)]
+    }
+}
+
+impl ConfigStore for RamStore {
+    fn save(
+        &self,
+        config: &[u8; CONFIG_LEN],
+        profile: &[u8; PROFILE_LEN],
+    ) -> Result<(), StoreError> {
+        let mut g = self.inner.lock().unwrap();
+        if g.fail {
+            return Err(StoreError);
+        }
+        let mut img = [0u8; IMAGE_LEN];
+        persist::assemble(&mut img, g.next_seq, config, profile);
+        let slot = g.next_slot;
+        g.slots[slot] = Some(img);
+        g.next_slot ^= 1;
+        g.next_seq = g.next_seq.wrapping_add(1);
+        g.saves += 1;
+        Ok(())
+    }
+
+    fn wipe(&self) -> Result<(), StoreError> {
+        let mut g = self.inner.lock().unwrap();
+        if g.fail {
+            return Err(StoreError);
+        }
+        g.slots = [None, None];
+        g.next_slot = 0;
+        g.next_seq = 1;
+        g.wipes += 1;
+        Ok(())
+    }
+}

--- a/firmware/lib/integration/src/sim/support.rs
+++ b/firmware/lib/integration/src/sim/support.rs
@@ -1,0 +1,44 @@
+//! Test-support builders and checkers over the wire images the sim records
+//! (`docs/osc-native-protocol.md` sec 3). Tests read these to assert on decoded
+//! shape, not raw bytes.
+
+use osc_protocol::crc::osc_crc;
+use osc_protocol::frame::Header;
+use osc_protocol::reply::FrameBuf;
+use osc_protocol::wire::{self, Id, Inst, Opcode};
+
+use super::WireFrame;
+
+/// Build and seal a host instruction frame: `FrameBuf::seal` output, leading
+/// 0x00 CRC prefix included (the wire replays it as the break byte).
+pub fn instruction(id: u8, op: Opcode, flags: u8, payload: &[u8]) -> Vec<u8> {
+    let mut b = FrameBuf::<264>::new();
+    b.start(Id::new(id), Inst::instruction(op, flags));
+    b.payload_mut()[..payload.len()].copy_from_slice(payload);
+    b.finish(payload.len() as u8);
+    b.seal().to_vec()
+}
+
+/// Assert a recorded frame is well-formed: LEN covers INST + CRC (sec 3.1) and
+/// the trailing CRC matches osc-CRC over the covered span (sec 3.2 -- the leading
+/// break byte is a no-op).
+pub fn assert_valid(frame: &WireFrame) {
+    let b = &frame.bytes;
+    assert!(b.len() >= 6, "frame too short: {b:02X?}");
+    let len = b[2];
+    assert!(len >= 3, "LEN must cover INST + CRC: {b:02X?}");
+    let covered = wire::covered_len(len);
+    assert!(b.len() >= covered + 2, "frame truncated: {b:02X?}");
+    let want = osc_crc(&b[..covered]);
+    let got = u16::from_le_bytes([b[covered], b[covered + 1]]);
+    assert_eq!(want, got, "CRC mismatch on {b:02X?}");
+}
+
+/// Decode a status frame into its `INST` byte and payload slice.
+pub fn status(frame: &WireFrame) -> (Inst, &[u8]) {
+    let b = &frame.bytes;
+    let head: &[u8; 4] = b[..4].try_into().expect("frame has a 4-byte header");
+    let h = Header::from_bytes(head);
+    let p = h.payload_len() as usize;
+    (h.inst, &b[Header::SIZE..Header::SIZE + p])
+}

--- a/firmware/lib/integration/src/sim/tests.rs
+++ b/firmware/lib/integration/src/sim/tests.rs
@@ -1,0 +1,126 @@
+//! End-to-end smoke: prove the whole loop (host frame -> wire -> real framer ->
+//! real dispatch -> real TX engine -> recorded reply) before the test-suite
+//! chunks build on this facade.
+
+use osc_core::BaudRate;
+use osc_protocol::wire::{Opcode, ResultCode};
+
+use super::servo::{DEFAULT_FIRMWARE, DEFAULT_MODEL};
+use super::{HandlerCost, Sim, core::TICKS_PER_US};
+use super::{Source, assert_valid, instruction, status};
+
+const SERVO_ID: u8 = 5;
+
+#[test]
+fn ping_round_trip() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.add_servo(SERVO_ID);
+
+    sim.host_send(&instruction(SERVO_ID, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    assert_eq!(frames.len(), 2, "host PING + servo reply: {frames:#?}");
+    let inst = frames
+        .iter()
+        .find(|f| f.from == Source::Host)
+        .expect("host frame");
+    let reply = frames
+        .iter()
+        .find(|f| matches!(f.from, Source::Servo(_)))
+        .expect("servo reply");
+
+    // A well-formed status from id 5 carrying model(2) + fw(1), p=3 (no pad).
+    assert_eq!(reply.from, Source::Servo(SERVO_ID));
+    assert_valid(reply);
+    let (rinst, payload) = status(reply);
+    assert!(rinst.is_status());
+    assert_eq!(rinst.result(), Some(ResultCode::Ok));
+    let m = DEFAULT_MODEL.to_le_bytes();
+    assert_eq!(payload, &[m[0], m[1], DEFAULT_FIRMWARE]);
+
+    // Reply lead: >= reply gap (fixed us, sec 7) and < 200 us after the instruction.
+    let lead = reply.at - inst.end;
+    assert!(
+        lead >= osc_drivers::bus::REPLY_GAP_US as u64 * TICKS_PER_US,
+        "reply must lead by >= reply gap, got {lead} ticks"
+    );
+    assert!(
+        lead < 200 * TICKS_PER_US,
+        "reply must land within 200 us, got {lead} ticks"
+    );
+}
+
+/// A costly `on_break` body defers the framer deadlines past the whole frame:
+/// every byte is already ringed (DMA is CPU-independent) when the pended wake
+/// finally lands, so the exchange completes correctly -- just late. Occupancy
+/// stretches reply latency; it must never lose an isolated frame.
+#[test]
+fn handler_cost_defers_delivery_without_loss() {
+    const BUSY_US: u64 = 150;
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(SERVO_ID);
+    sim.set_handler_cost(
+        s,
+        HandlerCost {
+            on_break_us: BUSY_US as u32,
+            ..Default::default()
+        },
+    );
+
+    sim.host_send(&instruction(SERVO_ID, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    assert_eq!(frames.len(), 2, "host PING + late servo reply: {frames:#?}");
+    let inst = frames
+        .iter()
+        .find(|f| f.from == Source::Host)
+        .expect("host frame");
+    let reply = frames
+        .iter()
+        .find(|f| matches!(f.from, Source::Servo(_)))
+        .expect("servo reply");
+    assert_valid(reply);
+    let (rinst, _) = status(reply);
+    assert_eq!(rinst.result(), Some(ResultCode::Ok));
+
+    // The header deadline pended behind the 150 us on_break body, so the
+    // reply cannot lead by less than the body's tail past the break.
+    let lead = reply.at - inst.end;
+    assert!(
+        lead > (BUSY_US - 60) * TICKS_PER_US,
+        "reply should be deferred by the busy body, lead {lead} ticks"
+    );
+
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 0);
+    assert_eq!(d.framing_drop_count, 0);
+}
+
+/// Break wakes landing while a body runs pend as ONE flag, not a queue:
+/// three wire breaks against a 500 us body deliver exactly two `on_break`
+/// invocations (the live one, then one coalesced pend) -- the silicon
+/// behavior behind the zero-gap frame loss, unchanged by the LBD wake
+/// (the flag is still one bit).
+#[test]
+fn pended_breaks_coalesce_like_pfic() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(SERVO_ID);
+    sim.set_handler_cost(
+        s,
+        HandlerCost {
+            on_break_us: 500,
+            ..Default::default()
+        },
+    );
+
+    sim.inject_break_at(1_000);
+    sim.inject_break_at(1_100);
+    sim.inject_break_at(1_200);
+    sim.run();
+
+    assert_eq!(
+        sim.delivered_breaks(s),
+        2,
+        "three wire breaks against a busy body must coalesce to two deliveries"
+    );
+}

--- a/firmware/lib/integration/tests/chains.rs
+++ b/firmware/lib/integration/tests/chains.rs
@@ -1,0 +1,476 @@
+//! Coordinated group reads/writes over the osc-native bus (sec 5, 6). Every case
+//! drives the REAL `ServoBus` + `osc_core` dispatch through the discrete-event
+//! `Sim` and asserts on the decoded shape of the recorded wire frames. Group
+//! payloads are hand-built per sec 5's tables and cross-checked against the
+//! `osc_protocol::group` parsers (the layout authority).
+
+use osc_core::regions::config::addr::identity::{FIRMWARE_VERSION, MODEL_NUMBER};
+use osc_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
+use osc_core::regions::control::addr::streaming::{STREAM_DECIMATION, STREAM_FIELD_MASK};
+use osc_core::regions::profile::span_word;
+use osc_integration::sim::{Source, WireFrame, assert_valid, instruction, status};
+use osc_protocol::wire::{Inst, Opcode, ResultCode};
+use rstest::rstest;
+use rstest_reuse::apply;
+
+mod support;
+use support::{byte_ticks, matrix, sim};
+
+/// The default RESPONSE_DEADLINE (60 us) works at every baud: sec 6 keys reclaim
+/// off the predecessor's *break* (its trigger -> break lead), and an observed
+/// break suspends the window while the frame plays out. The baud sweep is the
+/// regression for that -- at 1 M a short reply spends ~84 us on the wire, so
+/// frame-end-keyed reclaim (the original defect) would falsely reclaim every
+/// present-but-slow predecessor.
+const CHAIN_DEADLINE_US: u16 = 60;
+
+/// Broadcast frame ID for group ops (sec 5: the id-list, not the frame ID, selects
+/// responders).
+const BCAST: u8 = 0xFE;
+
+// --- group payload builders (sec 5 tables, verified against osc_protocol::group) -
+
+fn gread_uniform(addr: u16, count: u16, ids: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&addr.to_le_bytes());
+    p.extend_from_slice(&count.to_le_bytes());
+    p.extend_from_slice(ids);
+    p
+}
+
+fn gread_per_target(entries: &[(u8, u16, u16)]) -> Vec<u8> {
+    let mut p = Vec::new();
+    for &(id, addr, count) in entries {
+        p.push(id);
+        p.extend_from_slice(&addr.to_le_bytes());
+        p.extend_from_slice(&count.to_le_bytes());
+    }
+    p
+}
+
+fn gwrite_uniform(addr: u16, count: u8, entries: &[(u8, &[u8])]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&addr.to_le_bytes());
+    p.push(count);
+    for &(id, data) in entries {
+        assert_eq!(data.len(), count as usize, "uniform GWRITE stride");
+        p.push(id);
+        p.extend_from_slice(data);
+    }
+    p
+}
+
+fn gwrite_per_target(entries: &[(u8, u16, &[u8])]) -> Vec<u8> {
+    let mut p = Vec::new();
+    for &(id, addr, data) in entries {
+        p.push(id);
+        p.extend_from_slice(&addr.to_le_bytes());
+        p.push(data.len() as u8);
+        p.extend_from_slice(data);
+    }
+    p
+}
+
+// --- helpers ----------------------------------------------------------------
+
+fn replies(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect()
+}
+
+fn responder(f: &WireFrame) -> u8 {
+    f.bytes[1]
+}
+
+/// Decoded (result, payload) of a status reply, with well-formedness checked.
+fn decoded(f: &WireFrame) -> (ResultCode, Vec<u8>) {
+    assert_valid(f);
+    let (inst, payload) = status(f);
+    assert!(inst.is_status(), "reply is a status frame");
+    (inst.result().expect("valid result code"), payload.to_vec())
+}
+
+// --- reads (sec 6 status chains) -----------------------------------------------
+
+#[apply(matrix)]
+fn gread_uniform_chains_in_list_order(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2, 3] {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+    // Distinct model per servo so each reply's data is traceable to its owner.
+    let models = [0xAA01u16, 0xBB02, 0xCC03];
+    for (i, m) in models.iter().enumerate() {
+        sim.servo_table_mut(i, |t| t.config.identity.model_number = *m);
+    }
+
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        0,
+        &gread_uniform(MODEL_NUMBER, 2, &[1, 2, 3]),
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+
+    assert_eq!(reps.len(), 3, "one status per listed servo: {frames:#?}");
+    // Responder ids in list order.
+    assert_eq!(
+        reps.iter().map(|f| responder(f)).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    for (f, m) in reps.iter().zip(models.iter()) {
+        let (result, payload) = decoded(f);
+        assert_eq!(result, ResultCode::Ok);
+        assert_eq!(payload, m.to_le_bytes(), "each reply carries its own span");
+    }
+    // Every inter-reply gap respects reply gap (sec 6/7).
+    let reply_gap = support::reply_gap_ticks();
+    for w in reps.windows(2) {
+        let gap = w[1].at - w[0].end;
+        assert!(gap >= reply_gap, "chain gap {gap} < reply gap {reply_gap}");
+    }
+}
+
+#[apply(matrix)]
+fn gread_list_order_beats_id_order(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2, 3] {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        0,
+        &gread_uniform(MODEL_NUMBER, 2, &[3, 1, 2]),
+    ));
+    let frames = sim.run();
+    let order: Vec<u8> = replies(&frames).iter().map(|f| responder(f)).collect();
+    assert_eq!(
+        order,
+        vec![3, 1, 2],
+        "replies follow list order, not id order"
+    );
+}
+
+#[apply(matrix)]
+fn gread_profile_uniform_chains_gathered_replies(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2] {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+    // Each servo's slot 0 gathers model(2) + fw(1); distinct values per servo.
+    let models = [0x1122u16, 0x3344];
+    for (i, m) in models.iter().enumerate() {
+        sim.servo_table_mut(i, |t| {
+            t.config.identity.model_number = *m;
+            t.config.identity.firmware_version = 0x50 + i as u8;
+            t.profile.slots.words[0] = span_word(MODEL_NUMBER, 2);
+            t.profile.slots.words[1] = span_word(FIRMWARE_VERSION, 1);
+        });
+    }
+
+    // GREAD + PROFILE uniform: slot byte, then the id-list (sec 5.2).
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        Inst::FLAG_PROFILE,
+        &[0, 1, 2],
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+
+    assert_eq!(reps.len(), 2, "one status per listed servo: {frames:#?}");
+    assert_eq!(
+        reps.iter().map(|f| responder(f)).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    for (i, (f, m)) in reps.iter().zip(models.iter()).enumerate() {
+        let (result, payload) = decoded(f);
+        assert_eq!(result, ResultCode::Ok);
+        let mb = m.to_le_bytes();
+        assert_eq!(payload, &[mb[0], mb[1], 0x50 + i as u8]);
+    }
+}
+
+#[apply(matrix)]
+fn gread_profile_per_target_selects_distinct_slots(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2] {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+    sim.servo_table_mut(0, |t| {
+        t.config.identity.model_number = 0x1122;
+        t.profile.slots.words[0] = span_word(MODEL_NUMBER, 2);
+    });
+    sim.servo_table_mut(1, |t| {
+        t.config.identity.firmware_version = 0x77;
+        // Servo 2 answers from slot 3 -- per-target slot selection.
+        t.profile.slots.words[3 * 8] = span_word(FIRMWARE_VERSION, 1);
+    });
+
+    // [id, slot]x (sec 5.2).
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        Inst::FLAG_PROFILE | Inst::FLAG_PER_TARGET,
+        &[1, 0, 2, 3],
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+
+    assert_eq!(reps.len(), 2, "one status per listed servo: {frames:#?}");
+    let (r1, p1) = decoded(reps[0]);
+    assert_eq!((r1, p1.as_slice()), (ResultCode::Ok, &[0x22, 0x11][..]));
+    let (r2, p2) = decoded(reps[1]);
+    assert_eq!((r2, p2.as_slice()), (ResultCode::Ok, &[0x77][..]));
+}
+
+#[apply(matrix)]
+fn gread_per_target_reads_distinct_spans(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2, 3] {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+    sim.servo_table_mut(0, |t| t.config.identity.model_number = 0x1122);
+    sim.servo_table_mut(1, |t| t.config.identity.firmware_version = 0x5A);
+    sim.servo_table_mut(2, |t| t.config.identity.model_number = 0x3344);
+
+    // Each servo reads its own addr/count.
+    let payload = gread_per_target(&[
+        (1, MODEL_NUMBER, 2),
+        (2, FIRMWARE_VERSION, 1),
+        (3, MODEL_NUMBER, 3),
+    ]);
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        Inst::FLAG_PER_TARGET,
+        &payload,
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+    assert_eq!(reps.len(), 3, "{frames:#?}");
+
+    let by_id = |id: u8| decoded(reps.iter().find(|f| responder(f) == id).unwrap());
+    // Servo 1: 2-byte model.
+    assert_eq!(by_id(1).1, 0x1122u16.to_le_bytes());
+    // Servo 2: 1-byte firmware version.
+    assert_eq!(by_id(2).1, vec![0x5A]);
+    // Servo 3: 3-byte model + firmware (default fw 0x56).
+    assert_eq!(by_id(3).1, vec![0x44, 0x33, 0x56]);
+}
+
+#[apply(matrix)]
+fn missing_servo_reclaims_with_flag(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    // Only 1 and 3 present; 2 is absent from the bus.
+    let s1 = sim.add_servo_with(1, 0, CHAIN_DEADLINE_US);
+    let s3 = sim.add_servo_with(3, 0, CHAIN_DEADLINE_US);
+    sim.servo_table_mut(s1, |t| t.config.identity.model_number = 0x0101);
+    sim.servo_table_mut(s3, |t| t.config.identity.model_number = 0x0303);
+
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        0,
+        &gread_uniform(MODEL_NUMBER, 2, &[1, 2, 3]),
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+    assert_eq!(
+        reps.len(),
+        2,
+        "silent servo 2 produces no frame: {frames:#?}"
+    );
+
+    let r1 = reps.iter().find(|f| responder(f) == 1).unwrap();
+    let r3 = reps.iter().find(|f| responder(f) == 3).unwrap();
+
+    // Servo 3 reclaims slot 2 after servo 2's window lapses: predecessor-silent,
+    // but its own read data is still present.
+    let (res3, data3) = decoded(r3);
+    assert_eq!(res3, ResultCode::PredecessorSilent);
+    assert_eq!(
+        data3,
+        0x0303u16.to_le_bytes(),
+        "reclaimed slot keeps its data"
+    );
+    let (res1, _) = decoded(r1);
+    assert_eq!(res1, ResultCode::Ok);
+
+    // Reclaim window: servo 3 fires no earlier than servo 1's end + reply gap +
+    // RESPONSE_DEADLINE, and reasonably close to it.
+    let bt = byte_ticks(baud_idx);
+    let reclaim = CHAIN_DEADLINE_US as u64 * 48;
+    let floor = r1.end + support::reply_gap_ticks() + reclaim;
+    assert!(r3.at >= floor, "reclaim too early: {} < {}", r3.at, floor);
+    assert!(
+        r3.at <= floor + 8 * bt,
+        "reclaim not close to window: {} vs {}",
+        r3.at,
+        floor
+    );
+}
+
+#[apply(matrix)]
+fn error_status_keeps_chain_alive(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2, 3] {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+    sim.servo_table_mut(2, |t| t.config.identity.model_number = 0x9999);
+
+    // Per-target: servo 2's span is out of bounds -> Range error, empty payload.
+    let payload = gread_per_target(&[(1, MODEL_NUMBER, 2), (2, 0xFFFE, 4), (3, MODEL_NUMBER, 2)]);
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        Inst::FLAG_PER_TARGET,
+        &payload,
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+    assert_eq!(reps.len(), 3, "error keeps the chain alive: {frames:#?}");
+
+    let by_id = |id: u8| decoded(reps.iter().find(|f| responder(f) == id).unwrap());
+    assert_eq!(by_id(1).0, ResultCode::Ok);
+    let (res2, data2) = by_id(2);
+    assert_eq!(res2, ResultCode::Range, "out-of-range span -> error status");
+    assert!(data2.is_empty(), "error status has empty payload");
+    // Slot 2 follows normally -- only silence reclaims (sec 6).
+    let (res3, data3) = by_id(3);
+    assert_eq!(res3, ResultCode::Ok);
+    assert_eq!(data3, 0x9999u16.to_le_bytes());
+}
+
+// --- writes (sec 5) ------------------------------------------------------------
+
+#[apply(matrix)]
+fn gwrite_hold_commit_is_atomic_fleet_update(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2, 3] {
+        sim.add_servo(id);
+    }
+    let vals: [i32; 3] = [0x0011_2233, 0x0044_5566, 0x0077_1020];
+
+    // Uniform GWRITE + HOLD: staged, no reply, live table untouched.
+    let bytes: Vec<[u8; 4]> = vals.iter().map(|v| v.to_le_bytes()).collect();
+    let entries: Vec<(u8, &[u8])> = (1u8..=3)
+        .zip(bytes.iter())
+        .map(|(id, d)| (id, &d[..]))
+        .collect();
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gwrite,
+        Inst::FLAG_HOLD,
+        &gwrite_uniform(GOAL_VELOCITY, 4, &entries),
+    ));
+    let staged = sim.run();
+    assert!(replies(&staged).is_empty(), "GWRITE is silent: {staged:#?}");
+    for i in 0..3 {
+        assert_eq!(
+            sim.servo_table(i, |t| t.control.lifecycle.goal_velocity),
+            0,
+            "HOLD does not touch the live table"
+        );
+    }
+
+    // Broadcast COMMIT: all servos apply atomically, still silent.
+    sim.host_send(&instruction(BCAST, Opcode::Commit, 0, &[]));
+    let committed = sim.run();
+    assert!(
+        replies(&committed).is_empty(),
+        "COMMIT is silent: {committed:#?}"
+    );
+    for (i, v) in vals.iter().enumerate() {
+        assert_eq!(
+            sim.servo_table(i, |t| t.control.lifecycle.goal_velocity),
+            *v,
+            "COMMIT applied servo {i}'s staged value"
+        );
+    }
+}
+
+#[apply(matrix)]
+fn gwrite_per_target_applies_distinct_fields(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in [1u8, 2, 3] {
+        sim.add_servo(id);
+    }
+    let gv: i32 = 0x1234_5678;
+    let mask: u32 = 0xDEAD_BEEF;
+    let deci: u8 = 7;
+
+    let payload = gwrite_per_target(&[
+        (1, GOAL_VELOCITY, &gv.to_le_bytes()),
+        (2, STREAM_FIELD_MASK, &mask.to_le_bytes()),
+        (3, STREAM_DECIMATION, &[deci]),
+    ]);
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gwrite,
+        Inst::FLAG_PER_TARGET,
+        &payload,
+    ));
+    let frames = sim.run();
+    assert!(replies(&frames).is_empty(), "GWRITE is silent: {frames:#?}");
+
+    assert_eq!(
+        sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+        gv
+    );
+    assert_eq!(
+        sim.servo_table(1, |t| t.control.streaming.stream_field_mask),
+        mask
+    );
+    assert_eq!(
+        sim.servo_table(2, |t| t.control.streaming.stream_decimation),
+        deci
+    );
+}
+
+#[apply(matrix)]
+fn back_to_back_instructions_all_land(baud_idx: u8) {
+    // sec 7: no inter-frame gap is required. Each unicast WRITE is acked before the
+    // next is sent (a plain WRITE's ack shares the half-duplex wire, so the host
+    // cannot physically overlap the next frame with the ack); `run` advances the
+    // clock past each ack, so the follow-up frame lands right after with no
+    // inserted idle gap.
+    let mut sim = sim(baud_idx);
+    sim.add_servo(1);
+    let gv: i32 = 0x0AA0_1BB1;
+    let mask: u32 = 0x00C0_FFEE;
+
+    let addr_gv = GOAL_VELOCITY.to_le_bytes();
+    let mut w1 = vec![addr_gv[0], addr_gv[1]];
+    w1.extend_from_slice(&gv.to_le_bytes());
+    sim.host_send(&instruction(1, Opcode::Write, 0, &w1));
+    let f1 = sim.run();
+    let r1 = replies(&f1);
+    assert_eq!(r1.len(), 1, "first write acked: {f1:#?}");
+    let (res1, data1) = decoded(r1[0]);
+    assert_eq!(res1, ResultCode::Ok);
+    assert!(data1.is_empty(), "write ack is empty");
+
+    let addr_mask = STREAM_FIELD_MASK.to_le_bytes();
+    let mut w2 = vec![addr_mask[0], addr_mask[1]];
+    w2.extend_from_slice(&mask.to_le_bytes());
+    sim.host_send(&instruction(1, Opcode::Write, 0, &w2));
+    let f2 = sim.run();
+    let r2 = replies(&f2);
+    assert_eq!(r2.len(), 1, "second write acked: {f2:#?}");
+    assert_eq!(decoded(r2[0]).0, ResultCode::Ok);
+
+    // Both applied, in order.
+    assert_eq!(
+        sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+        gv
+    );
+    assert_eq!(
+        sim.servo_table(0, |t| t.control.streaming.stream_field_mask),
+        mask
+    );
+}

--- a/firmware/lib/integration/tests/hot_loop.rs
+++ b/firmware/lib/integration/tests/hot_loop.rs
@@ -1,0 +1,573 @@
+//! The production hot loop (sec 5.2/sec 6): the host bombards the bus with
+//! back-to-back silent frames -- `[GWRITE(HOLD) x N, COMMIT, GREAD]` repeated
+//! forever -- and the servos must keep up with zero gap between frames: no
+//! drops, no CRC fails, staged state applied atomically at COMMIT, and the
+//! GREAD (sent back-to-back after COMMIT) already reading the new values.
+//!
+//! The sim delivers wire events at exact ticks with zero-cost handlers, so
+//! these tests pin the LOGICAL zero-gap contract (framer re-anchor per break,
+//! staging across frames, commit-before-read ordering). ISR-latency effects
+//! are silicon-only and out of scope here.
+
+use osc_core::BaudRate;
+use osc_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
+use osc_core::regions::control::addr::streaming::STREAM_DECIMATION;
+use osc_integration::sim::{Source, WireFrame, assert_valid, instruction, status};
+use osc_protocol::wire::{Inst, Opcode, ResultCode};
+use rstest::rstest;
+use rstest_reuse::apply;
+
+mod support;
+use support::{matrix, sim};
+
+/// Break-keyed reclaim makes the 60 us default sound at every baud (see chains.rs).
+const CHAIN_DEADLINE_US: u16 = 60;
+const BCAST: u8 = 0xFE;
+const IDS: [u8; 3] = [1, 2, 3];
+
+fn gwrite_uniform(addr: u16, count: u8, entries: &[(u8, &[u8])]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&addr.to_le_bytes());
+    p.push(count);
+    for &(id, data) in entries {
+        assert_eq!(data.len(), count as usize, "uniform GWRITE stride");
+        p.push(id);
+        p.extend_from_slice(data);
+    }
+    p
+}
+
+fn gwrite_per_target(entries: &[(u8, u16, &[u8])]) -> Vec<u8> {
+    let mut p = Vec::new();
+    for &(id, addr, data) in entries {
+        p.push(id);
+        p.extend_from_slice(&addr.to_le_bytes());
+        p.push(data.len() as u8);
+        p.extend_from_slice(data);
+    }
+    p
+}
+
+fn gread_uniform(addr: u16, count: u16, ids: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&addr.to_le_bytes());
+    p.extend_from_slice(&count.to_le_bytes());
+    p.extend_from_slice(ids);
+    p
+}
+
+fn host_frames(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames.iter().filter(|f| f.from == Source::Host).collect()
+}
+
+fn replies(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect()
+}
+
+/// Every queued host frame must start exactly where the previous one ended --
+/// the test is void if the scheduler ever re-introduces pacing gaps.
+fn assert_zero_gap(hosts: &[&WireFrame]) {
+    for w in hosts.windows(2) {
+        assert_eq!(
+            w[1].at, w[0].end,
+            "host frames must be back-to-back: {hosts:#?}"
+        );
+    }
+}
+
+#[apply(matrix)]
+fn hot_loop_cycles_survive_zero_gap(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    for id in IDS {
+        sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
+    }
+
+    for cycle in 0..10u32 {
+        let gv: Vec<i32> = IDS
+            .iter()
+            .map(|&id| (cycle as i32) * 100 + id as i32)
+            .collect();
+        let deci = (cycle % 128) as u8 + 1;
+
+        // GWRITE(HOLD) x 2, COMMIT, GREAD -- one burst, zero gap throughout.
+        let bytes: Vec<[u8; 4]> = gv.iter().map(|v| v.to_le_bytes()).collect();
+        let entries: Vec<(u8, &[u8])> = IDS
+            .iter()
+            .zip(bytes.iter())
+            .map(|(&id, d)| (id, &d[..]))
+            .collect();
+        sim.host_send(&instruction(
+            BCAST,
+            Opcode::Gwrite,
+            Inst::FLAG_HOLD,
+            &gwrite_uniform(GOAL_VELOCITY, 4, &entries),
+        ));
+        let deci_entries: Vec<(u8, u16, &[u8])> = IDS
+            .iter()
+            .map(|&id| (id, STREAM_DECIMATION, std::slice::from_ref(&deci)))
+            .collect();
+        sim.host_send(&instruction(
+            BCAST,
+            Opcode::Gwrite,
+            Inst::FLAG_HOLD | Inst::FLAG_PER_TARGET,
+            &gwrite_per_target(&deci_entries),
+        ));
+        sim.host_send(&instruction(BCAST, Opcode::Commit, 0, &[]));
+        sim.host_send(&instruction(
+            BCAST,
+            Opcode::Gread,
+            0,
+            &gread_uniform(GOAL_VELOCITY, 4, &IDS),
+        ));
+        let frames = sim.run();
+
+        let hosts = host_frames(&frames);
+        assert_eq!(hosts.len(), 4, "cycle {cycle}: 4 host frames");
+        assert_zero_gap(&hosts);
+
+        // Both staged writes applied at COMMIT.
+        for (i, v) in gv.iter().enumerate() {
+            assert_eq!(
+                sim.servo_table(i, |t| t.control.lifecycle.goal_velocity),
+                *v,
+                "cycle {cycle}: servo {i} goal_velocity committed"
+            );
+            assert_eq!(
+                sim.servo_table(i, |t| t.control.streaming.stream_decimation),
+                deci,
+                "cycle {cycle}: servo {i} stream_decimation committed"
+            );
+        }
+
+        // GREAD chained replies in id-list order, already carrying the values
+        // committed one frame earlier on the wire.
+        let r = replies(&frames);
+        assert_eq!(r.len(), IDS.len(), "cycle {cycle}: {frames:#?}");
+        for (k, (&id, v)) in IDS.iter().zip(gv.iter()).enumerate() {
+            assert_eq!(r[k].from, Source::Servo(id), "cycle {cycle} slot {k}");
+            assert_valid(r[k]);
+            let (inst, payload) = status(r[k]);
+            assert_eq!(inst.result(), Some(ResultCode::Ok));
+            assert_eq!(payload, v.to_le_bytes(), "cycle {cycle} slot {k} data");
+        }
+
+        for i in 0..IDS.len() {
+            let d = sim.servo_diag(i);
+            assert_eq!(d.crc_fail_count, 0, "cycle {cycle}: servo {i} crc");
+            assert_eq!(d.framing_drop_count, 0, "cycle {cycle}: servo {i} drops");
+        }
+    }
+}
+
+#[apply(matrix)]
+fn noreply_write_bombardment_then_read(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo_with(IDS[0], 0, CHAIN_DEADLINE_US);
+
+    // 20 back-to-back silent writes to the same field; only the last survives.
+    let a = GOAL_VELOCITY.to_le_bytes();
+    let mut last: i32 = 0;
+    for k in 1..=20i32 {
+        last = k * 7;
+        let v = last.to_le_bytes();
+        sim.host_send(&instruction(
+            IDS[0],
+            Opcode::Write,
+            Inst::FLAG_NOREPLY,
+            &[a[0], a[1], v[0], v[1], v[2], v[3]],
+        ));
+    }
+    // ... then a plain READ, still zero gap after the burst.
+    sim.host_send(&instruction(IDS[0], Opcode::Read, 0, &[a[0], a[1], 4, 0]));
+    let frames = sim.run();
+
+    let hosts = host_frames(&frames);
+    assert_eq!(hosts.len(), 21, "20 writes + 1 read");
+    assert_zero_gap(&hosts);
+
+    let r = replies(&frames);
+    assert_eq!(r.len(), 1, "writes are silent, only the read replies");
+    assert_valid(r[0]);
+    let (inst, payload) = status(r[0]);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(payload, last.to_le_bytes());
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        last
+    );
+
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 0);
+    assert_eq!(d.framing_drop_count, 0);
+}
+
+/// THE zero-gap repro (transport sec 5, position and time from the stream):
+/// the same hot loop under silicon-realistic handler latency. Dispatch runs
+/// inside the deadline body on this architecture, so a GWRITE-class body
+/// (~70 us measured) makes following breaks pend and coalesce; a base that
+/// anchors on ISR-entry cursor snapshots then silently discards intact frames
+/// (staleness, not latency). The stream-derived design (`last_break_tick` +
+/// stream-continuity resolution) must keep this green across the baud sweep.
+#[apply(matrix)]
+fn hot_loop_survives_handler_latency(baud_idx: u8) {
+    use osc_integration::sim::HandlerCost;
+
+    let mut sim = sim(baud_idx);
+    // RESPONSE_DEADLINE must exceed worst-case dispatch+staging latency or a
+    // chain slot reclaims into a live-but-slow predecessor (band finding,
+    // transport sec 9 acceptance): with 70 us handler bodies the 60 us default
+    // is dishonest -- a real deployment tunes this register to its worst case.
+    for id in IDS {
+        sim.add_servo_with(id, 0, 250);
+    }
+    for i in 0..IDS.len() {
+        sim.set_handler_cost(
+            i,
+            HandlerCost {
+                on_break_us: 2,
+                on_deadline_us: 70,
+                on_tx_complete_us: 2,
+            },
+        );
+    }
+
+    for cycle in 0..10u32 {
+        let gv: Vec<i32> = IDS
+            .iter()
+            .map(|&id| (cycle as i32) * 100 + id as i32)
+            .collect();
+        let bytes: Vec<[u8; 4]> = gv.iter().map(|v| v.to_le_bytes()).collect();
+        let entries: Vec<(u8, &[u8])> = IDS
+            .iter()
+            .zip(bytes.iter())
+            .map(|(&id, d)| (id, &d[..]))
+            .collect();
+        sim.host_send(&instruction(
+            BCAST,
+            Opcode::Gwrite,
+            Inst::FLAG_HOLD,
+            &gwrite_uniform(GOAL_VELOCITY, 4, &entries),
+        ));
+        sim.host_send(&instruction(BCAST, Opcode::Commit, 0, &[]));
+        sim.host_send(&instruction(
+            BCAST,
+            Opcode::Gread,
+            0,
+            &gread_uniform(GOAL_VELOCITY, 4, &IDS),
+        ));
+        let frames = sim.run();
+        assert_zero_gap(&host_frames(&frames));
+
+        for (i, v) in gv.iter().enumerate() {
+            assert_eq!(
+                sim.servo_table(i, |t| t.control.lifecycle.goal_velocity),
+                *v,
+                "cycle {cycle}: servo {i} lost a GWRITE or COMMIT under latency"
+            );
+        }
+        let r = replies(&frames);
+        assert_eq!(
+            r.len(),
+            IDS.len(),
+            "cycle {cycle}: chain incomplete under latency"
+        );
+    }
+}
+
+/// Silicon-captured trap (event-trace): when a frame's own break
+/// FE delivery lags past its covered checkpoint (pended behind a long
+/// deadline body), the resolver reaches Covered INSIDE that on_break wake and
+/// stages the reply -- and the FE-kill in the same wake must not murder it.
+/// The reply belongs to the frontier frame still arriving, not to a frame the
+/// host abandoned; killing it leaves a stale pending frame that later arms the
+/// chain over an empty engine (ghost trigger, silent no-reply).
+#[apply(matrix)]
+fn plain_burst_survives_deadline_latency(baud_idx: u8) {
+    use osc_integration::sim::HandlerCost;
+
+    // Sweep the body cost so some delivery lands inside the covered window
+    // ([frame end - 2 byte-times, frame end)) regardless of rate -- the trap
+    // is a ~2-byte-time bullseye, not a single magic latency.
+    for dl in (10u32..100).step_by(2) {
+        let mut sim = sim(baud_idx);
+        sim.add_servo_with(1, 0, 250);
+        sim.set_handler_cost(
+            0,
+            HandlerCost {
+                on_break_us: 2,
+                on_deadline_us: dl,
+                on_tx_complete_us: 2,
+            },
+        );
+
+        for cycle in 0..5u32 {
+            let v = cycle as i32 + 1;
+            let d = v.to_le_bytes();
+            let a = GOAL_VELOCITY.to_le_bytes();
+            let mut p = vec![a[0], a[1]];
+            p.extend_from_slice(&d);
+            sim.host_send(&instruction(1, Opcode::Write, Inst::FLAG_NOREPLY, &p));
+            sim.host_send(&instruction(1, Opcode::Write, Inst::FLAG_NOREPLY, &p));
+            sim.host_send(&instruction(1, Opcode::Read, 0, &[a[0], a[1], 4, 0]));
+            let frames = sim.run();
+            assert_zero_gap(&host_frames(&frames));
+            assert_eq!(
+                sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+                v,
+                "dl={dl} cycle {cycle}: write lost under deadline latency"
+            );
+            let r = replies(&frames);
+            assert_eq!(
+                r.len(),
+                1,
+                "dl={dl} cycle {cycle}: READ reply lost (staged reply killed in its own wake?)"
+            );
+            assert_valid(r[0]);
+            let (inst, payload) = status(r[0]);
+            assert_eq!(inst.result(), Some(ResultCode::Ok), "dl={dl} cycle {cycle}");
+            assert_eq!(payload, d, "dl={dl} cycle {cycle}: stale read-back");
+        }
+        // A clean zero-gap wire gives the framer no excuse: every give-up
+        // here is a live frame sacrificed by starvation accounting.
+        let diag = sim.servo_diag(0);
+        assert_eq!(
+            diag.framing_drop_count, 0,
+            "dl={dl}: live frames sacrificed"
+        );
+        assert_eq!(diag.crc_fail_count, 0, "dl={dl}: trusted frame failed");
+    }
+}
+
+/// The bench's plain burst (`tool-burst --plain`: 8 NOREPLY WRITEs +
+/// READ, host waits out the reply between cycles) with IRREGULAR intra-burst
+/// gaps: the pirate's TXE-poll bubbles put 0-3-byte-time pauses between
+/// frames, so each write resolves sometimes as a caught-up frontier
+/// (dispatched at its covered checkpoint) and sometimes as a backlog frame
+/// (dispatched complete) mid-burst -- every seam of the inline dispatch path.
+/// Silicon showed ~0.3% no-reply/stale residuals at 1M in exactly this
+/// pattern; a drop here is that residual, deterministic.
+#[apply(matrix)]
+fn plain_burst_survives_gap_jitter(baud_idx: u8) {
+    use osc_integration::sim::HandlerCost;
+
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let a = GOAL_VELOCITY.to_le_bytes();
+    for dl in [5u32, 20, 45, 70] {
+        // Deterministic LCG per cost point; gaps vary per frame AND drift
+        // per cycle so cycle boundaries never resonate with the sweep.
+        let mut lcg: u64 = 0x243F6A8885A308D3 ^ (dl as u64);
+        let mut gap = move || {
+            lcg = lcg
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            // 0..=30 us: from zero-gap up to ~3 byte-times at 1M.
+            (lcg >> 33) % 31
+        };
+
+        let mut sim = sim(baud_idx);
+        sim.add_servo_with(1, 0, 250);
+        sim.set_handler_cost(
+            0,
+            HandlerCost {
+                on_break_us: 2,
+                on_deadline_us: dl,
+                on_tx_complete_us: 2,
+            },
+        );
+
+        for cycle in 0..60u32 {
+            let v = cycle as i32 + 1;
+            let d = v.to_le_bytes();
+            let mut at = sim.now_us() + 20;
+            for k in 0..8u32 {
+                let vk = v - (7 - k as i32);
+                let dk = vk.to_le_bytes();
+                let p = vec![a[0], a[1], dk[0], dk[1], dk[2], dk[3]];
+                sim.host_send_at(at, &instruction(1, Opcode::Write, Inst::FLAG_NOREPLY, &p));
+                // Next frame starts after this one plus the jittered bubble.
+                at += frame_us(rate, 10) + gap();
+            }
+            sim.host_send_at(at, &instruction(1, Opcode::Read, 0, &[a[0], a[1], 4, 0]));
+            let frames = sim.run();
+
+            assert_eq!(
+                sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+                v,
+                "dl={dl} cycle {cycle}: write lost"
+            );
+            let r = replies(&frames);
+            assert_eq!(r.len(), 1, "dl={dl} cycle {cycle}: READ reply lost");
+            assert_valid(r[0]);
+            let (inst, payload) = status(r[0]);
+            assert_eq!(inst.result(), Some(ResultCode::Ok), "dl={dl} cycle {cycle}");
+            assert_eq!(payload, d, "dl={dl} cycle {cycle}: stale read-back");
+        }
+        let diag = sim.servo_diag(0);
+        assert_eq!(diag.framing_drop_count, 0, "dl={dl}: live frames dropped");
+        assert_eq!(diag.crc_fail_count, 0, "dl={dl}: trusted frame failed");
+    }
+}
+
+/// Wire time of one frame (break + `n` data bytes) in us at `rate`, rounded
+/// up -- the jitter scheduler only needs a "no overlap" floor, not accuracy.
+fn frame_us(rate: BaudRate, n: u64) -> u64 {
+    let bits = 14 + n * 10;
+    (bits * 1_000_000).div_ceil(rate.as_hz() as u64)
+}
+
+/// The failing silicon signature (bench, `tool-reply-edges` STALE dump): the
+/// pirate's TXE feed stalls 50-100 bit-times INSIDE a frame -- mid-write4 and
+/// mid-READ on the captured cycle -- so the frontier burns its recheck budget
+/// and parks at the starvation horizon while the frame quietly completes (ring
+/// bytes raise no IRQ). The reply then rode a ~2x640 us-late wake carrying a
+/// value one write behind. Sweep the stall length and position across every
+/// frame of the burst, capped below the dead-transmitter horizon (64
+/// byte-times, sec 3.3): a stall past it IS a dead transmitter and the frame
+/// is sacrificed by design.
+#[apply(matrix)]
+fn plain_burst_survives_midframe_stall(baud_idx: u8) {
+    use osc_integration::sim::HandlerCost;
+
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let horizon_us = 64 * 10 * 1_000_000u64 / rate.as_hz() as u64;
+    let stalls: Vec<u64> = [30u64, 60, 94, 150, 400, 700]
+        .into_iter()
+        .filter(|s| *s < horizon_us * 3 / 4)
+        .collect();
+    let a = GOAL_VELOCITY.to_le_bytes();
+    for dl in [5u32, 20, 45, 70] {
+        for &stall_us in &stalls {
+            for stalled_frame in 0..9usize {
+                let mut sim = sim(baud_idx);
+                sim.add_servo_with(1, 0, 250);
+                sim.set_handler_cost(
+                    0,
+                    HandlerCost {
+                        on_break_us: 2,
+                        on_deadline_us: dl,
+                        on_tx_complete_us: 2,
+                    },
+                );
+
+                for cycle in 0..3u32 {
+                    let v = (cycle as i32 + 1) + 100 * stalled_frame as i32;
+                    let d = v.to_le_bytes();
+                    for k in 0..8u32 {
+                        let vk = v - (7 - k as i32);
+                        let dk = vk.to_le_bytes();
+                        let p = vec![a[0], a[1], dk[0], dk[1], dk[2], dk[3]];
+                        let f = instruction(1, Opcode::Write, Inst::FLAG_NOREPLY, &p);
+                        if k as usize == stalled_frame {
+                            // Split after the header + 2 payload bytes, the
+                            // captured shape.
+                            sim.host_send_stalled(&f, 6, stall_us);
+                        } else {
+                            sim.host_send(&f);
+                        }
+                    }
+                    let read = instruction(1, Opcode::Read, 0, &[a[0], a[1], 4, 0]);
+                    if stalled_frame == 8 {
+                        sim.host_send_stalled(&read, 6, stall_us);
+                    } else {
+                        sim.host_send(&read);
+                    }
+                    let frames = sim.run();
+
+                    let ctx =
+                        format!("dl={dl} stall={stall_us} frame={stalled_frame} cycle={cycle}");
+                    assert_eq!(
+                        sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+                        v,
+                        "{ctx}: write lost"
+                    );
+                    let r = replies(&frames);
+                    assert_eq!(r.len(), 1, "{ctx}: reply count");
+                    assert_valid(r[0]);
+                    let (inst, payload) = status(r[0]);
+                    assert_eq!(inst.result(), Some(ResultCode::Ok), "{ctx}");
+                    assert_eq!(payload, d, "{ctx}: stale read-back");
+                }
+                let diag = sim.servo_diag(0);
+                assert_eq!(
+                    diag.crc_fail_count, 0,
+                    "dl={dl} stall={stall_us} frame={stalled_frame}: trusted frame failed"
+                );
+            }
+        }
+    }
+}
+
+/// transport sec 9 throughput invariant: the consumer outruns the wire, so a
+/// sustained zero-gap flood of minimal frames drains through the ring (the
+/// queue, position from the stream) with zero loss -- the 512 B ring laps
+/// several times over the burst. The dispatch-cost sweep is derived from the
+/// per-frame wire time at this baud: the invariant holds only while per-frame
+/// dispatch stays below it, so a cost at or above the frame's wire time (e.g.
+/// a 70 us consumer at 3 M's ~42 us frame) is sustained overrun -- out of
+/// contract by design, and excluded.
+#[apply(matrix)]
+fn zero_gap_flood(baud_idx: u8) {
+    use osc_integration::sim::HandlerCost;
+
+    const FRAMES: i32 = 100;
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let a = GOAL_VELOCITY.to_le_bytes();
+
+    // Per-frame wire time of the minimal NOREPLY write; sweep the costs below it.
+    let sample = instruction(
+        1,
+        Opcode::Write,
+        Inst::FLAG_NOREPLY,
+        &[a[0], a[1], 0, 0, 0, 0],
+    );
+    let wire_us = frame_us(rate, sample.len() as u64 - 1);
+    let costs: Vec<u32> = [5u32, 20, 30, 45, 70]
+        .into_iter()
+        .filter(|c| (*c as u64) < wire_us)
+        .collect();
+
+    for &dl in &costs {
+        let mut sim = sim(baud_idx);
+        sim.add_servo_with(1, 0, 250);
+        sim.set_handler_cost(
+            0,
+            HandlerCost {
+                on_break_us: 2,
+                on_deadline_us: dl,
+                on_tx_complete_us: 2,
+            },
+        );
+
+        for k in 1..=FRAMES {
+            let d = k.to_le_bytes();
+            let p = vec![a[0], a[1], d[0], d[1], d[2], d[3]];
+            sim.host_send(&instruction(1, Opcode::Write, Inst::FLAG_NOREPLY, &p));
+        }
+        let read = instruction(1, Opcode::Read, 0, &[a[0], a[1], 4, 0]);
+        sim.host_send(&read);
+        let frames = sim.run();
+
+        assert_zero_gap(&host_frames(&frames));
+        assert_eq!(
+            sim.servo_table(0, |t| t.control.lifecycle.goal_velocity),
+            FRAMES,
+            "dl={dl}: flood tail write lost"
+        );
+        let r = replies(&frames);
+        assert_eq!(r.len(), 1, "dl={dl}: reply count");
+        assert_valid(r[0]);
+        let (inst, payload) = status(r[0]);
+        assert_eq!(inst.result(), Some(ResultCode::Ok), "dl={dl}");
+        assert_eq!(
+            payload,
+            FRAMES.to_le_bytes(),
+            "dl={dl}: stale flood read-back"
+        );
+        let diag = sim.servo_diag(0);
+        assert_eq!(diag.crc_fail_count, 0, "dl={dl}: trusted frame failed");
+        assert_eq!(diag.framing_drop_count, 0, "dl={dl}: flood dropped frames");
+    }
+}

--- a/firmware/lib/integration/tests/persistence.rs
+++ b/firmware/lib/integration/tests/persistence.rs
@@ -1,0 +1,183 @@
+//! Persistence semantics (`docs/osc-native-protocol.md` sec 9.4/9.5) over the
+//! wire: MGMT SAVE/FACTORY against the RAM store, the config-dirty telemetry
+//! bit, and the boot overlay a rebuilt servo takes -- sharing one leaked
+//! store across two `Sim`s models a reboot with flash intact.
+
+use osc_core::persist::{Image, Slot};
+use osc_core::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+use osc_core::regions::control::addr::lifecycle::TORQUE_ENABLE;
+use osc_core::regions::telemetry::addr::fault::CONFIG_DIRTY;
+use osc_integration::sim::{RamStore, Sim, Source, WireFrame, assert_valid, instruction, status};
+use osc_protocol::wire::{Id, MgmtOp, Opcode, ResultCode};
+use rstest::rstest;
+use rstest_reuse::apply;
+
+mod support;
+use support::{matrix, sim};
+
+const ID5: u8 = 5;
+const BROADCAST: u8 = Id::BROADCAST.as_byte();
+
+fn servo_frames(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect()
+}
+
+/// Assert exactly one well-formed servo reply and return it.
+fn sole_reply(frames: &[WireFrame]) -> &WireFrame {
+    let replies = servo_frames(frames);
+    assert_eq!(replies.len(), 1, "expected one servo reply: {frames:#?}");
+    assert_valid(replies[0]);
+    replies[0]
+}
+
+/// One MGMT exchange (empty args beyond the sub-op byte).
+fn mgmt(sim: &mut Sim, id: u8, op: MgmtOp) -> Vec<WireFrame> {
+    sim.host_send(&instruction(id, Opcode::Mgmt, 0, &[op as u8]));
+    sim.run()
+}
+
+/// One acked WRITE.
+fn write_ok(sim: &mut Sim, id: u8, addr: u16, data: &[u8]) {
+    let a = addr.to_le_bytes();
+    let mut payload = vec![a[0], a[1]];
+    payload.extend_from_slice(data);
+    sim.host_send(&instruction(id, Opcode::Write, 0, &payload));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+/// READ one byte back.
+fn read_byte(sim: &mut Sim, id: u8, addr: u16) -> u8 {
+    let a = addr.to_le_bytes();
+    sim.host_send(&instruction(id, Opcode::Read, 0, &[a[0], a[1], 1, 0]));
+    let frames = sim.run();
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    payload[0]
+}
+
+#[apply(matrix)]
+fn save_persists_the_live_regions_and_clears_dirty(baud_idx: u8) {
+    let store = RamStore::leak();
+    let mut sim = sim(baud_idx);
+    sim.add_servo_with_store(ID5, store);
+
+    write_ok(&mut sim, ID5, RESPONSE_DEADLINE_US, &200u16.to_le_bytes());
+    assert_eq!(read_byte(&mut sim, ID5, CONFIG_DIRTY), 1);
+
+    let frames = mgmt(&mut sim, ID5, MgmtOp::Save);
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(payload.is_empty());
+    assert_eq!(store.saves(), 1);
+    assert_eq!(read_byte(&mut sim, ID5, CONFIG_DIRTY), 0);
+
+    // The stored image is codec-valid and carries the written value.
+    let img = store.slot(Slot::A).expect("first save lands in slot A");
+    let parsed = Image::parse(&img).expect("stored image parses");
+    let at = RESPONSE_DEADLINE_US as usize;
+    assert_eq!(parsed.config[at..at + 2], 200u16.to_le_bytes());
+}
+
+#[apply(matrix)]
+fn save_with_torque_on_nacks_access(baud_idx: u8) {
+    let store = RamStore::leak();
+    let mut sim = sim(baud_idx);
+    sim.add_servo_with_store(ID5, store);
+
+    write_ok(&mut sim, ID5, TORQUE_ENABLE, &[1]);
+    let frames = mgmt(&mut sim, ID5, MgmtOp::Save);
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Access));
+    assert_eq!(store.saves(), 0);
+}
+
+#[apply(matrix)]
+fn save_failure_nacks_hardware_and_stays_dirty(baud_idx: u8) {
+    let store = RamStore::leak();
+    store.set_fail(true);
+    let mut sim = sim(baud_idx);
+    sim.add_servo_with_store(ID5, store);
+
+    write_ok(&mut sim, ID5, RESPONSE_DEADLINE_US, &200u16.to_le_bytes());
+    let frames = mgmt(&mut sim, ID5, MgmtOp::Save);
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Hardware));
+    assert_eq!(read_byte(&mut sim, ID5, CONFIG_DIRTY), 1);
+}
+
+#[apply(matrix)]
+fn factory_wipes_the_store_and_stages_reboot(baud_idx: u8) {
+    let store = RamStore::leak();
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo_with_store(ID5, store);
+
+    let frames = mgmt(&mut sim, ID5, MgmtOp::Save);
+    assert_eq!(status(sole_reply(&frames)).0.result(), Some(ResultCode::Ok));
+    assert!(store.slot(Slot::A).is_some());
+
+    let frames = mgmt(&mut sim, ID5, MgmtOp::Factory);
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(payload.is_empty());
+    assert_eq!(store.wipes(), 1);
+    assert!(store.slot(Slot::A).is_none() && store.slot(Slot::B).is_none());
+    assert!(sim.take_reboot(s).is_some(), "factory stages the reboot");
+}
+
+/// The sec 9.2 + 9.4 field story: ASSIGN takes a new id immediately, SAVE
+/// persists it, and the servo still answers on it after a reboot (fresh
+/// `Sim`, same store) -- while a factory-wiped store boots board defaults.
+#[apply(matrix)]
+fn saved_id_survives_reboot_until_factory(baud_idx: u8) {
+    let store = RamStore::leak();
+    let assign = {
+        let mut args = vec![MgmtOp::Assign as u8];
+        args.extend_from_slice(&[ID5; 16]); // the sim's default UID: id repeated
+        args.push(9);
+        args
+    };
+
+    {
+        let mut sim = sim(baud_idx);
+        sim.add_servo_with_store(ID5, store);
+        sim.host_send(&instruction(BROADCAST, Opcode::Mgmt, 0, &assign));
+        let frames = sim.run();
+        let reply = sole_reply(&frames);
+        assert_eq!(
+            reply.from,
+            Source::Servo(9),
+            "the ack leaves from the new id"
+        );
+        let frames = mgmt(&mut sim, 9, MgmtOp::Save);
+        assert_eq!(status(sole_reply(&frames)).0.result(), Some(ResultCode::Ok));
+    }
+
+    // Reboot: fresh sim, flash intact -- the saved id answers, the board
+    // default doesn't.
+    {
+        let mut sim = sim(baud_idx);
+        sim.add_servo_with_store(ID5, store);
+        sim.host_send(&instruction(9, Opcode::Ping, 0, &[]));
+        let frames = sim.run();
+        assert_eq!(sole_reply(&frames).from, Source::Servo(9));
+        sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+        assert!(servo_frames(&sim.run()).is_empty());
+
+        let frames = mgmt(&mut sim, 9, MgmtOp::Factory);
+        assert_eq!(status(sole_reply(&frames)).0.result(), Some(ResultCode::Ok));
+    }
+
+    // Reboot after FACTORY: the wiped store boots board defaults again.
+    {
+        let mut sim = sim(baud_idx);
+        sim.add_servo_with_store(ID5, store);
+        sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+        let frames = sim.run();
+        assert_eq!(sole_reply(&frames).from, Source::Servo(ID5));
+    }
+}

--- a/firmware/lib/integration/tests/protocol.rs
+++ b/firmware/lib/integration/tests/protocol.rs
@@ -1,0 +1,706 @@
+//! Instruction-set semantics (`docs/osc-native-protocol.md` sec 5): each case
+//! builds a sealed host instruction, runs the sim, and asserts on the decoded
+//! status frame + table state. Reads as the spec -- plain assertions, no
+//! snapshots.
+
+use osc_core::BaudRate;
+use osc_core::regions::config::addr::comms::{BAUD_RATE_IDX, ID};
+use osc_core::regions::control::addr::lifecycle::TORQUE_ENABLE;
+use osc_core::regions::profile::span_word;
+use osc_core::regions::{CALIB_BASE_ADDR, PROFILE_BASE_ADDR};
+use osc_integration::sim::{
+    HandlerCost, Sim, Source, WireFrame, assert_valid, instruction, status,
+};
+use osc_protocol::wire::{Id, Inst, MgmtOp, Opcode, ResultCode};
+use rstest::rstest;
+use rstest_reuse::apply;
+
+mod support;
+use support::{matrix, sim};
+
+const ID5: u8 = 5;
+
+/// Servo frames on the wire, in order.
+fn servo_frames(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect()
+}
+
+/// Assert exactly one well-formed servo reply and return it.
+fn sole_reply(frames: &[WireFrame]) -> &WireFrame {
+    let replies = servo_frames(frames);
+    assert_eq!(replies.len(), 1, "expected one servo reply: {frames:#?}");
+    assert_valid(replies[0]);
+    replies[0]
+}
+
+#[apply(matrix)]
+fn ping_reports_model_and_fw(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert!(inst.is_status());
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    let (model, fw) = sim.servo_table(s, |t| {
+        (
+            t.config.identity.model_number,
+            t.config.identity.firmware_version,
+        )
+    });
+    let m = model.to_le_bytes();
+    assert_eq!(payload, &[m[0], m[1], fw]);
+}
+
+#[apply(matrix)]
+fn read_returns_table_bytes(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // READ config identity span [0, 4): model(2) + fw(1) + reserved(1).
+    sim.host_send(&instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    let (model, fw) = sim.servo_table(s, |t| {
+        (
+            t.config.identity.model_number,
+            t.config.identity.firmware_version,
+        )
+    });
+    let m = model.to_le_bytes();
+    assert_eq!(payload, &[m[0], m[1], fw, 0]);
+}
+
+#[apply(matrix)]
+fn read_front_loaded_reply_matches_and_leaves_table(baud_idx: u8) {
+    // A READ is dispatched at covered-complete and CRC-verified at the frame end
+    // (the front-loaded path): the reply is byte-identical and the read-only op
+    // never touches the table.
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+    let before = sim.servo_table(s, |t| t.config.identity.model_number);
+
+    sim.host_send(&instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    let m = before.to_le_bytes();
+    assert_eq!(payload, &[m[0], m[1], 0x56, 0]);
+    assert_eq!(sim.servo_diag(s).crc_fail_count, 0);
+    assert_eq!(
+        sim.servo_table(s, |t| t.config.identity.model_number),
+        before,
+        "a read leaves the table untouched"
+    );
+}
+
+#[apply(matrix)]
+fn read_count_zero_is_range(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    sim.host_send(&instruction(ID5, Opcode::Read, 0, &[0, 0, 0, 0]));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Range));
+    assert!(payload.is_empty());
+}
+
+#[apply(matrix)]
+fn read_over_ceiling_is_limit(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    // count 253 exceeds the 252 B frame ceiling (sec 5.1).
+    sim.host_send(&instruction(ID5, Opcode::Read, 0, &[0, 0, 253, 0]));
+    let frames = sim.run();
+
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Limit));
+}
+
+#[apply(matrix)]
+fn write_acks_and_applies(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    let a = TORQUE_ENABLE.to_le_bytes();
+    sim.host_send(&instruction(ID5, Opcode::Write, 0, &[a[0], a[1], 1]));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(payload.is_empty());
+    assert!(sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+}
+
+#[apply(matrix)]
+fn write_noreply_is_silent_but_applies(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    let a = TORQUE_ENABLE.to_le_bytes();
+    sim.host_send(&instruction(
+        ID5,
+        Opcode::Write,
+        Inst::FLAG_NOREPLY,
+        &[a[0], a[1], 1],
+    ));
+    let frames = sim.run();
+
+    assert!(servo_frames(&frames).is_empty());
+    assert!(sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+}
+
+#[apply(matrix)]
+fn broadcast_write_is_silent_but_applies(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    let a = TORQUE_ENABLE.to_le_bytes();
+    sim.host_send(&instruction(0xFE, Opcode::Write, 0, &[a[0], a[1], 1]));
+    let frames = sim.run();
+
+    assert!(servo_frames(&frames).is_empty());
+    assert!(sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+}
+
+#[apply(matrix)]
+fn hold_then_commit_applies_atomically(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+    let a = TORQUE_ENABLE.to_le_bytes();
+
+    // WRITE + HOLD stages; the live field stays untouched, ack Ok.
+    sim.host_send(&instruction(
+        ID5,
+        Opcode::Write,
+        Inst::FLAG_HOLD,
+        &[a[0], a[1], 1],
+    ));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(!sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+
+    // Broadcast COMMIT applies the staged write silently.
+    sim.host_send(&instruction(0xFE, Opcode::Commit, 0, &[]));
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+    assert!(sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+
+    // A unicast COMMIT acks.
+    sim.host_send(&instruction(ID5, Opcode::Commit, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+#[apply(matrix)]
+fn large_write_stages_and_applies(baud_idx: u8) {
+    // LEN is the only size limit (sec 5.1): a >128 B write stages like any other
+    // (the buffer fits the largest legal write) and commits at its verdict.
+    // Target the calib pot-LUT span (writable, no field rules).
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    let mut data = vec![0u8; 130];
+    data[0..2].copy_from_slice(&0x1234u16.to_le_bytes()); // raw_min
+    data[2..4].copy_from_slice(&0x5678u16.to_le_bytes()); // raw_max
+    data[4] = 0xAB; // first LUT byte
+
+    let a = CALIB_BASE_ADDR.to_le_bytes();
+    let mut payload = vec![a[0], a[1]];
+    payload.extend_from_slice(&data);
+    sim.host_send(&instruction(ID5, Opcode::Write, 0, &payload));
+    let frames = sim.run();
+
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(sim.servo_diag(s).crc_fail_count, 0);
+    let (raw_min, raw_max, lut0) = sim.servo_table(s, |t| {
+        (
+            t.calib.pot_lut.raw_min,
+            t.calib.pot_lut.raw_max,
+            t.calib.pot_lut.lut[0],
+        )
+    });
+    assert_eq!(raw_min, 0x1234);
+    assert_eq!(raw_max, 0x5678);
+    assert_eq!((lut0 as u32) & 0xFF, 0xAB, "the >128 B payload landed");
+}
+
+#[apply(matrix)]
+fn mgmt_reboot_acks_then_surfaces(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    sim.host_send(&instruction(ID5, Opcode::Mgmt, 0, &[MgmtOp::Reboot as u8]));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(payload.is_empty());
+    assert!(sim.take_reboot(s).is_some());
+}
+
+#[apply(matrix)]
+fn mgmt_save_without_store_is_hardware_error(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    // SAVE (sec 9.4) on a servo with no persistence store seeded -> `hardware`.
+    sim.host_send(&instruction(ID5, Opcode::Mgmt, 0, &[MgmtOp::Save as u8]));
+    let frames = sim.run();
+
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Hardware));
+}
+
+/// Broadcast MGMT ENUM args: `prefix_len` bits + the prefix bytes (sec 9.2).
+fn enum_args(prefix_len: u8, prefix: &[u8]) -> Vec<u8> {
+    let mut args = vec![MgmtOp::Enum as u8, prefix_len];
+    args.extend_from_slice(prefix);
+    args
+}
+
+/// Broadcast MGMT ASSIGN args: `uid(12)` + `new_id` (sec 9.2).
+fn assign_args(uid: [u8; 16], new_id: u8) -> Vec<u8> {
+    let mut args = vec![MgmtOp::Assign as u8];
+    args.extend_from_slice(&uid);
+    args.push(new_id);
+    args
+}
+
+const BROADCAST: u8 = Id::BROADCAST.as_byte();
+
+#[apply(matrix)]
+fn mgmt_enum_prefix_selects_the_matching_servo(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+    let b = sim.add_servo(6);
+    // Distinct on bit 0 (the LSB-first stream's first bit, sec 9.2).
+    sim.seed_servo_uid(0, [0x00; 16]);
+    sim.seed_servo_uid(b, [0x01, 0xBB, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &enum_args(1, &[0x01]),
+    ));
+    let frames = sim.run();
+
+    let reply = sole_reply(&frames);
+    assert_eq!(
+        reply.from,
+        Source::Servo(6),
+        "only the prefix match answers"
+    );
+    let (inst, payload) = status(reply);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(payload, sim.servo_uid(b), "the reply is the full UID");
+}
+
+#[apply(matrix)]
+fn mgmt_enum_empty_prefix_is_the_tree_root(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // prefix_len 0 matches every servo -- with one on the bus, a clean reply.
+    sim.host_send(&instruction(BROADCAST, Opcode::Mgmt, 0, &enum_args(0, &[])));
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(payload, sim.servo_uid(s));
+}
+
+/// sec 9.2: a staged ENUM reply is collision-tolerant -- a peer's break landing
+/// in its reply gap (exactly the transport's staged-reply-kill evidence)
+/// must not silence it. Before the ENUM exemption the kill made the laggard
+/// of two matchers yield, the wire carried one clean frame, and the walk
+/// pruned the laggard's subtree.
+#[apply(matrix)]
+fn mgmt_enum_reply_survives_a_peer_break_in_the_reply_gap(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    sim.host_send(&instruction(BROADCAST, Opcode::Mgmt, 0, &enum_args(0, &[])));
+    // The instruction's wire end: a 14-bit break + 7 data bytes (8-byte ring
+    // image). A stray break dropped 6 us later sits inside the stage->trigger
+    // window at every baud: the frozen packet-end estimate is late by under
+    // a byte-time, and the trigger rides 12 us behind it.
+    let hz = BaudRate::from_idx(baud_idx).unwrap().as_hz() as u64;
+    let end_us = (14 + 7 * 10) * 1_000_000 / hz;
+    sim.inject_break_at(end_us + 6);
+    let frames = sim.run();
+
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(
+        payload,
+        sim.servo_uid(s),
+        "the reply survived the peer break"
+    );
+}
+
+/// Two matchers, one trigger lagging past the leader's break (the handler
+/// cost stands in for the silicon's dispatch-latency spread): the wire must
+/// carry the collision -- never one clean frame with the laggard silent
+/// (sec 9.2 "garbage IS the collision signal"; the yield hid id 1 from
+/// 65% of fleet walks at 1M).
+#[test_log::test]
+fn mgmt_enum_two_matchers_collide_never_one_clean_frame() {
+    let mut sim = sim(1); // 1M
+    let a = sim.add_servo(ID5);
+    let b = sim.add_servo(6);
+    let mut uid_a = [0u8; 16];
+    uid_a[0] = 0x03;
+    uid_a[1] = 0xAA;
+    let mut uid_b = [0u8; 16];
+    uid_b[0] = 0x03;
+    uid_b[1] = 0xBB;
+    sim.seed_servo_uid(a, uid_a);
+    sim.seed_servo_uid(b, uid_b);
+    // The laggard's deadline bodies cost 30 us: its trigger pends past the
+    // leader's whole break and fires mid-frame.
+    sim.set_handler_cost(
+        b,
+        HandlerCost {
+            on_deadline_us: 30,
+            ..Default::default()
+        },
+    );
+
+    // Both UIDs begin 0x03 -- an 8-bit prefix both match.
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &enum_args(8, &[0x03]),
+    ));
+    let frames = sim.run();
+
+    let replies = servo_frames(&frames);
+    assert!(!replies.is_empty(), "the laggard must not yield silently");
+    assert!(
+        replies.iter().all(|f| f.collided),
+        "two matchers -> colliding energy on the wire, never a clean lone frame: {replies:#?}"
+    );
+}
+
+#[apply(matrix)]
+fn mgmt_enum_mismatch_draws_silence(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+    sim.seed_servo_uid(0, [0x00; 16]);
+
+    // An empty subtree answers with a timeout, never a nack (sec 9.2).
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &enum_args(8, &[0xFF]),
+    ));
+    let frames = sim.run();
+
+    assert!(servo_frames(&frames).is_empty());
+}
+
+#[apply(matrix)]
+fn mgmt_enum_malformed_is_silent_on_broadcast_error_unicast(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    // prefix_len over 96 bits: broadcast stays silent (a nack storm is the
+    // one reply a broadcast must never draw)...
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &enum_args(129, &[]),
+    ));
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+
+    // ...while the same malformed query unicast gets the sec 5.3 layer-2 verdict.
+    sim.host_send(&instruction(ID5, Opcode::Mgmt, 0, &enum_args(129, &[])));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Instruction));
+}
+
+#[apply(matrix)]
+fn mgmt_assign_takes_the_id_and_acks_from_it(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &assign_args([ID5; 16], 42),
+    ));
+    let frames = sim.run();
+
+    let reply = sole_reply(&frames);
+    assert_eq!(reply.bytes[1], 42, "the ack already leaves from the new id");
+    let (inst, payload) = status(reply);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(payload.is_empty());
+    assert_eq!(
+        sim.servo_table(s, |t| t.config.comms.id),
+        42,
+        "mirrored into the config ID register for a later SAVE"
+    );
+
+    // The new id answers; the old id is nobody.
+    sim.host_send(&instruction(42, Opcode::Ping, 0, &[]));
+    let (inst, _) = status(sole_reply(&sim.run()));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    assert!(servo_frames(&sim.run()).is_empty());
+}
+
+#[apply(matrix)]
+fn mgmt_assign_foreign_uid_is_silent_and_inert(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &assign_args([0xEE; 16], 42),
+    ));
+    let frames = sim.run();
+
+    assert!(servo_frames(&frames).is_empty());
+    assert_eq!(sim.servo_table(s, |t| t.config.comms.id), ID5);
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let (inst, _) = status(sole_reply(&sim.run()));
+    assert_eq!(inst.result(), Some(ResultCode::Ok), "old id still answers");
+}
+
+#[apply(matrix)]
+fn mgmt_assign_invalid_id_nacks_validation(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // The sole UID match may nack without colliding (sec 9.2); 250 is past the
+    // unicast ceiling (sec 3.1).
+    sim.host_send(&instruction(
+        BROADCAST,
+        Opcode::Mgmt,
+        0,
+        &assign_args([ID5; 16], 250),
+    ));
+    let frames = sim.run();
+
+    let reply = sole_reply(&frames);
+    assert_eq!(reply.bytes[1], ID5, "the nack leaves from the unchanged id");
+    let (inst, _) = status(reply);
+    assert_eq!(inst.result(), Some(ResultCode::Validation));
+    assert_eq!(sim.servo_table(s, |t| t.config.comms.id), ID5);
+}
+
+#[apply(matrix)]
+fn profile_read_gathers_configured_spans(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // Configure slot 0 over the wire (sec 5.2: ordinary WRITEs, no new
+    // instruction): model+fw (3 B at 0x000, odd length -- no parity
+    // constraint) then the comms id byte.
+    let words = [span_word(0, 3), span_word(ID, 1)];
+    let mut payload = PROFILE_BASE_ADDR.to_le_bytes().to_vec();
+    for w in words {
+        payload.extend_from_slice(&w.to_le_bytes());
+    }
+    sim.host_send(&instruction(ID5, Opcode::Write, 0, &payload));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+
+    // READ + PROFILE names the slot; the reply is the spans' concatenation.
+    sim.host_send(&instruction(ID5, Opcode::Read, Inst::FLAG_PROFILE, &[0]));
+    let frames = sim.run();
+    let (inst, payload) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    let (model, fw) = sim.servo_table(s, |t| {
+        (
+            t.config.identity.model_number,
+            t.config.identity.firmware_version,
+        )
+    });
+    let m = model.to_le_bytes();
+    assert_eq!(payload, &[m[0], m[1], fw, ID5]);
+}
+
+#[apply(matrix)]
+fn profile_read_unconfigured_slot_is_range(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    // Slot 1 was never configured (all words disabled) -> `range` (sec 5.3).
+    sim.host_send(&instruction(ID5, Opcode::Read, Inst::FLAG_PROFILE, &[1]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Range));
+
+    // A slot index past the region is the same error.
+    sim.host_send(&instruction(ID5, Opcode::Read, Inst::FLAG_PROFILE, &[9]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Range));
+}
+
+#[apply(matrix)]
+fn profile_read_malformed_payload_is_instruction_error(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    // PROFILE payload is exactly one slot byte; an addr+count shape rejects.
+    sim.host_send(&instruction(
+        ID5,
+        Opcode::Read,
+        Inst::FLAG_PROFILE,
+        &[0, 0, 4, 0],
+    ));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Instruction));
+}
+
+#[apply(matrix)]
+fn corrupt_crc_gets_no_reply_and_counts(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    let a = TORQUE_ENABLE.to_le_bytes();
+    let mut frame = instruction(ID5, Opcode::Write, 0, &[a[0], a[1], 1]);
+    frame[4] ^= 0xFF; // corrupt a payload byte after sealing -> CRC no longer matches
+
+    sim.host_send(&frame);
+    let frames = sim.run();
+
+    // sec 5.3 layer 1: a corrupt frame is dropped silently and counted.
+    assert!(servo_frames(&frames).is_empty());
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 1);
+    assert_eq!(d.framing_drop_count, 0);
+    assert!(!sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+}
+
+#[apply(matrix)]
+fn wrong_id_is_ignored(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // Well-formed frame addressed to id 9; our servo is id 5.
+    sim.host_send(&instruction(9, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    assert!(servo_frames(&frames).is_empty());
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 0);
+    assert_eq!(d.framing_drop_count, 0);
+}
+
+#[apply(matrix)]
+fn alert_bit_mirrors_fault_flags(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    sim.servo_table_mut(s, |t| t.telemetry.fault.fault_flags = 1);
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert!(
+        inst.alert(),
+        "ALERT set while fault_flags nonzero (sec 5.3)"
+    );
+
+    sim.servo_table_mut(s, |t| t.telemetry.fault.fault_flags = 0);
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert!(!inst.alert());
+}
+
+#[apply(matrix)]
+fn id_change_acks_old_then_answers_new(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    sim.add_servo(ID5);
+
+    // WRITE the id field -> 7; the ack leaves from the OLD id, then the id lands.
+    let a = ID.to_le_bytes();
+    sim.host_send(&instruction(ID5, Opcode::Write, 0, &[a[0], a[1], 7]));
+    let frames = sim.run();
+    let r = sole_reply(&frames);
+    assert_eq!(
+        r.from,
+        Source::Servo(ID5),
+        "ack carries the old responder id"
+    );
+    let (inst, _) = status(r);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+
+    // A ping at the new id is answered.
+    sim.host_send(&instruction(7, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    assert_eq!(sole_reply(&frames).from, Source::Servo(7));
+
+    // A ping at the old id is silent.
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+}
+
+#[test]
+fn baud_change_acks_then_switches() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.add_servo(ID5);
+
+    // WRITE baud_rate_idx -> 3M. The ack leaves at the OLD 1M baud: the deferred
+    // apply lands only after the reply fully drains (sec 4.2).
+    let a = BAUD_RATE_IDX.to_le_bytes();
+    sim.host_send_at(
+        0,
+        &instruction(
+            ID5,
+            Opcode::Write,
+            0,
+            &[a[0], a[1], BaudRate::B3000000 as u8],
+        ),
+    );
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+
+    // A ping still at the old 1M baud garbles at the now-3M servo: silence.
+    sim.host_send_at(600, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    assert!(
+        servo_frames(&frames).is_empty(),
+        "old-baud ping must garble after the switch: {frames:#?}"
+    );
+
+    // Host follows the servo to 3M; a ping at the new baud is answered, proving
+    // the switch took effect after the ack drained.
+    sim.set_host_baud(BaudRate::B3000000);
+    sim.host_send_at(1200, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}

--- a/firmware/lib/integration/tests/resilience.rs
+++ b/firmware/lib/integration/tests/resilience.rs
@@ -1,0 +1,554 @@
+//! Framing faults and recovery (`docs/osc-native-protocol.md` sec 3.2, sec 3.3,
+//! sec 9.1). These document the break-framed convergence story: a corrupted
+//! frame is lost to its CRC, and the next break re-anchors cleanly -- anchor
+//! parity is irrelevant (sec 3.2 self-aligning feed). Plain assertions on the
+//! observed diagnostics counters.
+
+use osc_core::BaudRate;
+use osc_core::regions::control::addr::lifecycle::{GOAL_POSITION, GOAL_VELOCITY, TORQUE_ENABLE};
+use osc_integration::sim::{Sim, Source, WireFrame, assert_valid, instruction, status};
+use osc_protocol::wire::{Inst, Opcode, ResultCode};
+use rstest::rstest;
+use rstest_reuse::apply;
+
+mod support;
+use support::{byte_ticks, matrix, sim};
+
+const ID5: u8 = 5;
+
+fn servo_frames(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect()
+}
+
+fn sole_reply(frames: &[WireFrame]) -> &WireFrame {
+    let replies = servo_frames(frames);
+    assert_eq!(replies.len(), 1, "expected one servo reply: {frames:#?}");
+    assert_valid(replies[0]);
+    replies[0]
+}
+
+/// A WRITE of a 4-byte goal_velocity -- payload 6 B (even, no pad), footprint
+/// 12 B: a comfortably long frame to time a mid-flight garble against.
+fn write_gv(id: u8, val: i32) -> Vec<u8> {
+    let a = GOAL_VELOCITY.to_le_bytes();
+    let v = val.to_le_bytes();
+    instruction(id, Opcode::Write, 0, &[a[0], a[1], v[0], v[1], v[2], v[3]])
+}
+
+#[test]
+fn midframe_garble_costs_one_frame() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+
+    // Frame A: one stray ring byte injected inside its wire window. The
+    // stray byte fills A's span one byte early, so A's CRC covers a
+    // shifted window and fails -- A dies by DATA (the fault contract: the
+    // garble's FE is only a wake). No ack, not applied.
+    sim.host_send_at(0, &write_gv(ID5, 0x0A0A0A0A));
+    sim.inject_garble_at(50, 0xAA);
+
+    // Frame B: the stray byte advanced the ring by one, so B anchors at ODD
+    // parity -- irrelevant (sec 3.2 self-aligning feed): B validates, applies,
+    // and acks. Convergence costs exactly the one garbled frame.
+    sim.host_send_at(1000, &write_gv(ID5, 0x0B0B0B0B));
+
+    let frames = sim.run();
+
+    let (inst, _) = status(sole_reply(&frames)); // the sole reply is B's ack
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        0x0B0B0B0B,
+        "B applied despite the odd anchor"
+    );
+    // A dies exactly once at layer 1 -- by CRC or by starve; the contract
+    // is the sum, as elsewhere in this suite.
+    let d = sim.servo_diag(s);
+    assert_eq!(d.framing_drop_count + d.crc_fail_count, 1);
+}
+
+#[apply(matrix)]
+fn lone_garble_costs_nothing(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // A lone garble byte on an idle bus advances the ring by one -> the next
+    // frame anchors at odd parity -- irrelevant (sec 3.2): answered normally.
+    sim.inject_garble_at(10, 0xAA);
+    sim.host_send_at(100, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    let d = sim.servo_diag(s);
+    assert_eq!(d.framing_drop_count, 0);
+    assert_eq!(d.crc_fail_count, 0);
+}
+
+#[apply(matrix)]
+fn truncated_frame_starves_then_recovers(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // A sealed WRITE cut to 6 ring bytes (break + ID,LEN,INST,addr0,addr1): the
+    // header parses and computes a frame end that never arrives -> the framer's
+    // end-recheck plateau exhausts and the frame is dropped (sec 4.1). 6 B is even,
+    // so ring parity is preserved (no rearm needed).
+    let full = write_gv(ID5, 0x11223344);
+    sim.host_send_at(0, &full[..6]);
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+    assert_eq!(sim.servo_diag(s).framing_drop_count, 1);
+
+    // A complete ping afterwards is answered.
+    sim.host_send_at(1000, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+#[apply(matrix)]
+fn break_preempts_partial_frame(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // A truncated frame immediately followed by a complete ping (back-to-back):
+    // the ping's fresh break preempts the in-flight partial frame (sec 3.3) ->
+    // one framing_drop, and the ping re-anchors and is answered.
+    let full = write_gv(ID5, 0x11223344);
+    sim.host_send(&full[..6]);
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    // The partial dies exactly once at layer 1. The resolver classifies it
+    // through the CRC gate (the ping's bytes fill the partial's footprint
+    // window and the mixed span fails) rather than by FE position -- either
+    // counter is one honest event; the contract is the sum.
+    let d = sim.servo_diag(s);
+    assert_eq!(d.framing_drop_count + d.crc_fail_count, 1);
+}
+
+#[apply(matrix)]
+fn corrupt_crc_tail_cancels_front_loaded_read(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // A READ whose covered span is intact but whose trailing CRC is corrupted:
+    // the read is front-loaded (dispatched + reply staged) at covered-complete,
+    // then the wire-CRC check at the frame end fails -> the staged reply is
+    // dropped and counted, and the read-only op never touched the table.
+    let mut frame = instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]);
+    let last = frame.len() - 1;
+    frame[last] ^= 0xFF; // corrupt CRC-hi only; the covered span stays valid
+    sim.host_send(&frame);
+    let frames = sim.run();
+
+    assert!(
+        servo_frames(&frames).is_empty(),
+        "a bad-CRC read gets no reply: {frames:#?}"
+    );
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 1, "the wire-CRC check failed");
+    assert_eq!(d.framing_drop_count, 0);
+
+    // The next read is answered -- the pending frame was cleanly dropped.
+    sim.host_send_at(1000, &instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+#[test]
+fn break_after_covered_cancels_front_loaded_read() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+
+    // A READ is front-loaded at covered-complete (~86 us, two byte-times
+    // before the packet-end estimate) and CRC-verified at its end (~106 us).
+    // A fresh break dropped into that window preempts the frame and must
+    // cancel the staged reply -- no phantom read reply.
+    sim.host_send_at(0, &instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]));
+    sim.inject_break_at(95); // a stray break dropped into the read's window
+
+    let frames = sim.run();
+    assert!(
+        servo_frames(&frames).is_empty(),
+        "the cancelled read never replies: {frames:#?}"
+    );
+    // The injected mid-frame break shifts every byte after it, so the
+    // resolver sees a corrupt frame (CRC gate), not a positional preempt --
+    // one honest layer-1 count either way.
+    let d = sim.servo_diag(s);
+    assert!(
+        d.framing_drop_count + d.crc_fail_count >= 1,
+        "the preempted read is counted"
+    );
+
+    // The bus heals (sec 3.2) and answers a following read within the heal bound.
+    let mut answered = false;
+    for k in 0..3u64 {
+        sim.host_send_at(
+            200 + k * 200,
+            &instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]),
+        );
+        let frames = sim.run();
+        if let [r] = servo_frames(&frames)[..] {
+            assert_valid(r);
+            assert_eq!(status(r).0.result(), Some(ResultCode::Ok));
+            answered = true;
+            break;
+        }
+    }
+    assert!(answered, "a following read is answered after the break");
+}
+
+#[apply(matrix)]
+fn crc_fail_write_reverts_and_keeps_held_entry(baud_idx: u8) {
+    // sec 5.3 L1 across frames: a bad-CRC pending write must revert without
+    // disturbing entries HELD by an earlier frame. A HOLD stages torque_enable;
+    // a corrupt plain write of goal_velocity is staged on top then reverted;
+    // COMMIT must land only the held torque_enable.
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+    let te = TORQUE_ENABLE.to_le_bytes();
+    let gv = GOAL_VELOCITY.to_le_bytes();
+
+    sim.host_send(&instruction(
+        ID5,
+        Opcode::Write,
+        Inst::FLAG_HOLD,
+        &[te[0], te[1], 1],
+    ));
+    sim.run();
+    assert!(!sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+
+    // Corrupt a data byte (index 6, past the 2-byte addr) so the covered span
+    // fails CRC while still decoding as our goal_velocity write.
+    let mut bad = instruction(ID5, Opcode::Write, 0, &[gv[0], gv[1], 9, 9, 9, 9]);
+    bad[6] ^= 0xFF;
+    sim.host_send(&bad);
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+    assert_eq!(sim.servo_diag(s).crc_fail_count, 1);
+    assert_eq!(sim.servo_table(s, |t| t.control.lifecycle.goal_velocity), 0);
+
+    // COMMIT applies only the held torque_enable; the reverted write is gone.
+    sim.host_send(&instruction(ID5, Opcode::Commit, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert!(sim.servo_table(s, |t| t.control.lifecycle.torque_enable));
+    assert_eq!(sim.servo_table(s, |t| t.control.lifecycle.goal_velocity), 0);
+}
+
+#[test]
+fn break_preempts_pending_write_then_recovers() {
+    // A WRITE preempted by a fresh break before its CRC verdict must leave the
+    // table clean; the dangling staged write is reclaimed by the dispatcher
+    // auto-revert, so a following write applies.
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+
+    sim.host_send_at(0, &write_gv(ID5, 0x0A0A0A0A));
+    sim.inject_break_at(115); // a stray break dropped mid-frame
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        0,
+        "a preempted write must not mutate the table"
+    );
+
+    // Heal (sec 3.2) and confirm a following write applies + acks.
+    let mut applied = false;
+    for k in 0..3u64 {
+        sim.host_send_at(300 + k * 300, &write_gv(ID5, 0x0C0C0C0C));
+        let frames = sim.run();
+        if let [r] = servo_frames(&frames)[..] {
+            assert_valid(r);
+            assert_eq!(status(r).0.result(), Some(ResultCode::Ok));
+            applied = true;
+            break;
+        }
+    }
+    assert!(applied, "a following write is answered after the break");
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        0x0C0C0C0C
+    );
+}
+
+#[apply(matrix)]
+fn latched_refires_mid_frame_never_kill_the_trusted_stream(baud_idx: u8) {
+    // The fault contract's regression pin (bench: hot GWRITE+COMMIT+GREAD
+    // chains fell 95% -> 80%): spurious break wakes -- coalesced or lagged
+    // services; on the FE-era wake, latched-flag re-fires after NOREPLY
+    // frames -- land mid-frame while trusted traffic streams. Those wakes
+    // carry no position and no time; two of them during one frame's flight
+    // must cost NOTHING. (The deleted wire-fault fence recorded service-time
+    // cursors and killed the live frame here.)
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // A NOREPLY write (leaves the flag latched on real silicon), then a
+    // burst of acked writes with re-fires landing inside each wire window.
+    let a = GOAL_VELOCITY.to_le_bytes();
+    sim.host_send_at(
+        0,
+        &instruction(
+            ID5,
+            Opcode::Write,
+            Inst::FLAG_NOREPLY,
+            &[a[0], a[1], 1, 0, 0, 0],
+        ),
+    );
+    let bt_us = byte_ticks(baud_idx) / 48; // sim byte-time in us
+    let mut acks = 0;
+    for k in 0..4u64 {
+        let at = 1000 + k * 5000;
+        sim.host_send_at(at, &write_gv(ID5, 0x0C0C0C0C + k as i32));
+        // Two re-fires inside the frame's wire window: one early (header
+        // region), one late (interior) -- the old fence needed exactly two
+        // progressing services to plant mid-frame and kill.
+        sim.inject_wake_refire_at(at + 2 * bt_us, s);
+        sim.inject_wake_refire_at(at + 6 * bt_us, s);
+        let frames = sim.run();
+        acks += servo_frames(&frames).len();
+    }
+    assert_eq!(acks, 4, "every acked write answered despite re-fires");
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        0x0C0C0C0C + 3,
+        "last write applied"
+    );
+    let d = sim.servo_diag(s);
+    assert_eq!(
+        d.framing_drop_count + d.crc_fail_count,
+        0,
+        "re-fires cost nothing on a trusted stream"
+    );
+}
+
+#[test]
+fn foreign_baud_garbage_recovers_within_the_data_bound() {
+    // Foreign-baud recovery, specified to the fault contract (osc-native
+    // sec 3.4): a probe at a foreign baud rings FE-dense garble, and a
+    // phantom header inside it (garbage LEN) claims interior. Instructions
+    // following at the servo's own baud feed that interior -- and since an
+    // FE carries no position, NOTHING may kill the phantom by fault evidence
+    // (a fence built on service-time cursors killed live frames under burst
+    // load). The guarantee is data-bounded recovery instead: the phantom
+    // dies by footprint-fill CRC or by the starve horizon (64 byte-times of
+    // ring silence), the hunt then resolves the swallowed instruction from
+    // ring data, and -- the property that must stay dead -- the lateness
+    // NEVER becomes a steady state: every subsequent exchange is answered
+    // off its own frame.
+    const TICKS_PER_US: u64 = 48;
+    let mut sim = Sim::new(BaudRate::B2000000);
+    sim.add_servo(ID5);
+
+    sim.set_host_baud(BaudRate::B1000000);
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    sim.set_host_baud(BaudRate::B2000000);
+    sim.host_send_at(100, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    let ping = frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Host))
+        .nth(1)
+        .expect("own-baud ping recorded");
+    let reply = frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .find(|f| f.at > ping.end)
+        .expect("ping never answered -- swallowed as phantom interior");
+    assert_valid(reply);
+    assert_eq!(status(reply).0.result(), Some(ResultCode::Ok));
+    // Recovery bound: each 0x00-plausible junk anchor in the garble costs
+    // at most one starve horizon (64 byte-times = 320 us at 2M) on a quiet
+    // wire. The garble yields a couple such anchors; 3 horizons + a frame
+    // of slack is the contract's practical ceiling here.
+    let lead = reply.at - ping.end;
+    assert!(
+        lead < 1000 * TICKS_PER_US,
+        "ping answered {} us after its end -- recovery unbounded",
+        lead / TICKS_PER_US
+    );
+
+    // The exchanges after it stay clean and prompt -- no one-late residue
+    // (the indefinite cascade the hunt-flip fixed; CRC rejection of the
+    // phantom flips the hunt on, and the hunt converges).
+    for k in 0..2 {
+        sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+        let frames = sim.run();
+        let (inst, _) = status(sole_reply(&frames));
+        assert_eq!(inst.result(), Some(ResultCode::Ok), "follow-up {k}");
+    }
+}
+
+#[test]
+fn rescue_pulse_drops_to_500k() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+
+    // A >=300 us dominant low is a rescue command (sec 9.1): volatile switch to 0.5M.
+    sim.hold_line_low_at(0, 400);
+    sim.run();
+
+    // Volatile: the config register still reads the operational baud.
+    assert_eq!(
+        sim.servo_table(s, |t| t.config.comms.baud_rate_idx),
+        BaudRate::B1000000
+    );
+
+    // A ping at the operational 1M baud now mismatches the 0.5M servo -> no reply.
+    sim.host_send_at(600, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    assert!(servo_frames(&frames).is_empty());
+
+    // Talk at the rescue rate. The mismatched traffic left unparseable garble
+    // in the ring (byte count at a wrong-rate receiver is arbitrary), so sec 3.2
+    // allows one frame for the parity self-heal: the first valid ping may be
+    // spent on drop + rearm, the second must answer.
+    sim.set_host_baud(BaudRate::B500000);
+    let mut reply = None;
+    for attempt in 0..2u64 {
+        sim.host_send_at(
+            1200 + attempt * 600,
+            &instruction(ID5, Opcode::Ping, 0, &[]),
+        );
+        let frames = sim.run();
+        if let [r] = servo_frames(&frames)[..] {
+            assert_valid(r);
+            reply = Some(status(r).0);
+            break;
+        }
+    }
+    let inst = reply.expect("rescue ping answered within the sec 3.2 heal bound");
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+#[test]
+fn zero_payload_write_does_not_trip_rescue() {
+    // sec 9.1 phantom-rescue regression net: a long WRITE of zeros keeps the
+    // line dominant for most of its wire time (a zero byte is low for 9 of
+    // its 10 bit-times) -- bench-caught on the FE-era confirm, which sampled
+    // mid-payload and dropped the rate mid-instruction. The veto now lives
+    // in the chip's main-loop sampler (ring-frozen window: every completed
+    // char moves NDTR); at this model level the pin holds that ordinary
+    // traffic never produces a rescue declaration.
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+
+    let a = GOAL_POSITION.to_le_bytes();
+    let w = instruction(ID5, Opcode::Write, 0, &[a[0], a[1], 0, 0, 0, 0, 0, 0, 0, 0]);
+    sim.host_send_at(0, &w);
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+
+    // Still at the operational rate: a following 1M ping is answered clean.
+    sim.host_send_at(1_000, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(sim.servo_diag(s).framing_drop_count, 0);
+}
+
+#[apply(matrix)]
+fn short_break_is_not_rescue(baud_idx: u8) {
+    let mut sim = sim(baud_idx);
+    let s = sim.add_servo(ID5);
+
+    // Ordinary frames, each led by a normal break (risen by ISR entry, sec 9.1) --
+    // no false rescue, diagnostics stay clean across several exchanges.
+    for k in 0..4 {
+        sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+        let frames = sim.run();
+        let (inst, _) = status(sole_reply(&frames));
+        assert_eq!(inst.result(), Some(ResultCode::Ok), "frame {k}");
+    }
+
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 0);
+    assert_eq!(d.framing_drop_count, 0);
+    // No false rescue: the operational baud is unchanged.
+    assert_eq!(
+        sim.servo_table(s, |t| t.config.comms.baud_rate_idx),
+        BaudRate::from_idx(baud_idx).expect("valid baud idx")
+    );
+}
+
+/// The wrong-baud wedge, replayed: wrong-baud garble marination alone once
+/// made a fleet servo permanently deaf under the FE-era storm throttle (the
+/// mute's restore chain died through a stolen poll link). The surviving
+/// design (errors never interrupt; the wake is LBD-only -- transport sec 7)
+/// has no mute and nothing to wedge: faster-baud garble rings silently (zero
+/// wakes, sec 3.4), slower-baud garble wakes into junk that dies by data, and
+/// after one starve horizon of silence the servo answers at its configured
+/// rate.
+#[test]
+fn wrong_baud_marination_never_deafens() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let _s = sim.add_servo(ID5);
+
+    // Phase 1: 3M traffic at the 1M servo -- sub-10-bit lows, invisible.
+    sim.set_host_baud(BaudRate::B3000000);
+    for _ in 0..25 {
+        sim.host_send(&write_gv(ID5, 0x0A0A0A0A));
+    }
+    sim.run();
+
+    // Phase 2: 0.5M traffic -- every foreign break a genuine >=10-bit low:
+    // the servo wakes into garbled junk, anchors it, and data kills it.
+    sim.set_host_baud(BaudRate::B500000);
+    for _ in 0..25 {
+        sim.host_send(&write_gv(ID5, 0x0A0A0A0A));
+    }
+    sim.run();
+
+    // One starve horizon of bus silence (sec 3.4 host pacing), then a ping at
+    // the configured rate must answer.
+    sim.set_host_baud(BaudRate::B1000000);
+    let settle = sim.now_us() + 1_000;
+    sim.host_send_at(settle, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}
+
+/// The rescue half of the wedge: the wedged fleet was deaf-to-rescue because
+/// both rescue paths sat behind the muted wake. With the wake unmutable, a
+/// rescue pulse into a freshly marinated bus must run the sec 9.1 confirm chain
+/// and the servo must answer at the 0.5M rescue rate.
+#[test]
+fn rescue_reaches_a_marinated_servo() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let _s = sim.add_servo(ID5);
+
+    sim.set_host_baud(BaudRate::B3000000);
+    for _ in 0..25 {
+        sim.host_send(&write_gv(ID5, 0x0A0A0A0A));
+    }
+    sim.run();
+    sim.set_host_baud(BaudRate::B500000);
+    for _ in 0..25 {
+        sim.host_send(&write_gv(ID5, 0x0A0A0A0A));
+    }
+    sim.run();
+
+    let at = sim.now_us() + 1_000;
+    sim.hold_line_low_at(at, 400);
+    sim.run();
+
+    sim.set_host_baud(BaudRate::B500000);
+    sim.host_send_at(at + 2_000, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let (inst, _) = status(sole_reply(&frames));
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+}

--- a/firmware/lib/integration/tests/support/mod.rs
+++ b/firmware/lib/integration/tests/support/mod.rs
@@ -1,0 +1,46 @@
+//! Shared harness for the integration suite: the baud sweep template and its
+//! `Sim` builder. A test `#[apply(matrix)]`s a case per wire baud (sec 2 of
+//! `osc-native-protocol.md`); the folded-in `#[test_log::test]` routes the
+//! core-lib `log` traces to env_logger (gated on `RUST_LOG`).
+//!
+//! Included via `mod support;` from every test binary, so each item carries a
+//! dead-code allow -- no single binary uses all of them.
+#![allow(unused_macros)]
+
+use osc_core::BaudRate;
+use osc_integration::sim::Sim;
+use rstest_reuse::template;
+
+/// One `#[test]` per wire baud (0.5M / 1M / 2M / 3M -- `BaudRate` indices).
+/// Edit the `#[values(...)]` list to change baud coverage everywhere at once.
+/// Folds in `#[test_log::test]`, so an apply site needs only `#[apply(matrix)]`.
+#[template]
+#[rstest]
+#[test_log::test]
+#[allow(dead_code, unused_macros)]
+pub fn matrix(#[values(0u8, 1, 2, 3)] baud_idx: u8) {}
+
+/// A fresh `Sim` at the matrix baud.
+#[allow(dead_code)]
+pub fn sim(baud_idx: u8) -> Sim {
+    Sim::new(BaudRate::from_idx(baud_idx).expect("valid baud idx"))
+}
+
+/// Sim ticks for one wire byte-time (10 bits) at the matrix baud. Mirrors the
+/// sim core's own byte timing (48 ticks/us); exact integer division for every
+/// baud in the set. Tests that assert on wire-proportional bounds build them
+/// from this so the bound scales with baud instead of pinning to 1 M.
+#[allow(dead_code)]
+pub fn byte_ticks(baud_idx: u8) -> u64 {
+    let hz = BaudRate::from_idx(baud_idx)
+        .expect("valid baud idx")
+        .as_hz() as u64;
+    48 * 1_000_000 / hz * 10
+}
+
+/// reply gap in sim ticks -- fixed time at every baud (sec 7), imported from the
+/// driver so the pin cannot drift from the spec constant.
+#[allow(dead_code)]
+pub fn reply_gap_ticks() -> u64 {
+    osc_drivers::bus::REPLY_GAP_US as u64 * 48
+}

--- a/firmware/lib/integration/tests/timing.rs
+++ b/firmware/lib/integration/tests/timing.rs
@@ -1,0 +1,210 @@
+//! Sequencing-time properties of the osc-native transport (sec 4.1, 6, 7, 9.3).
+//!
+//! The `Sim` dispatches with a ZERO CPU-time model: dispatch and CRC are
+//! instantaneous, so every tick here is pure wire/scheduling time. These are
+//! therefore SEQUENCING assertions -- they pin reply gap behaviour, chain-gap
+//! ordering, and drift tolerance against the ideal sim clock. Wall-clock
+//! turnaround (the ~41 us projection of sec 7) is the bench's job, not this suite.
+
+use osc_core::BaudRate;
+use osc_core::regions::calib::addr::pot_lut::LUT;
+use osc_core::regions::config::addr::identity::MODEL_NUMBER;
+use osc_integration::sim::{Sim, Source, WireFrame, assert_valid, instruction, status};
+use osc_protocol::wire::{Opcode, ResultCode};
+use rstest::rstest;
+use rstest_reuse::apply;
+
+mod support;
+use support::matrix;
+
+const TICKS_PER_US: u64 = 48;
+
+/// 1 byte-time (10 bits) in sim ticks at `rate`.
+fn byte_ticks(rate: BaudRate) -> u64 {
+    TICKS_PER_US * 1_000_000 / rate.as_hz() as u64 * 10
+}
+
+const BCAST: u8 = 0xFE;
+
+fn gread_uniform(addr: u16, count: u16, ids: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&addr.to_le_bytes());
+    p.extend_from_slice(&count.to_le_bytes());
+    p.extend_from_slice(ids);
+    p
+}
+
+fn host_frame(frames: &[WireFrame]) -> &WireFrame {
+    frames
+        .iter()
+        .find(|f| f.from == Source::Host)
+        .expect("host frame recorded")
+}
+
+fn replies(frames: &[WireFrame]) -> Vec<&WireFrame> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect()
+}
+
+#[apply(matrix)]
+fn reply_lead_respects_reply_gap(baud_idx: u8) {
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let mut sim = Sim::new(rate);
+    sim.add_servo(1);
+    let instr = instruction(1, Opcode::Ping, 0, &[]);
+    sim.host_send(&instr);
+    let frames = sim.run();
+
+    let host = host_frame(&frames);
+    let reps = replies(&frames);
+    assert_eq!(reps.len(), 1, "ping -> one reply at {rate:?}: {frames:#?}");
+    assert_valid(reps[0]);
+
+    let bt = byte_ticks(rate);
+    let reply_gap = support::reply_gap_ticks();
+    let lead = reps[0].at - host.end;
+
+    // Hard floor: reply gap, fixed us at every baud (sec 7).
+    assert!(
+        lead >= reply_gap,
+        "{rate:?}: lead {lead} < reply gap {reply_gap}"
+    );
+
+    // Generous ceiling from the ring-cadence estimate (framer.rs): the
+    // frozen packet-end runs late by at most the wake epsilon (1/2 bt) plus
+    // the drift pad (span >> 6); two byte-times covers both with margin.
+    let fp = instr.len() as u64;
+    let ceil = reply_gap + 2 * bt + ((fp * bt) >> 6);
+    assert!(lead <= ceil, "{rate:?}: lead {lead} > ceiling {ceil}");
+}
+
+#[apply(matrix)]
+fn chain_gaps_scale_with_baud(baud_idx: u8) {
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let mut sim = Sim::new(rate);
+    for id in [1u8, 2, 3] {
+        sim.add_servo(id);
+    }
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        0,
+        &gread_uniform(MODEL_NUMBER, 2, &[1, 2, 3]),
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+    assert_eq!(reps.len(), 3, "{frames:#?}");
+
+    let bt = byte_ticks(rate);
+    let reply_gap = support::reply_gap_ticks();
+    for w in reps.windows(2) {
+        let gap = w[1].at - w[0].end;
+        assert!(gap >= reply_gap, "gap {gap} < reply gap {reply_gap}");
+        // Snoop-driven: a slot fires reply gap after its predecessor's status end,
+        // so the gap stays within a few byte-times (no reclaim in a full chain).
+        assert!(gap <= reply_gap + 6 * bt, "gap {gap} unexpectedly wide");
+    }
+    // Whole chain completes in well under a millisecond of wire time.
+    let span = reps.last().unwrap().end - host_frame(&frames).end;
+    assert!(
+        span < 1_000 * TICKS_PER_US,
+        "chain span {span} ticks too long"
+    );
+}
+
+#[apply(matrix)]
+fn skewed_servo_still_answers(baud_idx: u8) {
+    // +/-1 % is the worst untrimmed-HSI throw (sec 9.3). Cursor-verified wakes absorb
+    // the drift; nothing drops.
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    for skew in [-10_000i32, 10_000] {
+        let mut sim = Sim::new(rate);
+        sim.add_servo_with(1, skew, 60);
+        sim.host_send(&instruction(1, Opcode::Ping, 0, &[]));
+        let frames = sim.run();
+        let reps = replies(&frames);
+        assert_eq!(reps.len(), 1, "skew {skew}: ping answered: {frames:#?}");
+        assert_valid(reps[0]);
+        let (inst, _) = status(reps[0]);
+        assert_eq!(inst.result(), Some(ResultCode::Ok));
+
+        let diag = sim.servo_diag(0);
+        assert_eq!(diag.crc_fail_count, 0, "skew {skew}: no CRC drops");
+        assert_eq!(diag.framing_drop_count, 0, "skew {skew}: no framing drops");
+    }
+}
+
+#[apply(matrix)]
+fn skewed_servo_survives_long_frame(baud_idx: u8) {
+    // The framer's deadline-B margin scales with footprint (footprint >> 6), so
+    // a long frame keeps enough slack for +1 % drift (sec 4.1 regression).
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let mut sim = Sim::new(rate);
+    sim.add_servo_with(1, 10_000, 60);
+
+    // 50 i32 words = 200 B into the rule-free calibration LUT (torque off by
+    // default -> the persistent section is writable).
+    let words: Vec<i32> = (0..50).map(|i| 0x0100_0000 + i).collect();
+    let addr = LUT.to_le_bytes();
+    let mut payload = vec![addr[0], addr[1]];
+    for w in &words {
+        payload.extend_from_slice(&w.to_le_bytes());
+    }
+    sim.host_send(&instruction(1, Opcode::Write, 0, &payload));
+    let frames = sim.run();
+    let reps = replies(&frames);
+    assert_eq!(reps.len(), 1, "long write acked: {frames:#?}");
+    let (inst, data) = status(reps[0]);
+    assert_eq!(inst.result(), Some(ResultCode::Ok), "long write applies");
+    assert!(data.is_empty(), "write ack is empty");
+
+    let stored = sim.servo_table(0, |t| t.calib.pot_lut.lut);
+    assert_eq!(&stored[..50], &words[..], "all 200 B landed under drift");
+    assert_eq!(sim.servo_diag(0).framing_drop_count, 0);
+}
+
+#[apply(matrix)]
+fn skewed_chain_sequences_correctly(baud_idx: u8) {
+    let rate = BaudRate::from_idx(baud_idx).expect("valid baud idx");
+    let mut sim = Sim::new(rate);
+    let skews = [-10_000i32, 0, 10_000];
+    for (id, skew) in (1u8..=3).zip(skews.iter()) {
+        sim.add_servo_with(id, *skew, 60);
+    }
+
+    sim.host_send(&instruction(
+        BCAST,
+        Opcode::Gread,
+        0,
+        &gread_uniform(MODEL_NUMBER, 2, &[1, 2, 3]),
+    ));
+    let frames = sim.run();
+    let reps = replies(&frames);
+    assert_eq!(reps.len(), 3, "{frames:#?}");
+
+    // In list order, no reclaim flags despite the +/-1 % clock spread.
+    assert_eq!(
+        reps.iter().map(|f| f.bytes[1]).collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    for f in &reps {
+        assert_valid(f);
+        let (inst, _) = status(f);
+        assert_eq!(
+            inst.result(),
+            Some(ResultCode::Ok),
+            "no predecessor-silent under drift"
+        );
+    }
+    // Gaps measured on the ideal sim clock still honour reply gap.
+    let reply_gap = support::reply_gap_ticks();
+    for w in reps.windows(2) {
+        let gap = w[1].at - w[0].end;
+        assert!(gap >= reply_gap, "gap {gap} < reply gap {reply_gap}");
+    }
+    for i in 0..3 {
+        assert_eq!(sim.servo_diag(i).crc_fail_count, 0);
+    }
+}

--- a/firmware/lib/integration/tests/trim.rs
+++ b/firmware/lib/integration/tests/trim.rs
@@ -1,0 +1,378 @@
+//! MGMT CAL break-pair ruler (`docs/osc-native-protocol.md` sec 9.3): the host
+//! announces a break train, its crystal spaces the breaks, and each servo
+//! measures the announced gap with its own clock -- break-FE entry stamps at
+//! both ends of every gap, so entry latency cancels. Plain assertions on the
+//! trim decisions and on the transport's health after trains.
+
+use osc_core::BaudRate;
+use osc_core::regions::config::DEFAULT_RESPONSE_DEADLINE_US;
+use osc_integration::sim::{Sim, Source, instruction, status};
+use osc_protocol::wire::{Inst, Opcode, ResultCode};
+
+mod support;
+
+const ID: u8 = 5;
+const BROADCAST: u8 = 0xFE;
+const GAP_US: u64 = 400;
+const GAPS: u8 = 8;
+/// First ruler mark, us after the announce frame's start -- clear of the
+/// frame itself at every operational baud.
+const TRAIN_LEAD_US: u64 = 200;
+
+fn cal_announce(gap_us: u16, gaps: u8) -> Vec<u8> {
+    let [lo, hi] = gap_us.to_le_bytes();
+    instruction(BROADCAST, Opcode::Mgmt, 0, &[0x06, lo, hi, gaps])
+}
+
+/// Announce at `t0`, then `marks` breaks on exact `GAP_US` spacing.
+fn send_train(sim: &mut Sim, t0: u64, marks: u64) {
+    sim.host_send_at(t0, &cal_announce(GAP_US as u16, GAPS));
+    for k in 0..marks {
+        sim.host_send_break_at(t0 + TRAIN_LEAD_US + k * GAP_US);
+    }
+}
+
+fn train_end(t0: u64) -> u64 {
+    t0 + TRAIN_LEAD_US + GAPS as u64 * GAP_US
+}
+
+/// The trio's real signature (+5.2k ppm, bench-measured): one train, one
+/// decision, the nominal-seed acquire jump. Positive = slower.
+#[test_log::test]
+fn cal_train_draws_the_acquire_jump() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), Some(2));
+}
+
+#[test_log::test]
+fn slow_clock_draws_the_symmetric_speedup() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, -5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), Some(-2));
+}
+
+/// The ruler is us-denominated, so the measurement is baud-independent --
+/// the same train at 3M reads the same skew.
+#[test_log::test]
+fn cal_at_3m_reads_the_same_skew() {
+    let mut sim = Sim::new(BaudRate::B3000000);
+    let s = sim.add_servo_with(ID, 5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), Some(2));
+}
+
+/// Inside half a nominal step the rounding IS the deadband: a well-trimmed
+/// chip is never poked.
+#[test_log::test]
+fn near_nominal_clock_holds_still() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 900, DEFAULT_RESPONSE_DEADLINE_US);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), None);
+}
+
+/// A stray FE mid-gap (line noise) splits one gap into two sub-gate halves:
+/// both rejected, two of the announced gaps spent, the survivors still carry
+/// the decision -- a noisy train costs precision, never correctness.
+#[test_log::test]
+fn spurious_fe_mid_train_costs_gaps_not_the_train() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.inject_garble_at(TRAIN_LEAD_US + 3 * GAP_US + GAP_US / 2, 0xAA);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), Some(2));
+}
+
+/// Every gap outside the +/-6% gate (a host that can't keep the announced
+/// spacing): fewer than half the gaps validate, and the train decides
+/// NOTHING -- a mangled ruler yields no reading rather than a wrong one.
+#[test_log::test]
+fn mangled_train_decides_nothing() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    sim.host_send_at(0, &cal_announce(GAP_US as u16, GAPS));
+    // Marks at alternating 150/650 us -- every gap far outside the gate.
+    let mut t = TRAIN_LEAD_US;
+    for k in 0..(GAPS as u64 + 1) {
+        sim.host_send_break_at(t);
+        t += if k % 2 == 0 { 150 } else { 650 };
+    }
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), None);
+}
+
+/// The train's break bytes are scan noise the framer's hunt clears silently:
+/// the first instruction after a train answers clean, and neither counter
+/// moved -- CAL is invisible to the link diagnostics.
+#[test_log::test]
+fn train_then_ping_answers_clean() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.host_send_at(train_end(0) + 500, &instruction(ID, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let replies: Vec<_> = frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect();
+    assert_eq!(replies.len(), 1, "the ping's ack: {frames:#?}");
+    let (inst, _) = status(replies[0]);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    let d = sim.servo_diag(s);
+    assert_eq!(d.framing_drop_count, 0);
+    assert_eq!(d.crc_fail_count, 0);
+}
+
+/// A train that dies mid-way trips the silence watchdog: no decision, and
+/// the transport is back to answering within two announced gaps.
+#[test_log::test]
+fn dead_train_frees_the_transport() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID);
+    sim.host_send_at(0, &cal_announce(GAP_US as u16, GAPS));
+    sim.host_send_break_at(TRAIN_LEAD_US);
+    sim.host_send_break_at(TRAIN_LEAD_US + GAP_US);
+    sim.host_send_at(5_000, &instruction(ID, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let replies: Vec<_> = frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect();
+    assert_eq!(replies.len(), 1, "the ping's ack: {frames:#?}");
+    let (inst, _) = status(replies[0]);
+    assert_eq!(inst.result(), Some(ResultCode::Ok));
+    assert_eq!(sim.poll_clock_trim(s), None);
+}
+
+/// CAL is broadcast-only (sec 9.3): a unicast CAL's ack would put our own break
+/// on the wire exactly where the train starts, so it decodes Unsupported and
+/// is answered as an instruction error.
+#[test_log::test]
+fn unicast_cal_is_refused() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID);
+    let [lo, hi] = (GAP_US as u16).to_le_bytes();
+    sim.host_send_at(0, &instruction(ID, Opcode::Mgmt, 0, &[0x06, lo, hi, GAPS]));
+    let frames = sim.run();
+    let replies: Vec<_> = frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)))
+        .collect();
+    assert_eq!(replies.len(), 1, "the refusal: {frames:#?}");
+    let (inst, _) = status(replies[0]);
+    assert_eq!(inst.result(), Some(ResultCode::Instruction));
+    assert_eq!(sim.poll_clock_trim(s), None);
+}
+
+// ---- differential drift tracker (sec 9.3) ----------------------------------
+
+const OTHER_ID: u8 = 6;
+/// Silent hot-loop stand-in: WRITE|NOREPLY, 42-byte payload -> 48-byte
+/// footprint, 480 us of wire at 1M; host seam = 20 us.
+const PERIOD_US: u64 = 500;
+
+fn silent_write() -> Vec<u8> {
+    instruction(OTHER_ID, Opcode::Write, Inst::FLAG_NOREPLY, &[0u8; 42])
+}
+
+/// `n` silent frames from `t0`, PERIOD_US apart.
+fn send_silent(sim: &mut Sim, t0: u64, n: u64) -> u64 {
+    let f = silent_write();
+    for k in 0..n {
+        sim.host_send_at(t0 + k * PERIOD_US, &f);
+    }
+    t0 + n * PERIOD_US
+}
+
+/// The tracker follows drift injected mid-run: the baseline absorbs the
+/// host's queuing seam AND the boot-time skew, and a later rate change is
+/// read as its shift -- one step of drift draws one step of correction,
+/// with no CAL in sight.
+#[test_log::test]
+fn tracker_follows_thermal_drift() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 0, DEFAULT_RESPONSE_DEADLINE_US);
+    // Baseline (32 pairs) + one full window (128) at the boot rate.
+    let t = send_silent(&mut sim, 0, 180);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), None, "no drift, no decision");
+    // Thermal drift: +2600 ppm, continuously (the clock never steps).
+    sim.set_servo_skew_at(t, s, 2_600);
+    send_silent(&mut sim, t + PERIOD_US, 140);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), Some(1));
+}
+
+/// A constant seam and a constant skew are BOTH invisible: the tracker
+/// measures changes, not states -- absolute correction is CAL's job.
+#[test_log::test]
+fn constant_seam_and_skew_cancel() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    send_silent(&mut sim, 0, 320);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), None);
+    assert_eq!(sim.poll_clock_trim(s), None);
+}
+
+/// Solicited frames never pair -- an ack's turnaround rides another clock,
+/// and at 1M a reply gap slips under the span gate. The silent-shape rule
+/// keeps them out entirely: acked traffic yields no pairs, no windows.
+#[test_log::test]
+fn solicited_frames_never_pair() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 0, DEFAULT_RESPONSE_DEADLINE_US);
+    let f = instruction(OTHER_ID, Opcode::Write, 0, &[0u8; 42]); // acked shape
+    for k in 0..320 {
+        sim.host_send_at(k * PERIOD_US, &f);
+    }
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), None);
+}
+
+/// The full composition: CAL anchors absolute, the tracker holds through
+/// quiet, then follows a later drift on top -- each layer consuming exactly
+/// its own signal.
+#[test_log::test]
+fn cal_anchors_then_tracker_follows() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 5_200, DEFAULT_RESPONSE_DEADLINE_US);
+    send_train(&mut sim, 0, GAPS as u64 + 1);
+    sim.run();
+    assert_eq!(
+        sim.poll_clock_trim(s),
+        Some(2),
+        "CAL takes the acquire jump"
+    );
+    // Quiet stretch (clear of the post-train hunt's trailing wakes):
+    // baseline recaptures post-CAL, windows read no drift.
+    let t = send_silent(&mut sim, train_end(0) + 5_000, 180);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), None, "no drift since the anchor");
+    // Motor heat: +2600 ppm on top of the boot skew.
+    sim.set_servo_skew_at(t, s, 5_200 + 2_600);
+    send_silent(&mut sim, t + PERIOD_US, 140);
+    sim.run();
+    assert_eq!(sim.poll_clock_trim(s), Some(3));
+}
+
+// ---- bench-shape regression ----------------------------------------------
+//
+// The hardware tracker probe feeds 24-frame WRITE|NOREPLY bursts with
+// ~4-bit seams and a -6.9k ppm host detune, and the silicon tracker reads
+// ZERO -- while every DES tracker test above (500 us-period FOREIGN traffic)
+// stays green. These twins replicate the bench shape exactly; the fork
+// between them and against silicon localizes the starvation.
+
+/// Bench burst geometry at 1M: 10-byte frame + break = 110 us wire,
+/// 4-bit pirate seam, 24 frames per burst, settle gap between bursts.
+const BURST_FRAMES: u64 = 24;
+const BURST_PERIOD_US: u64 = 114;
+const BURST_SETTLE_US: u64 = 5_000;
+
+fn goal_write(id: u8) -> Vec<u8> {
+    use osc_core::regions::control::addr::lifecycle::GOAL_POSITION;
+    let mut payload = GOAL_POSITION.to_le_bytes().to_vec();
+    payload.extend_from_slice(&0i32.to_le_bytes());
+    instruction(id, Opcode::Write, Inst::FLAG_NOREPLY, &payload)
+}
+
+fn send_bursts(sim: &mut Sim, frame: &[u8], mut t: u64, bursts: u64) -> u64 {
+    for _ in 0..bursts {
+        for k in 0..BURST_FRAMES {
+            sim.host_send_at(t + k * BURST_PERIOD_US, frame);
+        }
+        t += BURST_FRAMES * BURST_PERIOD_US + BURST_SETTLE_US;
+    }
+    t
+}
+
+fn last_trim(sim: &mut Sim, s: usize) -> Option<i8> {
+    let mut last = None;
+    while let Some(v) = sim.poll_clock_trim(s) {
+        last = Some(v);
+    }
+    last
+}
+
+#[test_log::test]
+fn tracker_follows_bench_bursts_foreign() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 0, DEFAULT_RESPONSE_DEADLINE_US);
+    let f = goal_write(OTHER_ID);
+    let t = send_bursts(&mut sim, &f, 0, 3);
+    sim.run();
+    assert_eq!(last_trim(&mut sim, s), None, "baseline absorbs the seam");
+    sim.set_servo_skew_at(t, s, 6_900);
+    send_bursts(&mut sim, &f, t + 100, 16);
+    sim.run();
+    let moved = last_trim(&mut sim, s);
+    assert!(
+        matches!(moved, Some(n) if n >= 2),
+        "foreign bursts feed the tracker: {moved:?}"
+    );
+}
+
+#[test_log::test]
+fn tracker_follows_bench_bursts_self_addressed() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 0, DEFAULT_RESPONSE_DEADLINE_US);
+    let f = goal_write(ID);
+    let t = send_bursts(&mut sim, &f, 0, 3);
+    sim.run();
+    assert_eq!(last_trim(&mut sim, s), None, "baseline absorbs the seam");
+    sim.set_servo_skew_at(t, s, 6_900);
+    send_bursts(&mut sim, &f, t + 100, 16);
+    sim.run();
+    let moved = last_trim(&mut sim, s);
+    assert!(
+        matches!(moved, Some(n) if n >= 2),
+        "self-addressed bursts feed the tracker: {moved:?}"
+    );
+}
+
+/// The silicon reality behind the bench-shape starvation:
+/// NOREPLY frames leave the wire-fault flag latched (nothing transmits to
+/// retire it), and its level-pend re-fire lands in the seam before the
+/// next frame's bytes (transport sec 7). A re-fire is NOT a break -- stamping
+/// the drift tracker from it clobbers the pair in flight and starves the
+/// tracker to zero, while clean-break sims stay green. The fix gates the
+/// drift stamp on ring freshness (fault contract: fault handling is
+/// idempotent), the same cursor idiom the CAL run already uses.
+#[test_log::test]
+fn tracker_survives_latched_refires_between_frames() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo_with(ID, 0, DEFAULT_RESPONSE_DEADLINE_US);
+    let f = goal_write(ID);
+    let send = |sim: &mut Sim, mut t: u64, bursts: u64| -> u64 {
+        for _ in 0..bursts {
+            for k in 0..BURST_FRAMES {
+                sim.host_send_at(t + k * BURST_PERIOD_US, &f);
+                // A spurious wake per seam (the FE-era latched re-fire
+                // shape), just before the next frame's bytes.
+                sim.inject_wake_refire_at(t + k * BURST_PERIOD_US + 112, s);
+            }
+            t += BURST_FRAMES * BURST_PERIOD_US + BURST_SETTLE_US;
+        }
+        t
+    };
+    let t = send(&mut sim, 0, 3);
+    sim.run();
+    assert_eq!(last_trim(&mut sim, s), None, "baseline absorbs the seam");
+    sim.set_servo_skew_at(t, s, 6_900);
+    send(&mut sim, t + 100, 16);
+    sim.run();
+    let moved = last_trim(&mut sim, s);
+    assert!(
+        matches!(moved, Some(n) if n >= 2),
+        "re-fires must not eat the tracker's pairs: {moved:?}"
+    );
+}


### PR DESCRIPTION
The discrete-event simulation suite — gear 2 of the three in docs/testing.md.

The sim drives the real Framer/Chain/ServoBus/dispatch code against simulated wire timing with a zero-CPU-time model: wide on logic and sequencing at every baud, deliberately blind to wall-clock (that's the bench's job). 273 tests — protocol conformance, chain reclaim, the fault contract under garble/phantom-anchor/latched-refire abuse, zero-gap floods that lap the ring, trim convergence, persistence.

This completes firmware/lib: the workspace is identical to #20's tip. 499 tests total.
