### PR TITLE
firmware: ch32 chip crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,29 @@ jobs:
         run: cargo check -p osc-drivers --features mocks
       - name: cargo check --features bench
         run: cargo check -p osc-drivers --features bench
+
+  ch32-build-test:
+    name: build + test (firmware/ch32)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: firmware/ch32
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust (nightly + clippy + rustfmt)
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: firmware/ch32
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --tests --features ch32v006x8x6 -- -D warnings
+      - name: cargo build
+        run: cargo build --features ch32v006x8x6
+      - name: cargo test
+        run: cargo test --features ch32v006x8x6 --lib
+      - name: cargo check --features bench
+        run: cargo check --features ch32v006x8x6,bench

--- a/firmware/ch32/Cargo.toml
+++ b/firmware/ch32/Cargo.toml
@@ -1,0 +1,44 @@
+[workspace]
+resolver = "2"
+
+[package]
+name    = "osc-ch32"
+version = "0.0.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+ch32-metapac     = { git = "https://github.com/ch32-rs/ch32-metapac", default-features = false, features = ["pac"] }
+osc-core         = { path = "../lib/core" }
+osc-drivers      = { path = "../lib/drivers" }
+osc-protocol     = { path = "../lib/osc-protocol" }
+osc-units        = { path = "../lib/units" }
+osc-log          = { path = "../lib/log" }
+portable-atomic  = { version = "1", default-features = false }
+riscv            = "0.12"
+critical-section = "1.2"
+defmt            = { version = "1", optional = true }
+
+# RISC-V targets lack hardware CAS; opt into the single-core assumption so
+# RMW lowers to lw/sw pairs instead of pulling in critical-section. Host
+# builds (clippy, unit tests) use portable-atomic's native x86 path.
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+portable-atomic = { version = "1", default-features = false, features = ["unsafe-assume-single-core"] }
+
+[dev-dependencies]
+critical-section = { version = "1.2", features = ["std"] }
+
+[build-dependencies]
+ch32-metapac = { git = "https://github.com/ch32-rs/ch32-metapac", default-features = false, features = ["metadata"] }
+
+[features]
+default      = ["ch32v006x8x6"]
+ch32v006x8x6 = ["ch32-metapac/ch32v006x8x6"]
+rt           = ["ch32-metapac/rt"]
+# Forward the drivers' probe counters (crate::bench pattern).
+bench        = ["osc-drivers/bench"]
+defmt        = ["dep:defmt", "osc-core/defmt", "osc-drivers/defmt", "osc-log/defmt"]
+# Direct single wire (rev C HDSEL, or rev B with the buffer bypassed) --
+# tinyboot's flag. Default (absent) = rev B 74LVC2G241 buffer + TX_EN,
+# full duplex behind it. Reshapes `cfg::BusWiring` to match.
+half-duplex = []

--- a/firmware/ch32/build.rs
+++ b/firmware/ch32/build.rs
@@ -1,0 +1,316 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::error::Error;
+use std::fmt::Write as FmtWrite;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use ch32_metapac::metadata::METADATA;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    for p in METADATA.peripherals {
+        if let Some(regs) = &p.registers {
+            println!("cargo:rustc-cfg={}_{}", regs.kind, regs.version);
+        }
+    }
+
+    generate_pin_and_usart_mapping(&out)?;
+
+    // Ship the saved-config linker fragment (`INCLUDE osc-config.x` in a
+    // board's memory.x); the link-search path propagates to the board link.
+    fs::copy("osc-config.x", out.join("osc-config.x"))?;
+    println!("cargo:rustc-link-search={}", out.display());
+    println!("cargo:rerun-if-changed=osc-config.x");
+
+    println!("cargo:rerun-if-changed=build.rs");
+    Ok(())
+}
+
+fn port_index(port: char) -> usize {
+    (port as usize) - ('A' as usize)
+}
+
+fn generate_pin_and_usart_mapping(out: &Path) -> Result<(), Box<dyn Error>> {
+    let mut code = String::new();
+
+    // discriminant = (port_index << 5) | pin_number.
+    let mut pins: Vec<(char, u8)> = Vec::new();
+    for p in METADATA.peripherals {
+        if let Some(regs) = &p.registers
+            && regs.kind == "gpio"
+        {
+            let port = p.name.chars().nth(4).unwrap();
+            let pins_per_port: u8 = match regs.version {
+                "v0" => 8,
+                "v3" => 16,
+                "x0" => 24,
+                _ => 8,
+            };
+            for n in 0..pins_per_port {
+                pins.push((port, n));
+            }
+        }
+    }
+    pins.sort();
+
+    writeln!(code, "#[derive(Copy, Clone, Debug, PartialEq, Eq)]")?;
+    writeln!(code, "#[repr(u8)]")?;
+    writeln!(code, "#[allow(dead_code)]")?;
+    writeln!(code, "pub enum Pin {{")?;
+    for &(port, num) in &pins {
+        let discrim = (port_index(port) << 5) | (num as usize);
+        writeln!(code, "    P{port}{num} = {discrim:#04x},")?;
+    }
+    writeln!(code, "}}")?;
+    writeln!(code)?;
+
+    writeln!(code, "impl Pin {{")?;
+    writeln!(code, "    #[inline(always)]")?;
+    writeln!(
+        code,
+        "    pub const fn port_index(self) -> usize {{ (self as u8 >> 5) as usize }}"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "    #[inline(always)]")?;
+    writeln!(
+        code,
+        "    pub const fn pin_number(self) -> usize {{ (self as u8 & 0x1f) as usize }}"
+    )?;
+    writeln!(code)?;
+    writeln!(code, "    #[inline(always)]")?;
+    writeln!(
+        code,
+        "    pub fn gpio_regs(self) -> ch32_metapac::gpio::Gpio {{ ch32_metapac::GPIO(self.port_index()) }}"
+    )?;
+    writeln!(code, "}}")?;
+    writeln!(code)?;
+
+    struct RemapGroup {
+        peripheral_name: String,
+        tx_pin: Option<String>,
+        rx_pin: Option<String>,
+    }
+
+    let mut groups: BTreeMap<(String, u8), RemapGroup> = BTreeMap::new();
+
+    for p in METADATA.peripherals {
+        if let Some(regs) = &p.registers {
+            if regs.kind != "usart" {
+                continue;
+            }
+            for pin_entry in p.pins {
+                let remap_val = match pin_entry.remap {
+                    Some(r) => r,
+                    None => continue,
+                };
+                let key = (p.name.to_string(), remap_val);
+                let group = groups.entry(key).or_insert_with(|| RemapGroup {
+                    peripheral_name: p.name.to_string(),
+                    tx_pin: None,
+                    rx_pin: None,
+                });
+                match pin_entry.signal {
+                    "TX" => group.tx_pin = Some(pin_entry.pin.to_string()),
+                    "RX" => group.rx_pin = Some(pin_entry.pin.to_string()),
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    writeln!(code, "#[derive(Copy, Clone, Debug, PartialEq, Eq)]")?;
+    writeln!(code, "#[allow(dead_code)]")?;
+    writeln!(code, "pub enum UsartMapping {{")?;
+    for ((peri, remap), group) in &groups {
+        let variant = format!("{}Remap{}", capitalize_peripheral(peri), remap);
+        let tx = group.tx_pin.as_deref().unwrap_or("?");
+        let rx = group.rx_pin.as_deref().unwrap_or("?");
+        writeln!(code, "    /// {peri} remap {remap}: TX={tx}, RX={rx}")?;
+        writeln!(code, "    {variant},")?;
+    }
+    writeln!(code, "}}")?;
+    writeln!(code)?;
+
+    writeln!(code, "impl UsartMapping {{")?;
+
+    writeln!(code, "    pub const fn tx_pin(self) -> Pin {{")?;
+    writeln!(code, "        match self {{")?;
+    for ((peri, remap), group) in &groups {
+        let variant = format!("{}Remap{}", capitalize_peripheral(peri), remap);
+        let tx = group.tx_pin.as_ref().expect("USART mapping missing TX pin");
+        writeln!(code, "            UsartMapping::{variant} => Pin::{tx},")?;
+    }
+    writeln!(code, "        }}")?;
+    writeln!(code, "    }}")?;
+    writeln!(code)?;
+
+    writeln!(code, "    pub const fn rx_pin(self) -> Pin {{")?;
+    writeln!(code, "        match self {{")?;
+    for ((peri, remap), group) in &groups {
+        let variant = format!("{}Remap{}", capitalize_peripheral(peri), remap);
+        let rx = group.rx_pin.as_ref().expect("USART mapping missing RX pin");
+        writeln!(code, "            UsartMapping::{variant} => Pin::{rx},")?;
+    }
+    writeln!(code, "        }}")?;
+    writeln!(code, "    }}")?;
+    writeln!(code)?;
+
+    writeln!(code, "    pub const fn remap_value(self) -> u8 {{")?;
+    writeln!(code, "        match self {{")?;
+    for (peri, remap) in groups.keys() {
+        let variant = format!("{}Remap{}", capitalize_peripheral(peri), remap);
+        writeln!(code, "            UsartMapping::{variant} => {remap},")?;
+    }
+    writeln!(code, "        }}")?;
+    writeln!(code, "    }}")?;
+    writeln!(code)?;
+
+    writeln!(
+        code,
+        "    pub const fn regs(self) -> ch32_metapac::usart::Usart {{"
+    )?;
+    writeln!(code, "        match self {{")?;
+    for ((peri, remap), group) in &groups {
+        let variant = format!("{}Remap{}", capitalize_peripheral(peri), remap);
+        let peri_const = &group.peripheral_name;
+        writeln!(
+            code,
+            "            UsartMapping::{variant} => ch32_metapac::{peri_const},"
+        )?;
+    }
+    writeln!(code, "        }}")?;
+    writeln!(code, "    }}")?;
+    writeln!(code)?;
+
+    writeln!(code, "    pub const fn peripheral_index(self) -> u8 {{")?;
+    writeln!(code, "        match self {{")?;
+    for (peri, remap) in groups.keys() {
+        let variant = format!("{}Remap{}", capitalize_peripheral(peri), remap);
+        let index: String = peri.chars().filter(|c| c.is_ascii_digit()).collect();
+        writeln!(code, "            UsartMapping::{variant} => {index},")?;
+    }
+    writeln!(code, "        }}")?;
+    writeln!(code, "    }}")?;
+
+    writeln!(code, "}}")?;
+
+    generate_timer_mappings(&mut code)?;
+
+    fs::write(out.join("generated.rs"), code)?;
+    Ok(())
+}
+
+fn generate_timer_mappings(code: &mut String) -> Result<(), Box<dyn Error>> {
+    const SIGNALS: &[(&str, &str)] = &[
+        ("CH1", "ch1_pin"),
+        ("CH2", "ch2_pin"),
+        ("CH3", "ch3_pin"),
+        ("CH4", "ch4_pin"),
+        ("ETR", "etr_pin"),
+        ("BKIN", "bkin_pin"),
+        ("CH1N", "ch1n_pin"),
+        ("CH2N", "ch2n_pin"),
+        ("CH3N", "ch3n_pin"),
+    ];
+
+    for p in METADATA.peripherals {
+        let Some(regs) = &p.registers else { continue };
+        if regs.kind != "timer" {
+            continue;
+        }
+
+        let mut remaps: BTreeSet<u8> = BTreeSet::new();
+        for pin in p.pins {
+            if let Some(r) = pin.remap {
+                remaps.insert(r);
+            }
+        }
+        if remaps.is_empty() {
+            continue;
+        }
+
+        let enum_name = format!("{}Mapping", capitalize_peripheral(p.name));
+        let timer_has_signal: BTreeSet<&str> = p.pins.iter().map(|pp| pp.signal).collect();
+
+        writeln!(code)?;
+        writeln!(code, "#[derive(Copy, Clone, Debug, PartialEq, Eq)]")?;
+        writeln!(code, "#[repr(u8)]")?;
+        writeln!(code, "#[allow(dead_code)]")?;
+        writeln!(code, "pub enum {enum_name} {{")?;
+        for r in &remaps {
+            writeln!(code, "    Remap{r} = {r},")?;
+        }
+        writeln!(code, "}}")?;
+        writeln!(code)?;
+
+        writeln!(code, "impl {enum_name} {{")?;
+        writeln!(code, "    #[inline(always)]")?;
+        writeln!(
+            code,
+            "    pub const fn remap_value(self) -> u8 {{ self as u8 }}"
+        )?;
+
+        for (signal, method) in SIGNALS {
+            if !timer_has_signal.contains(signal) {
+                continue;
+            }
+
+            let pins_by_remap: Vec<(u8, Option<&str>)> = remaps
+                .iter()
+                .map(|r| {
+                    let pin = p
+                        .pins
+                        .iter()
+                        .find(|pp| pp.remap == Some(*r) && pp.signal == *signal)
+                        .map(|pp| pp.pin);
+                    (*r, pin)
+                })
+                .collect();
+
+            // Accessor returns `Pin` directly if every remap exposes signal; else `Option<Pin>`.
+            let always_exposed = pins_by_remap.iter().all(|(_, pin)| pin.is_some());
+
+            writeln!(code)?;
+            if always_exposed {
+                writeln!(code, "    pub const fn {method}(self) -> Pin {{")?;
+                writeln!(code, "        match self {{")?;
+                for (r, pin) in &pins_by_remap {
+                    let name = pin.expect("always_exposed checked above");
+                    writeln!(code, "            {enum_name}::Remap{r} => Pin::{name},")?;
+                }
+            } else {
+                writeln!(code, "    pub const fn {method}(self) -> Option<Pin> {{")?;
+                writeln!(code, "        match self {{")?;
+                for (r, pin) in &pins_by_remap {
+                    let value = match pin {
+                        Some(name) => format!("Some(Pin::{name})"),
+                        None => "None".to_string(),
+                    };
+                    writeln!(code, "            {enum_name}::Remap{r} => {value},")?;
+                }
+            }
+            writeln!(code, "        }}")?;
+            writeln!(code, "    }}")?;
+        }
+
+        writeln!(code, "}}")?;
+    }
+
+    Ok(())
+}
+
+fn capitalize_peripheral(name: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = true;
+    for c in name.chars() {
+        if capitalize_next {
+            result.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(c.to_ascii_lowercase());
+        }
+    }
+    result
+}

--- a/firmware/ch32/osc-config.x
+++ b/firmware/ch32/osc-config.x
@@ -1,0 +1,7 @@
+/* osc-ch32 saved-config slot bases (protocol sec 9.4), resolved against the
+   board's CONFIG_A/CONFIG_B memory regions -- SAVE uses page 0 of each 512 B
+   window, page 1 spare. Shipped into the linker search path by osc-ch32's
+   build.rs; a board's memory.x pulls it in with `INCLUDE osc-config.x`.
+   Consumed by providers/config_store.rs. */
+_config_a = ORIGIN(CONFIG_A);
+_config_b = ORIGIN(CONFIG_B);

--- a/firmware/ch32/src/cfg/board_wiring.rs
+++ b/firmware/ch32/src/cfg/board_wiring.rs
@@ -1,0 +1,140 @@
+//! Board-tunable wiring. Schematic-fixed pieces (USART/TIM2/TIM1 remaps,
+//! OPA inputs, TX_EN, STAT, PWM frequency, ADC sample time) live in
+//! [`super::chip`]; anything tunable per board (within the analog/digital
+//! pin buckets the chip + this board's free-pin set allow) lives here.
+
+use osc_drivers::Level;
+
+use crate::cfg::chip::{AnalogChannel, DigitalPin};
+#[cfg(not(feature = "half-duplex"))]
+use crate::hal::Pin;
+use crate::hal::opa;
+
+/// Bus wire wiring -- exists only on the buffered default wire (the
+/// wire mode is a compile-time board choice; see `providers/tx_wire`). The
+/// direct wire needs no bus wiring at all: PC0 carries everything, and on a
+/// buffer-populated board running the direct wire, the board's TX_EN
+/// pull-down is what keeps the buffer released -- no firmware involved.
+#[cfg(not(feature = "half-duplex"))]
+#[derive(Copy, Clone)]
+pub struct BusWiring {
+    /// 74LVC2G241 direction pin: high = the buffer drives TX onto the data
+    /// line and mutes the receive path (inverted enable, same signal);
+    /// low = wire released, the data line feeds RX.
+    pub tx_en: Pin,
+}
+
+#[derive(Copy, Clone)]
+pub struct DrvEn {
+    pub pin: DigitalPin,
+    /// Level driven to enable the H-bridge driver IC.
+    pub active: Level,
+}
+
+impl DrvEn {
+    pub const fn inactive(&self) -> Level {
+        match self.active {
+            Level::High => Level::Low,
+            Level::Low => Level::High,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct CurrentSenseConfig {
+    pub gain: opa::Gain,
+    pub bias: opa::Bias,
+}
+
+#[derive(Copy, Clone)]
+pub struct AdcPins {
+    pub pos: AnalogChannel,
+    pub ntc: AnalogChannel,
+    pub vbus: AnalogChannel,
+    pub vmotor: (AnalogChannel, AnalogChannel),
+}
+
+/// `V_adc = V_in * bot_ohm / (top_ohm + bot_ohm)`.
+#[derive(Copy, Clone)]
+pub struct Divider {
+    pub top_ohm: u32,
+    pub bot_ohm: u32,
+}
+
+/// beta-model NTC params: `R_ntc(T) = r0_ohm * exp(beta * (1/T - 1/T0))`.
+#[derive(Copy, Clone)]
+pub struct NtcCal {
+    pub beta: u16,
+    pub r0_ohm: u32,
+    /// T0 in centi-degC (matches `osc_units::CentiCelsius`).
+    pub t0_cc: i16,
+    pub bias_r_ohm: u32,
+}
+
+/// Schematic-derived constants identical across every unit of a PCB design.
+#[derive(Copy, Clone)]
+pub struct Calibration {
+    pub shunt_r_mohm: u16,
+    pub vbus_divider: Divider,
+    pub vmotor_divider: Divider,
+    pub ntc: NtcCal,
+}
+
+/// Board-tunable wiring; consumed during `Ch32ControlIo::new` and not retained.
+#[derive(Copy, Clone)]
+pub struct BoardWiring {
+    /// Scope/probe pad; toggled once per DMA-TC ISR.
+    pub dbg: DigitalPin,
+    pub drv_en: DrvEn,
+    #[cfg(not(feature = "half-duplex"))]
+    pub bus: BusWiring,
+    pub current_sense: CurrentSenseConfig,
+    pub sensors: AdcPins,
+}
+
+impl BoardWiring {
+    /// Compile-time call site: `const _: () = WIRING.assert_valid();`
+    pub const fn assert_valid(&self) {
+        self.assert_scratch_distinct();
+        #[cfg(not(feature = "half-duplex"))]
+        self.assert_bus_distinct();
+        self.assert_sensors_distinct();
+    }
+
+    const fn assert_scratch_distinct(&self) {
+        if (self.dbg as u8) == (self.drv_en.pin as u8) {
+            panic!("BoardWiring: dbg and drv_en.pin must not share a DigitalPin");
+        }
+    }
+
+    #[cfg(not(feature = "half-duplex"))]
+    const fn assert_bus_distinct(&self) {
+        let tx_en = self.bus.tx_en;
+        if (tx_en as u8) == (self.dbg.pin() as u8) || (tx_en as u8) == (self.drv_en.pin.pin() as u8)
+        {
+            panic!("BoardWiring: bus TX_EN must not share a pin with dbg or drv_en");
+        }
+    }
+
+    const fn assert_sensors_distinct(&self) {
+        let chs: [AnalogChannel; 5] = [
+            self.sensors.pos,
+            self.sensors.ntc,
+            self.sensors.vbus,
+            self.sensors.vmotor.0,
+            self.sensors.vmotor.1,
+        ];
+        let n = chs.len();
+        let mut i = 0;
+        while i < n {
+            let mut j = i + 1;
+            while j < n {
+                if (chs[i] as u8) == (chs[j] as u8) {
+                    panic!("BoardWiring: duplicate sensor AnalogChannel");
+                }
+                j += 1;
+            }
+            i += 1;
+        }
+    }
+}

--- a/firmware/ch32/src/cfg/chip.rs
+++ b/firmware/ch32/src/cfg/chip.rs
@@ -1,0 +1,117 @@
+//! V006-board-fixed constants. Anything in [`super::BoardWiring`] is
+//! board-tunable; anything here is determined by the chip + this board's
+//! schematic and lives in one place.
+
+use crate::hal::{Pin, Tim1Mapping, UsartMapping, adc, opa, timer};
+
+// === osc-native bus (USART1 on PC0/PC1; direct HDSEL single-wire, or the
+// rev B 74LVC2G241 buffered wire by default (`half-duplex` = direct) -- see
+// providers/tx_wire; the TX_EN pin is board wiring, `BusWiring`) ===
+
+pub const BUS_USART_MAPPING: UsartMapping = UsartMapping::Usart1Remap3;
+
+/// Pin whose input level tracks the bus wire (rescue-break sensing, protocol sec 9.1):
+/// the single-wire pin itself on the direct wire; the buffer's receive
+/// output (the USART RX pin) on the buffered wire.
+#[cfg(feature = "half-duplex")]
+pub const BUS_LINE_PIN: Pin = BUS_USART_MAPPING.tx_pin();
+#[cfg(not(feature = "half-duplex"))]
+pub const BUS_LINE_PIN: Pin = BUS_USART_MAPPING.rx_pin();
+
+// === OPA current sense ===
+
+pub const CURRENT_SENSE_OPA_INPUT: opa::InputMode = opa::InputMode::Differential {
+    pos: opa::PositiveInput::PA2,
+    neg: opa::NegativeInput::PA4,
+};
+pub const CURRENT_SENSE_OPA_OUTPUT: opa::Output = opa::Output::Internal;
+
+// === Motor + STAT (TIM1 Remap8) ===
+//
+// Remap8, not Remap7: identical pins for every channel this board uses
+// (CH2/PC5, CH3/PC6, CH4/PC7 -- the schematic's T1Cx_7 pins), but a remap
+// places FUNCTIONS, used or not, and Remap7 also puts the complementary
+// outputs CH1N/CH2N/CH3N on PC0/PC1/PC2 -- double-tenanting the bus pin
+// (PC0 = USART1_TX under Usart1Remap3), which the RM forbids. A
+// never-enabled OC function's AF signal is its reset state (0), so
+// whenever HDSEL released the pin the mux fell through to CH1N's 0 and
+// clamped the bus (bench: wire stuck low at idle, rose the instant
+// TIM1EN dropped). Remap8 parks the unused CHxN functions on PA3 (analog
+// VPOS -- digital mux disconnected) and PB0/PB1 (not bonded on TSSOP20).
+pub const MOTOR_TIM1_MAPPING: Tim1Mapping = Tim1Mapping::Remap8;
+pub const MOTOR_IN1_CH: timer::Channel = timer::Channel::CH3;
+pub const MOTOR_IN2_CH: timer::Channel = timer::Channel::CH2;
+pub const MOTOR_IN1_PIN: Pin = tim1_channel_pin(MOTOR_TIM1_MAPPING, MOTOR_IN1_CH);
+pub const MOTOR_IN2_PIN: Pin = tim1_channel_pin(MOTOR_TIM1_MAPPING, MOTOR_IN2_CH);
+pub const MOTOR_PWM_FREQ_HZ: u32 = 20_000;
+pub const STAT_LED_PIN: Pin = MOTOR_TIM1_MAPPING.ch4_pin();
+
+const fn tim1_channel_pin(m: Tim1Mapping, c: timer::Channel) -> Pin {
+    match c {
+        timer::Channel::CH1 => m.ch1_pin(),
+        timer::Channel::CH2 => m.ch2_pin(),
+        timer::Channel::CH3 => m.ch3_pin(),
+        timer::Channel::CH4 => m.ch4_pin(),
+    }
+}
+
+// === ADC ===
+
+pub const ADC_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
+
+/// ADC channels available as board-configurable sensor inputs on the V006F8P6.
+/// Excludes A0 (PA0, claimed by the OPA current-sense input pair).
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum AnalogChannel {
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+    A6,
+    A7,
+}
+
+impl AnalogChannel {
+    pub const fn channel(self) -> adc::Channel {
+        match self {
+            Self::A1 => adc::Channel::IN1,
+            Self::A2 => adc::Channel::IN2,
+            Self::A3 => adc::Channel::IN3,
+            Self::A4 => adc::Channel::IN4,
+            Self::A5 => adc::Channel::IN5,
+            Self::A6 => adc::Channel::IN6,
+            Self::A7 => adc::Channel::IN7,
+        }
+    }
+
+    pub const fn pin(self) -> Pin {
+        match self {
+            Self::A1 => Pin::PA1,
+            Self::A2 => Pin::PA2,
+            Self::A3 => Pin::PA3,
+            Self::A4 => Pin::PA4,
+            Self::A5 => Pin::PA5,
+            Self::A6 => Pin::PA6,
+            Self::A7 => Pin::PA7,
+        }
+    }
+}
+
+/// Free GPIOs on this board available as scratch outputs (DBG, motor DRV_EN).
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum DigitalPin {
+    PC3,
+    PD0,
+}
+
+impl DigitalPin {
+    pub const fn pin(self) -> Pin {
+        match self {
+            Self::PC3 => Pin::PC3,
+            Self::PD0 => Pin::PD0,
+        }
+    }
+}

--- a/firmware/ch32/src/cfg/mod.rs
+++ b/firmware/ch32/src/cfg/mod.rs
@@ -1,0 +1,44 @@
+pub mod board_wiring;
+pub mod chip;
+
+#[cfg(not(feature = "half-duplex"))]
+pub use board_wiring::BusWiring;
+pub use board_wiring::{
+    AdcPins, BoardWiring, Calibration, CurrentSenseConfig, Divider, DrvEn, NtcCal,
+};
+pub use chip::{AnalogChannel, DigitalPin};
+
+use osc_core::ConfigDefaults;
+
+use crate::control::Scales;
+use crate::providers::usart_baud;
+
+#[derive(Copy, Clone)]
+pub struct BoardConfig {
+    pub wiring: BoardWiring,
+    pub calibration: Calibration,
+    pub defaults: ConfigDefaults,
+}
+
+/// Boot-time-derived values that the `run!` macro folds at compile time so the
+/// linker can drop __udivdi3 / __udivsi3 / __umodsi3 entirely.
+#[derive(Copy, Clone)]
+pub struct Precomputed {
+    pub scales: Scales,
+    pub pwm_psc: u16,
+    pub pwm_arr: u16,
+    pub usart_brr: u32,
+}
+
+impl Precomputed {
+    pub const fn compute(cfg: &BoardConfig) -> Self {
+        let (pwm_psc, pwm_arr) = crate::hal::timer::pwm_dividers_from_hz(chip::MOTOR_PWM_FREQ_HZ);
+        let gain_factor = cfg.wiring.current_sense.gain.factor();
+        Self {
+            scales: Scales::new(&cfg.calibration, gain_factor),
+            pwm_psc,
+            pwm_arr,
+            usart_brr: usart_baud::brr_for(cfg.defaults.baud),
+        }
+    }
+}

--- a/firmware/ch32/src/control/mod.rs
+++ b/firmware/ch32/src/control/mod.rs
@@ -1,0 +1,64 @@
+//! Chip-side control-loop layer. Mirrors `services/` for the other half of
+//! the osc-core trait surface (`Sensors`, `Motor`, `ControlIo`) -- each
+//! submodule binds 1:1 to its osc-core trait; the bundle here impls
+//! `ControlIo` so the `Kernel` can reach both via `parts()`.
+
+pub mod motor;
+pub mod sensors;
+
+pub use motor::Ch32Motor;
+pub use sensors::{Ch32Sensors, Scales};
+
+use osc_core::ControlIo;
+
+use crate::cfg::{BoardConfig, Precomputed, chip};
+use crate::runtime::init::BringupResult;
+
+pub struct Ch32ControlIo {
+    pub sensors: Ch32Sensors,
+    pub motor: Ch32Motor,
+}
+
+impl Ch32ControlIo {
+    pub fn new(cfg: BoardConfig, pre: Precomputed) -> Self {
+        crate::log::info!("Ch32ControlIo::new: start");
+        let BoardConfig {
+            wiring,
+            calibration,
+            defaults,
+        } = cfg;
+
+        crate::log::debug!(
+            "scales: vbus_q32={} vmotor_q32={} shunt_q32={}",
+            pre.scales.vbus_q32,
+            pre.scales.vmotor_q32,
+            pre.scales.shunt_q32,
+        );
+
+        let drv_en_pin = wiring.drv_en.pin.pin();
+        let drv_en_active = wiring.drv_en.active;
+
+        let BringupResult { shunt_bias_raw } = crate::runtime::bringup(&wiring, &defaults, &pre);
+
+        crate::log::info!("Ch32ControlIo::new: complete");
+        Self {
+            sensors: Ch32Sensors::new(calibration, shunt_bias_raw, pre.scales),
+            motor: Ch32Motor::new(
+                chip::MOTOR_IN1_CH,
+                chip::MOTOR_IN2_CH,
+                drv_en_pin,
+                drv_en_active,
+                pre.pwm_arr,
+            ),
+        }
+    }
+}
+
+impl ControlIo for Ch32ControlIo {
+    type Sensors = Ch32Sensors;
+    type Motor = Ch32Motor;
+
+    fn parts(&mut self) -> (&mut Ch32Sensors, &mut Ch32Motor) {
+        (&mut self.sensors, &mut self.motor)
+    }
+}

--- a/firmware/ch32/src/control/motor.rs
+++ b/firmware/ch32/src/control/motor.rs
@@ -1,0 +1,122 @@
+//! Chip-side motor service. Translates `osc_core::MotorCmd` into TIM1
+//! H-bridge writes per the DRV8212P truth table:
+//! (1,1)=BRAKE, (0,0)=COAST, (1,0)=fwd, (0,1)=rev.
+//! Slow decay holds the idle leg HIGH; Fast decay holds it LOW. Effort ->
+//! duty math uses `>>15` to dodge soft-div in the ISR.
+
+use osc_core::{DecayMode, Motor as MotorTrait, MotorCmd};
+use osc_drivers::Level;
+
+use crate::hal::{Pin, gpio, timer};
+
+pub struct Ch32Motor {
+    in1: timer::Channel,
+    in2: timer::Channel,
+    drv_en: Pin,
+    drv_en_active: Level,
+    drv_en_inactive: Level,
+    pwm_arr: u16,
+}
+
+impl Ch32Motor {
+    pub const fn new(
+        in1: timer::Channel,
+        in2: timer::Channel,
+        drv_en: Pin,
+        drv_en_active: Level,
+        pwm_arr: u16,
+    ) -> Self {
+        let drv_en_inactive = match drv_en_active {
+            Level::High => Level::Low,
+            Level::Low => Level::High,
+        };
+        Self {
+            in1,
+            in2,
+            drv_en,
+            drv_en_active,
+            drv_en_inactive,
+            pwm_arr,
+        }
+    }
+}
+
+impl MotorTrait for Ch32Motor {
+    fn write(&mut self, cmd: MotorCmd) {
+        const STATIC_HIGH: u16 = u16::MAX;
+        match cmd {
+            MotorCmd::Disabled => {
+                gpio::set_level(self.drv_en, self.drv_en_inactive);
+                timer::set_duty(self.in1, 0);
+                timer::set_duty(self.in2, 0);
+            }
+            MotorCmd::Coast => {
+                gpio::set_level(self.drv_en, self.drv_en_active);
+                timer::set_duty(self.in1, 0);
+                timer::set_duty(self.in2, 0);
+            }
+            MotorCmd::Brake => {
+                gpio::set_level(self.drv_en, self.drv_en_active);
+                timer::set_duty(self.in1, STATIC_HIGH);
+                timer::set_duty(self.in2, STATIC_HIGH);
+            }
+            MotorCmd::Drive { duty, decay } => {
+                gpio::set_level(self.drv_en, self.drv_en_active);
+                let ticks = effort_to_ticks(duty.0.unsigned_abs(), self.pwm_arr);
+                if ticks == 0 {
+                    // Slow decay at zero ticks would lock both legs HIGH = BRAKE; coast instead.
+                    timer::set_duty(self.in1, 0);
+                    timer::set_duty(self.in2, 0);
+                    return;
+                }
+                let arr_minus = self.pwm_arr.saturating_sub(ticks);
+                let (in1, in2) = match (decay, duty.0 >= 0) {
+                    (DecayMode::Slow, true) => (STATIC_HIGH, arr_minus),
+                    (DecayMode::Slow, false) => (arr_minus, STATIC_HIGH),
+                    (DecayMode::Fast, true) => (ticks, 0),
+                    (DecayMode::Fast, false) => (0, ticks),
+                };
+                timer::set_duty(self.in1, in1);
+                timer::set_duty(self.in2, in2);
+            }
+        }
+    }
+}
+
+/// `mag * arr / 32767`, approximated with `>>15` to dodge soft-div in the ISR.
+fn effort_to_ticks(mag: u16, pwm_arr: u16) -> u16 {
+    let m = mag.min(i16::MAX as u16) as u32;
+    let prod = m * pwm_arr as u32;
+    ((prod + (1 << 14)) >> 15) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effort_zero_maps_to_zero_ticks() {
+        assert_eq!(effort_to_ticks(0, 1200), 0);
+    }
+
+    #[test]
+    fn effort_full_scale_maps_to_arr() {
+        assert_eq!(effort_to_ticks(i16::MAX as u16, 1200), 1200);
+    }
+
+    #[test]
+    fn effort_clamps_above_i16_max() {
+        assert_eq!(effort_to_ticks(u16::MAX, 1200), 1200);
+    }
+
+    #[test]
+    fn effort_to_ticks_monotonic() {
+        let arr = 1200;
+        let mut last = 0;
+        for mag in (0..=i16::MAX as u16).step_by(317) {
+            let t = effort_to_ticks(mag, arr);
+            assert!(t >= last, "non-monotonic at mag={mag}: {last} -> {t}");
+            last = t;
+        }
+    }
+}

--- a/firmware/ch32/src/control/sensors/convert.rs
+++ b/firmware/ch32/src/control/sensors/convert.rs
@@ -1,0 +1,213 @@
+//! Stateless raw-ADC -> engineering-unit math. `Scales` precomputes Q32
+//! reciprocals at compile time (called from `cfg::Precomputed`) so the
+//! 20 kHz ISR runs one `mulhu` per conversion and the linker drops
+//! `__udivdi3` / `__divdi3` entirely.
+
+use osc_units::{CentiCelsius, Microrads, Milliamps, Millivolts};
+
+use crate::cfg::{Calibration, Divider, NtcCal};
+
+const ADC_MAX_RAW: u32 = 4095;
+
+#[derive(Copy, Clone)]
+pub struct Scales {
+    pub vbus_q32: u32,
+    pub vmotor_q32: u32,
+    pub shunt_q32: u32,
+}
+
+impl Scales {
+    pub const fn new(cal: &Calibration, gain_factor: u16) -> Self {
+        Self {
+            vbus_q32: divider_q32(&cal.vbus_divider),
+            vmotor_q32: divider_q32(&cal.vmotor_divider),
+            shunt_q32: shunt_q32(gain_factor, cal.shunt_r_mohm),
+        }
+    }
+}
+
+const fn divider_q32(d: &Divider) -> u32 {
+    let bot = if d.bot_ohm == 0 { 1 } else { d.bot_ohm } as u64;
+    let sum = d.top_ohm.saturating_add(d.bot_ohm) as u64;
+    let num = sum << 32;
+    let den = ADC_MAX_RAW as u64 * bot;
+    let q = num / den;
+    if q > u32::MAX as u64 {
+        u32::MAX
+    } else {
+        q as u32
+    }
+}
+
+const fn shunt_q32(gain_factor: u16, r_mohm: u16) -> u32 {
+    let g = if gain_factor == 0 { 1 } else { gain_factor } as u64;
+    let r = if r_mohm == 0 { 1 } else { r_mohm } as u64;
+    let num = 1000u64 << 32;
+    let den = ADC_MAX_RAW as u64 * g * r;
+    let q = num / den;
+    if q > u32::MAX as u64 {
+        u32::MAX
+    } else {
+        q as u32
+    }
+}
+
+pub(super) fn divider_to_mv(raw: u16, vdd_mv: u32, scale_q32: u32) -> Millivolts {
+    let prod = raw as u32 * vdd_mv;
+    let v_in = ((prod as u64) * scale_q32 as u64) >> 32;
+    Millivolts(v_in.min(i16::MAX as u64) as i16)
+}
+
+pub(super) fn vmotor_diff_mv(raw_a: u16, raw_b: u16, vdd_mv: u32, scale_q32: u32) -> Millivolts {
+    let a = divider_to_mv(raw_a, vdd_mv, scale_q32).0 as i32;
+    let b = divider_to_mv(raw_b, vdd_mv, scale_q32).0 as i32;
+    Millivolts((a - b).unsigned_abs().min(i16::MAX as u32) as i16)
+}
+
+pub(super) fn shunt_to_milliamps(
+    raw: u16,
+    bias_raw: u16,
+    vdd_mv: u32,
+    scale_q32: u32,
+) -> Milliamps {
+    let signed = raw as i32 - bias_raw as i32;
+    let mag = signed.unsigned_abs() as u64 * vdd_mv as u64;
+    let i_ma_mag = ((mag * scale_q32 as u64) >> 32) as i32;
+    let i_ma = if signed >= 0 { i_ma_mag } else { -i_ma_mag };
+    Milliamps(i_ma.clamp(i16::MIN as i32, i16::MAX as i32) as i16)
+}
+
+pub(super) fn ntc_to_centi_celsius(_raw: u16, cal: &NtcCal) -> CentiCelsius {
+    // TODO: full beta-model needs fixed-point ln; pass-through returns T0.
+    let _ = (cal.beta, cal.r0_ohm, cal.bias_r_ohm);
+    CentiCelsius(cal.t0_cc)
+}
+
+pub(super) fn pos_to_microrads(raw: u16, min_urad: i32, max_urad: i32) -> Microrads {
+    // `>>12` approximates `/4095` (1 part in 4096) to dodge __divdi3 in the ISR.
+    let span = (max_urad as i64).wrapping_sub(min_urad as i64);
+    let interp = (span * raw as i64) >> 12;
+    Microrads(min_urad.saturating_add(interp as i32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VDD_MV: u32 = 3300;
+    const HALF_PI_URAD: i32 = 1_570_796;
+
+    fn rev_b_calibration() -> Calibration {
+        Calibration {
+            shunt_r_mohm: 10,
+            vbus_divider: Divider {
+                top_ohm: 20_000,
+                bot_ohm: 10_000,
+            },
+            vmotor_divider: Divider {
+                top_ohm: 20_000,
+                bot_ohm: 10_000,
+            },
+            ntc: NtcCal {
+                beta: 3950,
+                r0_ohm: 10_000,
+                t0_cc: 2500,
+                bias_r_ohm: 10_000,
+            },
+        }
+    }
+
+    #[test]
+    fn shunt_zero_at_bias() {
+        let scale = shunt_q32(32, 10);
+        assert_eq!(shunt_to_milliamps(2048, 2048, VDD_MV, scale), Milliamps(0));
+    }
+
+    #[test]
+    fn shunt_sign_follows_bias_offset() {
+        let scale = shunt_q32(32, 10);
+        let above = shunt_to_milliamps(2148, 2048, VDD_MV, scale);
+        let below = shunt_to_milliamps(1948, 2048, VDD_MV, scale);
+        assert!(above.0 > 0, "above bias must be positive, got {}", above.0);
+        assert!(below.0 < 0, "below bias must be negative, got {}", below.0);
+        assert_eq!(above.0, -below.0);
+    }
+
+    #[test]
+    fn shunt_saturates_to_i16_range() {
+        let scale = shunt_q32(32, 10);
+        let max_pos = shunt_to_milliamps(u16::MAX, 0, VDD_MV, scale);
+        let max_neg = shunt_to_milliamps(0, u16::MAX, VDD_MV, scale);
+        assert_eq!(max_pos, Milliamps(i16::MAX));
+        assert_eq!(max_neg, Milliamps(i16::MIN));
+    }
+
+    #[test]
+    fn divider_known_two_to_one() {
+        let scale = divider_q32(&Divider {
+            top_ohm: 20_000,
+            bot_ohm: 10_000,
+        });
+        let v = divider_to_mv(2048, VDD_MV, scale);
+        assert!((4900..=5000).contains(&v.0), "got {}", v.0);
+    }
+
+    #[test]
+    fn divider_full_scale_caps_at_i16_max() {
+        let scale = divider_q32(&Divider {
+            top_ohm: 90_000,
+            bot_ohm: 10_000,
+        });
+        let v = divider_to_mv(4095, VDD_MV, scale);
+        assert_eq!(v, Millivolts(i16::MAX));
+    }
+
+    #[test]
+    fn vmotor_diff_is_symmetric() {
+        let scale = divider_q32(&Divider {
+            top_ohm: 20_000,
+            bot_ohm: 10_000,
+        });
+        let ab = vmotor_diff_mv(3000, 1000, VDD_MV, scale);
+        let ba = vmotor_diff_mv(1000, 3000, VDD_MV, scale);
+        assert_eq!(ab, ba);
+    }
+
+    #[test]
+    fn vmotor_diff_zero_when_equal() {
+        let scale = divider_q32(&Divider {
+            top_ohm: 20_000,
+            bot_ohm: 10_000,
+        });
+        assert_eq!(vmotor_diff_mv(2000, 2000, VDD_MV, scale), Millivolts(0));
+    }
+
+    #[test]
+    fn pos_endpoints_match_range() {
+        let lo = pos_to_microrads(0, -HALF_PI_URAD, HALF_PI_URAD);
+        let hi = pos_to_microrads(4095, -HALF_PI_URAD, HALF_PI_URAD);
+        assert_eq!(lo, Microrads(-HALF_PI_URAD));
+        let span_per_lsb = (2 * HALF_PI_URAD as i64) / 4096;
+        let err = (HALF_PI_URAD - hi.0) as i64;
+        assert!(err <= span_per_lsb + 1, "err={err} lsb={span_per_lsb}");
+    }
+
+    #[test]
+    fn pos_midpoint_near_zero() {
+        let mid = pos_to_microrads(2048, -HALF_PI_URAD, HALF_PI_URAD);
+        let span_per_lsb = (2 * HALF_PI_URAD as i64) / 4096;
+        assert!(
+            (mid.0 as i64).abs() <= span_per_lsb,
+            "midpoint not near zero: {}",
+            mid.0
+        );
+    }
+
+    #[test]
+    fn scales_new_returns_nonzero_q32() {
+        let scales = Scales::new(&rev_b_calibration(), 32);
+        assert!(scales.vbus_q32 > 0);
+        assert!(scales.vmotor_q32 > 0);
+        assert!(scales.shunt_q32 > 0);
+    }
+}

--- a/firmware/ch32/src/control/sensors/lpf.rs
+++ b/firmware/ch32/src/control/sensors/lpf.rs
@@ -1,0 +1,59 @@
+//! Vcal reference low-pass filter. EWMA, alpha = 1/128. `state_q6` keeps 6
+//! sub-LSB bits so the filter resolves drift slower than 1 LSB per step
+//! without integer-rounding biasing the steady state.
+
+pub(super) struct VcalLpf {
+    state_q6: i32,
+    initialized: bool,
+}
+
+impl VcalLpf {
+    pub(super) const fn new() -> Self {
+        Self {
+            state_q6: 0,
+            initialized: false,
+        }
+    }
+
+    pub(super) fn update(&mut self, raw: u16) -> u16 {
+        let x = (raw as i32) << 6;
+        if !self.initialized {
+            self.state_q6 = x;
+            self.initialized = true;
+        } else {
+            self.state_q6 += (x - self.state_q6) >> 7;
+        }
+        (self.state_q6 >> 6) as u16
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initialises_on_first_sample() {
+        let mut lpf = VcalLpf::new();
+        assert_eq!(lpf.update(1234), 1234);
+    }
+
+    #[test]
+    fn constant_input_steady_state() {
+        let mut lpf = VcalLpf::new();
+        lpf.update(500);
+        for _ in 0..256 {
+            assert_eq!(lpf.update(500), 500);
+        }
+    }
+
+    #[test]
+    fn step_converges() {
+        let mut lpf = VcalLpf::new();
+        lpf.update(0);
+        let mut last = 0;
+        for _ in 0..2000 {
+            last = lpf.update(1000) as i32;
+        }
+        assert!((last - 1000).abs() <= 2, "last={last}");
+    }
+}

--- a/firmware/ch32/src/control/sensors/mod.rs
+++ b/firmware/ch32/src/control/sensors/mod.rs
@@ -1,0 +1,100 @@
+//! Chip-side sensor composer. The 20 kHz control-loop ISR drains
+//! `ADC_DMA_BUF` at the slot indices in `scan`, feeds the raw codes through
+//! the pipeline in `convert` (+ the Vcal LPF in `lpf`), and hands the result
+//! to the kernel via `osc_core::Sensors::sample`. Math is V006-and-board-
+//! shaped: 12-bit ADC, shunt-resistor current, NTC-thermistor temp,
+//! voltage-divider rails, peak/trough sampling under center-aligned PWM.
+
+mod convert;
+mod lpf;
+pub(crate) mod scan;
+
+pub use convert::Scales;
+
+use osc_core::{ConversionVariables, RawSamples, Sample, Sensors as SensorsTrait};
+
+use crate::cfg::Calibration;
+use crate::runtime::statics::read_sample_tick;
+
+use convert::{
+    divider_to_mv, ntc_to_centi_celsius, pos_to_microrads, shunt_to_milliamps, vmotor_diff_mv,
+};
+use lpf::VcalLpf;
+use scan::{
+    SCAN_IDX_NTC, SCAN_IDX_POS, SCAN_IDX_SHUNT_POST, SCAN_IDX_VCAL, SCAN_IDX_VMOTOR_A,
+    SCAN_IDX_VMOTOR_B, SCAN_PEAK_OFFSET, SCAN_TROUGH_OFFSET, scan_slot,
+};
+
+pub struct Ch32Sensors {
+    calibration: Calibration,
+    shunt_bias_raw: u16,
+    scales: Scales,
+    vcal_lpf: VcalLpf,
+}
+
+impl Ch32Sensors {
+    pub const fn new(calibration: Calibration, shunt_bias_raw: u16, scales: Scales) -> Self {
+        Self {
+            calibration,
+            shunt_bias_raw,
+            scales,
+            vcal_lpf: VcalLpf::new(),
+        }
+    }
+}
+
+impl SensorsTrait for Ch32Sensors {
+    /// Called from DMA1 TC ISR. Peak drives current; trough is diagnostic.
+    fn sample(&mut self, vars: &ConversionVariables) -> Sample {
+        let raw_shunt_post_trough = scan_slot(SCAN_TROUGH_OFFSET, SCAN_IDX_SHUNT_POST);
+        let raw_vmotor_a_trough = scan_slot(SCAN_TROUGH_OFFSET, SCAN_IDX_VMOTOR_A);
+        let raw_vmotor_b_trough = scan_slot(SCAN_TROUGH_OFFSET, SCAN_IDX_VMOTOR_B);
+
+        let raw_shunt_post_peak = scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_SHUNT_POST);
+        let raw_pos = scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_POS);
+        let raw_ntc = scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_NTC);
+        let raw_vmotor_a = scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_VMOTOR_A);
+        let raw_vmotor_b = scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_VMOTOR_B);
+        let raw_vcal = scan_slot(SCAN_PEAK_OFFSET, SCAN_IDX_VCAL);
+        let raw_vbus = 0u16;
+
+        let filtered_vcal = self.vcal_lpf.update(raw_vcal);
+        let vdd_mv = vars.vdd_mv as u32;
+
+        let post_peak = shunt_to_milliamps(
+            raw_shunt_post_peak,
+            self.shunt_bias_raw,
+            vdd_mv,
+            self.scales.shunt_q32,
+        );
+        let post_trough = shunt_to_milliamps(
+            raw_shunt_post_trough,
+            self.shunt_bias_raw,
+            vdd_mv,
+            self.scales.shunt_q32,
+        );
+
+        Sample {
+            tick: read_sample_tick(),
+            pos: pos_to_microrads(raw_pos, vars.pos_min_phys_urad, vars.pos_max_phys_urad),
+            current: post_peak,
+            current_post_trough: post_trough,
+            temp: ntc_to_centi_celsius(raw_ntc, &self.calibration.ntc),
+            vbus: divider_to_mv(raw_vbus, vdd_mv, self.scales.vbus_q32),
+            vmotor: vmotor_diff_mv(raw_vmotor_a, raw_vmotor_b, vdd_mv, self.scales.vmotor_q32),
+            raw: RawSamples {
+                pos: raw_pos,
+                current: raw_shunt_post_peak,
+                shunt_post_trough: raw_shunt_post_trough,
+                temp: raw_ntc,
+                vbus: raw_vbus,
+                vmotor_a: raw_vmotor_a,
+                vmotor_a_trough: raw_vmotor_a_trough,
+                vmotor_b: raw_vmotor_b,
+                vmotor_b_trough: raw_vmotor_b_trough,
+                vcal: raw_vcal,
+                vcal_lpf: filtered_vcal,
+            },
+        }
+    }
+}

--- a/firmware/ch32/src/control/sensors/scan.rs
+++ b/firmware/ch32/src/control/sensors/scan.rs
@@ -1,0 +1,38 @@
+//! Chip-shape ADC scan layout. Two scans per PWM period under center-aligned
+//! PWM (peak + trough); UG fires TRGO at CNT=0 before CEN=1 so the trough
+//! scan lands at offset 0 and the peak scan lands at `ADC_SCAN_LEN`. Slot
+//! indices within a scan reflect the configured RSQR sequence.
+
+use core::cell::SyncUnsafeCell;
+
+/// In `AdcPins` field order: pos, ntc, vbus, vmotor.0, vmotor.1.
+pub(crate) const ADC_SENSOR_COUNT: usize = 5;
+
+/// Scan = `[IN9/OpaOut, IN7/PD4/pos, IN2/PC4/ntc,
+///          IN5/PD5/vmA, IN6/PD6/vmB, IN10/Vcal]`. IN1 (PA1/vbus) excluded.
+pub(crate) const ADC_SCAN_LEN: usize = 6;
+
+/// Two scans per PWM period (peak + trough under center-aligned PWM, RCR=0).
+pub(crate) const ADC_DMA_BUF_LEN: usize = ADC_SCAN_LEN * 2;
+
+pub(crate) static ADC_DMA_BUF: SyncUnsafeCell<[u16; ADC_DMA_BUF_LEN]> =
+    SyncUnsafeCell::new([0; ADC_DMA_BUF_LEN]);
+
+pub(super) const SCAN_PEAK_OFFSET: usize = ADC_SCAN_LEN;
+pub(super) const SCAN_TROUGH_OFFSET: usize = 0;
+
+pub(super) const SCAN_IDX_SHUNT_POST: usize = 0;
+pub(super) const SCAN_IDX_POS: usize = 1;
+pub(super) const SCAN_IDX_NTC: usize = 2;
+pub(super) const SCAN_IDX_VMOTOR_A: usize = 3;
+pub(super) const SCAN_IDX_VMOTOR_B: usize = 4;
+pub(super) const SCAN_IDX_VCAL: usize = 5;
+
+/// Read trough slots before peak; DMA overwrites trough first after TC.
+#[inline(always)]
+pub(super) fn scan_slot(offset: usize, idx: usize) -> u16 {
+    let i = offset + idx;
+    debug_assert!(i < 2 * ADC_SCAN_LEN);
+    // SAFETY: index bounded above; `ADC_DMA_BUF` is a fixed-length static.
+    unsafe { (ADC_DMA_BUF.get() as *const u16).add(i).read_volatile() }
+}

--- a/firmware/ch32/src/hal/SAFETY.md
+++ b/firmware/ch32/src/hal/SAFETY.md
@@ -1,0 +1,90 @@
+# HAL concurrency safety boundary
+
+This crate wraps `ch32-metapac` registers. The metapac exposes safe `.modify()` /
+`.write()` / `.read()` for every register, but **MMIO register access is outside
+Rust's data-race model** — `.modify()` is a lw/op/sw on a peripheral address and
+the compiler will not catch a race between two priority contexts touching the
+same register. The lost-update bug class is real: an RMW racing against a
+different-bit write from a higher-priority context silently drops the latter.
+
+This module is the safety boundary. Code outside `hal/` should only call HAL
+helpers and never touch the metapac directly. Each helper that needs more than
+"single-context, safe" treatment carries an inline contract above its
+definition — read those at the source, not from a parallel registry here.
+
+## Concurrency model on V006 (QingKe V2A)
+
+The chip has two PFIC priority classes:
+
+- **HIGH** — ISRs at this class serialize against each other (no mutual
+  preemption) and preempt both LOW ISRs and MAIN.
+- **LOW** — ISRs preempt MAIN; they cannot preempt each other or HIGH.
+- **MAIN** — the dispatcher / service loop; preempted by any ISR; cannot
+  preempt them.
+
+The chip has no atomic XOR / fetch-or on MMIO. The available atomic
+primitives are hardware-provided per-register:
+
+- GPIO `BSHR` / `BCR` — per-pin set/clear.
+- DMA channel `IFCR` — per-flag write-1-to-clear.
+- USART status bits — clear by the SR-then-DR read sequence.
+
+Implication: any register written by ≥ 2 priority contexts is unsafe to RMW
+unless **every bit one context might write is also written by the other** (so
+the RMW is at worst self-healing), OR the access is wrapped in a critical
+section, OR an atomic primitive replaces the RMW.
+
+## Audit tiers
+
+Every `.modify()` in this module sits in one of three tiers. New callers must
+keep this invariant true.
+
+### Tier 1 — single-context: safe
+
+The register is only ever written by one priority context. RMW is fine; no
+annotation required.
+
+### Tier 2 — multi-context registers, RMW guarded by internal CS
+
+The register is written from ≥ 2 priority contexts but only same-bit. The
+helper wraps its `.modify()` in `critical_section::with` so the RMW is atomic
+against any preempting writer to the same register. Callers don't need their
+own CS.
+
+CS cost on V006/V2A is ~5 cycles via `mstatus.MIE` (csrrci + csrw). Nested CS
+(calling these from inside an ISR or another CS) is a no-op — the inner
+`with` re-disables already-disabled interrupts.
+
+### Tier 3 — must use atomic primitives, not `.modify()`
+
+Registers where multiple priorities touch *different bits*. RMW here corrupts
+state. Use the per-register atomic primitive instead:
+
+- GPIO port-bit toggle → `BSHR` / `BCR`, never `OUTDR.modify`.
+- DMA channel flag clear → `IFCR.write` (write-1-to-clear, hardware-atomic
+  per bit), never `IFCR.modify`.
+
+## Adding a new HAL helper — checklist
+
+1. **Identify every priority context that calls it.** Trace from this crate
+   outward; if the helper is `pub`, also check callers in other crates.
+2. **Identify every other helper that writes the same register.** Their
+   callers count too.
+3. **If single-context** → Tier 1, no annotation needed.
+4. **If multi-context same-bit** → Tier 2; wrap the RMW in
+   `critical_section::with` and document the contract inline.
+5. **If multi-context different-bit** → Tier 3 is required. Options:
+   - Replace RMW with an atomic primitive (BSHR/BCR/IFCR/single-bit write).
+   - Wrap the modify in `critical_section::with(|_| ...)`.
+   - Hoist the write to a single context and route requests via an atomic
+     "pending" flag (the apply-after-ISR pattern).
+
+## Why we don't mark `.modify()` `unsafe` upstream
+
+The race class is *any* non-atomic peripheral access reachable from multiple
+priorities, not `.modify()` specifically — a bare `read()` then `write()` has
+the same race. Marking `.modify()` `unsafe` at the metapac layer would force
+`unsafe` on every legitimate single-writer use across the entire chiptool
+ecosystem (every chip family, every embedded Rust HAL). The proper gate is
+the HAL surface: this module is the chokepoint, and these tier rules are how
+we enforce it.

--- a/firmware/ch32/src/hal/adc/mod.rs
+++ b/firmware/ch32/src/hal/adc/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(adc_v00x, path = "v00x.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/adc/v00x.rs
+++ b/firmware/ch32/src/hal/adc/v00x.rs
@@ -1,0 +1,150 @@
+use ch32_metapac::ADC;
+
+use crate::hal::Pin;
+
+pub use ch32_metapac::adc::vals::{Extsel, SampleTime};
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Channel {
+    IN0 = 0,
+    IN1 = 1,
+    IN2 = 2,
+    IN3 = 3,
+    IN4 = 4,
+    IN5 = 5,
+    IN6 = 6,
+    IN7 = 7,
+    // IN8 is unused on v006 (no external bonding on this package).
+    OpaOut = 9,
+    /// IN10 = "Vcal" per datasheet block diagram. SMP lives in SAMPTR1.
+    Vcal = 10,
+}
+
+impl Channel {
+    /// `None` for internal channels (OpaOut, Vcal). Caller configures pin as analog input.
+    pub const fn pin(self) -> Option<Pin> {
+        match self {
+            Channel::IN0 => Some(Pin::PA2),
+            Channel::IN1 => Some(Pin::PA1),
+            Channel::IN2 => Some(Pin::PC4),
+            Channel::IN3 => Some(Pin::PD2),
+            Channel::IN4 => Some(Pin::PD3),
+            Channel::IN5 => Some(Pin::PD5),
+            Channel::IN6 => Some(Pin::PD6),
+            Channel::IN7 => Some(Pin::PD4),
+            Channel::OpaOut | Channel::Vcal => None,
+        }
+    }
+}
+
+/// Sample time should match source Z (divider Thevenin equivalent) for S/H settling.
+#[derive(Copy, Clone)]
+pub struct Input {
+    pub channel: Channel,
+    pub sample_time: SampleTime,
+}
+
+impl Input {
+    pub const fn new(channel: Channel, sample_time: SampleTime) -> Self {
+        Self {
+            channel,
+            sample_time,
+        }
+    }
+}
+
+/// `channels.len()` must be 1..=16.
+pub fn set_sequence(channels: &[Channel]) {
+    assert!(!channels.is_empty() && channels.len() <= 16);
+    for (i, &ch) in channels.iter().enumerate() {
+        let v = ch as u8;
+        match i {
+            0..=5 => ADC.rsqr3().modify(|w| w.set_sq(i, v)),
+            6..=11 => ADC.rsqr2().modify(|w| w.set_sq(i - 6, v)),
+            12..=15 => ADC.rsqr1().modify(|w| w.set_sq(i - 12, v)),
+            _ => unreachable!(),
+        }
+    }
+    ADC.rsqr1().modify(|w| w.set_l((channels.len() - 1) as u8));
+}
+
+pub fn set_sample_time(channel: Channel, t: SampleTime) {
+    let ch = channel as usize;
+    if ch < 10 {
+        ADC.samptr2().modify(|w| w.set_smp(ch, t));
+    } else {
+        // SAMPTR1 covers SMP10..SMP15 (n = 0..6).
+        ADC.samptr1().modify(|w| w.set_smp(ch - 10, t));
+    }
+}
+
+pub fn set_external_trigger(source: Extsel) {
+    ADC.ctlr2().modify(|w| {
+        w.set_extsel(source);
+        w.set_exttrig(true);
+    });
+}
+
+pub fn set_scan_mode(enable: bool) {
+    ADC.ctlr1().modify(|w| w.set_scan(enable));
+}
+
+pub fn set_dma(enable: bool) {
+    ADC.ctlr2().modify(|w| w.set_dma(enable));
+}
+
+/// CTLR3.ADC_LP. Reset default is set; gates the internal OPA->IN9 path,
+/// so it must be cleared before the OpaOut channel reads non-zero.
+pub fn set_low_power(enable: bool) {
+    ADC.ctlr3().modify(|w| w.set_adc_lp(enable));
+}
+
+pub fn enable() {
+    ADC.ctlr2().modify(|w| w.set_adon(true));
+    crate::hal::delay_cycles(1_000);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXTERNAL: &[Channel] = &[
+        Channel::IN0,
+        Channel::IN1,
+        Channel::IN2,
+        Channel::IN3,
+        Channel::IN4,
+        Channel::IN5,
+        Channel::IN6,
+        Channel::IN7,
+    ];
+
+    #[test]
+    fn external_channels_have_pins() {
+        for ch in EXTERNAL {
+            assert!(ch.pin().is_some(), "{:?} has no pin", *ch as u8);
+        }
+    }
+
+    #[test]
+    fn internal_channels_have_no_pin() {
+        assert!(Channel::OpaOut.pin().is_none());
+        assert!(Channel::Vcal.pin().is_none());
+    }
+
+    #[test]
+    fn external_channels_map_to_distinct_pins() {
+        for (i, a) in EXTERNAL.iter().enumerate() {
+            for b in &EXTERNAL[i + 1..] {
+                assert_ne!(
+                    a.pin().unwrap(),
+                    b.pin().unwrap(),
+                    "channels {:?} and {:?} share a pin",
+                    *a as u8,
+                    *b as u8
+                );
+            }
+        }
+    }
+}

--- a/firmware/ch32/src/hal/afio/mod.rs
+++ b/firmware/ch32/src/hal/afio/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(afio_v00x, path = "v00x.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/afio/v00x.rs
+++ b/firmware/ch32/src/hal/afio/v00x.rs
@@ -1,0 +1,26 @@
+use ch32_metapac::AFIO;
+
+#[inline]
+pub fn set_usart_remap(n: u8, remap: u8) {
+    match n {
+        1 => AFIO.pcfr1().modify(|w| w.set_usart1_rm(remap)),
+        2 => AFIO.pcfr1().modify(|w| w.set_usart2_rm(remap)),
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn set_tim_remap(n: u8, remap: u8) {
+    match n {
+        1 => AFIO.pcfr1().modify(|w| w.set_tim1_rm(remap)),
+        2 => AFIO.pcfr1().modify(|w| w.set_tim2_rm(remap)),
+        _ => {}
+    }
+}
+
+#[inline]
+pub fn set_spi_remap(n: u8, remap: u8) {
+    if n == 1 {
+        AFIO.pcfr1().modify(|w| w.set_spi1_rm(remap));
+    }
+}

--- a/firmware/ch32/src/hal/clocks.rs
+++ b/firmware/ch32/src/hal/clocks.rs
@@ -1,0 +1,54 @@
+use ch32_metapac::rcc::vals::{Adcpre, Hpre};
+
+pub const HSI_HZ: u32 = 24_000_000;
+/// V006 RM sec 3, RCC_CTLR: each HSITRIM step shifts HSI by ~60 kHz.
+pub const HSI_TRIM_STEP_HZ: u32 = 60_000;
+pub const PLL_MUL: u32 = 2;
+pub const SYSCLK_HZ: u32 = HSI_HZ * PLL_MUL;
+
+pub const HPRE_DIV: u32 = 1;
+pub const ADCPRE_DIV: u32 = 4;
+
+pub const HCLK_HZ: u32 = SYSCLK_HZ / HPRE_DIV;
+pub const PCLK_HZ: u32 = HCLK_HZ;
+pub const TIM_CLK_HZ: u32 = HCLK_HZ;
+pub const ADCCLK_HZ: u32 = HCLK_HZ / ADCPRE_DIV;
+pub const SYSTICK_TICKS_PER_US: u32 = HCLK_HZ / 1_000_000;
+pub const SYSTICK_TICKS_PER_MS: u32 = HCLK_HZ / 1_000;
+
+pub const fn hpre_val() -> Hpre {
+    match HPRE_DIV {
+        1 => Hpre::DIV1,
+        2 => Hpre::DIV2,
+        3 => Hpre::DIV3,
+        4 => Hpre::DIV4,
+        5 => Hpre::DIV5,
+        6 => Hpre::DIV6,
+        7 => Hpre::DIV7,
+        8 => Hpre::DIV8,
+        16 => Hpre::DIV16,
+        32 => Hpre::DIV32,
+        64 => Hpre::DIV64,
+        128 => Hpre::DIV128,
+        256 => Hpre::DIV256,
+        _ => panic!("unsupported HPRE_DIV"),
+    }
+}
+
+pub const fn adcpre_val() -> Adcpre {
+    match ADCPRE_DIV {
+        2 => Adcpre::DIV2,
+        4 => Adcpre::DIV4,
+        6 => Adcpre::DIV6,
+        8 => Adcpre::DIV8,
+        12 => Adcpre::DIV12,
+        16 => Adcpre::DIV16,
+        24 => Adcpre::DIV24,
+        32 => Adcpre::DIV32,
+        48 => Adcpre::DIV48,
+        64 => Adcpre::DIV64,
+        96 => Adcpre::DIV96,
+        128 => Adcpre::DIV128,
+        _ => panic!("unsupported ADCPRE_DIV"),
+    }
+}

--- a/firmware/ch32/src/hal/dma/mod.rs
+++ b/firmware/ch32/src/hal/dma/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(dma_v1, path = "v1.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/dma/v1.rs
+++ b/firmware/ch32/src/hal/dma/v1.rs
@@ -1,0 +1,165 @@
+use ch32_metapac::DMA1;
+
+pub use ch32_metapac::dma::vals::{Dir, Pl, Size};
+
+/// DMA1 priority ladder (arbiter: higher `Pl` wins; equal `Pl` breaks by
+/// lowest channel number). The one hard invariant is that an inbound RX byte's
+/// drain must never be deferred past the FE-IRQ entry -- a deferred drain lets
+/// the break IRQ read a cursor that hasn't counted the byte (no-reply) or a
+/// `DATAR` clear steal it (ring loss). A bringup spike (`rx_dma_drain_latency`)
+/// proved the arbiter preempts per-beat, so RX alone at the top bounds its
+/// drain wait to one in-flight transfer (much less than IRQ latency) regardless
+/// of any competitor's burst length:
+///
+///   VERYHIGH  CH5 RX ring          -- inbound bytes, never deferred
+///   HIGH      CH1 ADC              -- motor kernel; wins HIGH ties (lowest #)
+///             CH4 TX               -- reply wire arms
+///             CH6 M2M -> snapshot  -- copies the reply payload for CRC + wire
+///   MEDIUM    CH3 SPI-CRC feed     -- must run BEHIND CH6 so the copy it reads
+///                                    is written first (producer -> consumer)
+///
+/// RX CRC feeds the SPI engine straight from the ring (no M2M staging), so CH6
+/// serves only the reply snapshot and CH7 is unused.
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Channel {
+    CH1 = 1,
+    CH2 = 2,
+    CH3 = 3,
+    CH4 = 4,
+    CH5 = 5,
+    CH6 = 6,
+    CH7 = 7,
+}
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub dir: Dir,
+    pub circ: bool,
+    pub pinc: bool,
+    pub minc: bool,
+    /// Applied to both peripheral and memory sides.
+    pub size: Size,
+    pub htie: bool,
+    pub tcie: bool,
+    pub pl: Pl,
+}
+
+pub fn configure(ch: Channel, cfg: &Config, paddr: u32, maddr: u32, count: u16) {
+    let n = (ch as u8 - 1) as usize;
+    let c = DMA1.ch(n);
+    c.par().write_value(paddr);
+    c.mar().write_value(maddr);
+    c.ndtr().write(|w| w.set_ndt(count));
+    c.cr().write(|w| {
+        w.set_dir(cfg.dir);
+        w.set_circ(cfg.circ);
+        w.set_pinc(cfg.pinc);
+        w.set_minc(cfg.minc);
+        w.set_psize(cfg.size);
+        w.set_msize(cfg.size);
+        w.set_htie(cfg.htie);
+        w.set_tcie(cfg.tcie);
+        w.set_pl(cfg.pl);
+    });
+}
+
+/// Memory-to-memory byte copy: `src` -> `dst`, `count` bytes, started
+/// immediately (no peripheral request -- MEM2MEM free-runs at bus speed).
+/// PAR is the source (DIR = from-peripheral), both sides increment.
+pub fn configure_m2m(ch: Channel, src: u32, dst: u32, count: u16, pl: Pl) {
+    let n = (ch as u8 - 1) as usize;
+    let c = DMA1.ch(n);
+    c.par().write_value(src);
+    c.mar().write_value(dst);
+    c.ndtr().write(|w| w.set_ndt(count));
+    // EN in the same CR write (spike-proven shape).
+    c.cr().write(|w| {
+        w.set_mem2mem(true);
+        w.set_dir(Dir::FROMPERIPHERAL);
+        w.set_pinc(true);
+        w.set_minc(true);
+        w.set_psize(Size::BITS8);
+        w.set_msize(Size::BITS8);
+        w.set_pl(pl);
+        w.set_en(true);
+    });
+}
+
+/// Channel must be disabled when called.
+pub fn set_count(ch: Channel, count: u16) {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.ch(n).ndtr().write(|w| w.set_ndt(count));
+}
+
+// SAFETY: see hal/SAFETY.md. CH(n).CR is per-channel; channels driven from
+// >= 2 priority contexts (the CH4 TX channel today, touched from MAIN and
+// HIGH ISRs) need the CS to keep EN/TCIE RMW atomic. Single-context channels
+// pay the CS cost but stay correct.
+// `inline(always)` folds this into the TIM2 CC3 hot path so the wire-driver
+// activate sequence stays inside the `.highcode` body -- no standalone flash
+// fetch per call.
+#[inline(always)]
+pub fn enable(ch: Channel) {
+    let n = (ch as u8 - 1) as usize;
+    critical_section::with(|_| {
+        DMA1.ch(n).cr().modify(|w| w.set_en(true));
+    });
+}
+
+#[inline(always)]
+pub fn disable(ch: Channel) {
+    let n = (ch as u8 - 1) as usize;
+    critical_section::with(|_| {
+        DMA1.ch(n).cr().modify(|w| w.set_en(false));
+    });
+}
+
+#[inline(always)]
+pub fn set_tcie(ch: Channel, enable: bool) {
+    let n = (ch as u8 - 1) as usize;
+    critical_section::with(|_| {
+        DMA1.ch(n).cr().modify(|w| w.set_tcie(enable));
+    });
+}
+
+#[inline(always)]
+pub fn set_htie(ch: Channel, enable: bool) {
+    let n = (ch as u8 - 1) as usize;
+    critical_section::with(|_| {
+        DMA1.ch(n).cr().modify(|w| w.set_htie(enable));
+    });
+}
+
+pub fn clear_tc_flag(ch: Channel) {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.ifcr().write(|w| w.set_tcif(n, true));
+}
+
+pub fn clear_ht_flag(ch: Channel) {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.ifcr().write(|w| w.set_htif(n, true));
+}
+
+#[inline]
+pub fn is_ht_flag(ch: Channel) -> bool {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.isr().read().htif(n)
+}
+
+#[inline]
+pub fn is_tc_flag(ch: Channel) -> bool {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.isr().read().tcif(n)
+}
+
+#[inline]
+pub fn remaining(ch: Channel) -> u16 {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.ch(n).ndtr().read().ndt()
+}
+
+pub fn is_enabled(ch: Channel) -> bool {
+    let n = (ch as u8 - 1) as usize;
+    DMA1.ch(n).cr().read().en()
+}

--- a/firmware/ch32/src/hal/esig.rs
+++ b/firmware/ch32/src/hal/esig.rs
@@ -1,0 +1,17 @@
+//! ESIG electronic signature (RM ch. 19): factory-burned chip identity in
+//! system ROM, readable at any width. Only the 96-bit UID is consumed here.
+
+const UNIID_BASE: *const u32 = 0x1FFF_F7E8 as *const u32;
+
+/// The factory UID in the protocol sec 9.2 wire shape: the 96-bit ESIG as 12
+/// little-endian bytes (UNIID1's low byte first, then UNIID2, UNIID3 -- RM
+/// sec 19.2), zero-padded to the fixed 16-byte field.
+pub fn uid() -> [u8; 16] {
+    let mut out = [0u8; 16];
+    for w in 0..3 {
+        // SAFETY: ESIG is an always-readable factory ROM region (RM sec 19.1).
+        let v = unsafe { UNIID_BASE.add(w).read_volatile() };
+        out[w * 4..w * 4 + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    out
+}

--- a/firmware/ch32/src/hal/exti/mod.rs
+++ b/firmware/ch32/src/hal/exti/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(exti_common, path = "v00x.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/exti/v00x.rs
+++ b/firmware/ch32/src/hal/exti/v00x.rs
@@ -1,0 +1,30 @@
+use ch32_metapac::{AFIO, EXTI};
+
+use super::super::Pin;
+
+#[inline]
+pub fn configure_falling_edge(pin: Pin) {
+    let line = pin.pin_number();
+    let port = pin.port_index() as u8;
+    AFIO.exticr().modify(|w| w.set_exti(line, port));
+    EXTI.ftenr().modify(|w| w.set_tr(line, true));
+}
+
+#[inline]
+pub fn clear_pending(pin: Pin) {
+    let line = pin.pin_number();
+    // INTFR is W1C; the default-zero closure leaves other lines' pending
+    // bits untouched while a `1` clears `line`.
+    EXTI.intfr().write(|w| w.set_if_(line, true));
+}
+
+#[inline]
+pub fn set_irq(pin: Pin, enable: bool) {
+    let line = pin.pin_number();
+    EXTI.intenr().modify(|w| w.set_mr(line, enable));
+}
+
+#[inline]
+pub fn is_pending(pin: Pin) -> bool {
+    EXTI.intfr().read().if_(pin.pin_number())
+}

--- a/firmware/ch32/src/hal/flash/mod.rs
+++ b/firmware/ch32/src/hal/flash/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(flash_v00x, path = "v00x.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/flash/v00x.rs
+++ b/firmware/ch32/src/hal/flash/v00x.rs
@@ -1,0 +1,112 @@
+const KEY1: u32 = 0x4567_0123;
+const KEY2: u32 = 0xCDEF_89AB;
+const FLASH: ch32_metapac::flash::Flash = ch32_metapac::FLASH;
+
+pub const PAGE_SIZE: usize = 256;
+const BUF_LOAD_SIZE: usize = 4;
+
+#[inline(always)]
+fn wait_busy() {
+    while FLASH.statr().read().bsy() {}
+    debug_assert!(
+        !FLASH.statr().read().wrprterr(),
+        "flash write protection error"
+    );
+    // EOP is W1C -- required after every BUFRST, BUFLOAD, STRT.
+    FLASH.statr().modify(|w| w.set_eop(true));
+}
+
+fn unlock() {
+    FLASH.keyr().write(|w| w.set_keyr(KEY1));
+    FLASH.keyr().write(|w| w.set_keyr(KEY2));
+    FLASH.modekeyr().write(|w| w.set_modekeyr(KEY1));
+    FLASH.modekeyr().write(|w| w.set_modekeyr(KEY2));
+}
+
+#[inline(always)]
+fn lock() {
+    FLASH.ctlr().write(|w| {
+        w.set_lock(true);
+        w.set_flock(true);
+    });
+}
+
+/// Erase one 256-byte page (RM sec 18.4.6).
+pub fn erase(addr: u32) {
+    unlock();
+    FLASH.ctlr().write(|w| w.set_fter(true));
+    FLASH.addr().write(|w| w.set_far(addr));
+    FLASH.ctlr().write(|w| {
+        w.set_fter(true);
+        w.set_strt(true);
+    });
+    wait_busy();
+    FLASH.ctlr().write(|_| {});
+    lock();
+}
+
+/// Fast-page write (RM sec 18.4.5) from scattered segments streamed in order --
+/// one buffer-load pass, one program cycle; no staging copy. `addr` 4-byte
+/// aligned, each segment's len a multiple of 4, the total must not cross a
+/// page boundary. Buffer words past the total program as erased (BUFRST
+/// leaves them all-1s).
+pub fn write(addr: u32, segs: &[&[u8]]) {
+    let page_base = addr & !(PAGE_SIZE as u32 - 1);
+    let total: usize = segs.iter().map(|s| s.len()).sum();
+    debug_assert!(
+        (addr as usize & (BUF_LOAD_SIZE - 1)) == 0,
+        "write: addr not word-aligned"
+    );
+    debug_assert!(
+        addr + total as u32 <= page_base + PAGE_SIZE as u32,
+        "write: crosses page boundary"
+    );
+
+    unlock();
+    FLASH.ctlr().write(|w| w.set_ftpg(true));
+    FLASH.ctlr().write(|w| {
+        w.set_ftpg(true);
+        w.set_bufrst(true);
+    });
+    wait_busy();
+
+    let mut buf_addr = addr;
+    for seg in segs {
+        debug_assert!(
+            seg.len().is_multiple_of(BUF_LOAD_SIZE),
+            "write: segment not word-aligned"
+        );
+        let mut ptr = seg.as_ptr() as *const u32;
+        for _ in 0..seg.len() / BUF_LOAD_SIZE {
+            // Sources may sit at any alignment (a stack header array).
+            let word = unsafe { ptr.read_unaligned() };
+            unsafe { core::ptr::write_volatile(buf_addr as *mut u32, word) };
+            FLASH.ctlr().write(|w| {
+                w.set_ftpg(true);
+                w.set_bufload(true);
+            });
+            wait_busy();
+            buf_addr += BUF_LOAD_SIZE as u32;
+            ptr = unsafe { ptr.add(1) };
+        }
+    }
+
+    FLASH.addr().write(|w| w.set_far(page_base));
+    FLASH.ctlr().write(|w| {
+        w.set_ftpg(true);
+        w.set_strt(true);
+    });
+    wait_busy();
+    FLASH.ctlr().write(|_| {});
+    lock();
+}
+
+pub fn boot_mode() -> bool {
+    FLASH.statr().read().boot_mode()
+}
+
+pub fn set_boot_mode(mode: bool) {
+    FLASH.boot_modekeyp().write(|w| w.set_modekeyr(KEY1));
+    FLASH.boot_modekeyp().write(|w| w.set_modekeyr(KEY2));
+    FLASH.statr().modify(|w| w.set_boot_mode(mode));
+}

--- a/firmware/ch32/src/hal/gpio/mod.rs
+++ b/firmware/ch32/src/hal/gpio/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(gpio_v0, path = "v0.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/gpio/v0.rs
+++ b/firmware/ch32/src/hal/gpio/v0.rs
@@ -1,0 +1,83 @@
+use osc_drivers::Level;
+
+use super::super::Pin;
+
+#[derive(Copy, Clone)]
+pub enum Pull {
+    None,
+    Up,
+    Down,
+}
+
+/// Packed: bits 3:0 = CFGLR nibble (MODE low, CNF high), bits 7/6 = ODR high/low.
+/// MODE: INPUT=00, OUTPUT_10MHZ=01. CNF<<2: PP/ANALOG=00, FLOAT/OD=01, PULL/AF_PP=10, AF_OD=11.
+#[derive(Copy, Clone)]
+pub struct PinMode(u8);
+
+impl PinMode {
+    /// MODE=00 + CNF=00. Disconnects the schmitt buffer; required for ADC/OPA
+    /// inputs (floating-input keeps the digital buffer hot and clamps high-Z).
+    pub const ANALOG: Self = Self(0b0000);
+    pub const INPUT_FLOATING: Self = Self(0b0100);
+    pub const INPUT_PULL_UP: Self = Self(0b1000 | 0x80);
+    pub const INPUT_PULL_DOWN: Self = Self(0b1000 | 0x40);
+    pub const OUTPUT_PUSH_PULL: Self = Self(0b0001);
+    pub const OUTPUT_OPEN_DRAIN: Self = Self(0b0101);
+    pub const AF_PUSH_PULL: Self = Self(0b1001);
+    pub const AF_OPEN_DRAIN: Self = Self(0b1101);
+
+    pub fn input_pull(pull: Pull) -> Self {
+        match pull {
+            Pull::Up => Self::INPUT_PULL_UP,
+            Pull::Down => Self::INPUT_PULL_DOWN,
+            Pull::None => Self::INPUT_FLOATING,
+        }
+    }
+}
+
+#[inline(always)]
+pub fn configure(pin: Pin, mode: PinMode) {
+    let regs = pin.gpio_regs();
+    let n = pin.pin_number();
+
+    let shift = n * 4;
+    let mask = !(0xFu32 << shift);
+    let bits = ((mode.0 & 0x0F) as u32) << shift;
+    regs.cfglr().modify(|w| w.0 = (w.0 & mask) | bits);
+
+    if mode.0 & 0xC0 != 0 {
+        regs.outdr().modify(|w| w.set_odr(n, mode.0 & 0x80 != 0));
+    }
+}
+
+/// Raw input level of a pin (INDR read); `true` iff the pin reads low.
+#[inline]
+pub fn is_low(pin: Pin) -> bool {
+    let mask = 1u32 << pin.pin_number();
+    pin.gpio_regs().indr().read().0 & mask == 0
+}
+
+#[inline]
+pub fn set_level(pin: Pin, level: Level) {
+    if level == Level::High {
+        pin.gpio_regs()
+            .bshr()
+            .write(|w| w.0 = 1 << pin.pin_number());
+    } else {
+        pin.gpio_regs().bcr().write(|w| w.0 = 1 << pin.pin_number());
+    }
+}
+
+// SAFETY: see hal/SAFETY.md (Tier 3). BSHR/BCR are atomic single-bit writes;
+// OUTDR RMW would race a higher-priority ISR's BSHR/BCR on another pin of the
+// same port and stomp it.
+#[inline]
+pub fn toggle(pin: Pin) {
+    let regs = pin.gpio_regs();
+    let mask = 1u32 << pin.pin_number();
+    if regs.indr().read().0 & mask != 0 {
+        regs.bcr().write(|w| w.0 = mask);
+    } else {
+        regs.bshr().write(|w| w.0 = mask);
+    }
+}

--- a/firmware/ch32/src/hal/mod.rs
+++ b/firmware/ch32/src/hal/mod.rs
@@ -1,0 +1,40 @@
+mod generated {
+    include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+}
+pub use generated::{Pin, Tim1Mapping, Tim2Mapping, UsartMapping};
+
+pub mod adc;
+pub mod afio;
+pub mod clocks;
+pub mod dma;
+pub mod esig;
+pub mod exti;
+pub mod flash;
+pub mod gpio;
+pub mod opa;
+pub mod pfic;
+pub mod rcc;
+pub mod systick;
+pub mod timer;
+pub mod usart;
+
+#[inline(always)]
+pub fn delay_cycles(n: u32) {
+    for _ in 0..n {
+        core::hint::spin_loop();
+    }
+}
+
+/// Busy-wait for `ms` ms. Reinitializes SYSTICK on entry -- safe to call early.
+pub fn delay_ms(ms: u32) {
+    use ch32_metapac::SYSTICK;
+    use ch32_metapac::systick::vals::Stclk;
+    let target = ms.saturating_mul(clocks::SYSTICK_TICKS_PER_MS);
+    SYSTICK.cmp().write_value(u32::MAX);
+    SYSTICK.cnt().write_value(0);
+    SYSTICK.ctlr().write(|w| {
+        w.set_ste(true);
+        w.set_stclk(Stclk::HCLK);
+    });
+    while SYSTICK.cnt().read() < target {}
+}

--- a/firmware/ch32/src/hal/opa/mod.rs
+++ b/firmware/ch32/src/hal/opa/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(opa_v00x, path = "v00x.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/opa/v00x.rs
+++ b/firmware/ch32/src/hal/opa/v00x.rs
@@ -1,0 +1,144 @@
+use ch32_metapac::OPA;
+
+use crate::hal::Pin;
+
+const KEY1: u32 = 0x4567_0123;
+const KEY2: u32 = 0xCDEF_89AB;
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Gain {
+    X4 = 0b011,
+    X8 = 0b100,
+    X16 = 0b101,
+    X32 = 0b110,
+}
+
+impl Gain {
+    pub const fn factor(self) -> u16 {
+        match self {
+            Gain::X4 => 4,
+            Gain::X8 => 8,
+            Gain::X16 => 16,
+            Gain::X32 => 32,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum PositiveInput {
+    PA2 = 0b00,
+    PD7 = 0b01,
+    PD3 = 0b10,
+    PD1 = 0b11,
+}
+
+impl PositiveInput {
+    pub const fn pin(self) -> Pin {
+        match self {
+            PositiveInput::PA2 => Pin::PA2,
+            PositiveInput::PD7 => Pin::PD7,
+            PositiveInput::PD3 => Pin::PD3,
+            PositiveInput::PD1 => Pin::PD1,
+        }
+    }
+}
+
+/// In PGA differential mode (RM 17.2.1.3), the negative pin is OPA_CHN2 (PA4).
+#[derive(Copy, Clone)]
+pub enum NegativeInput {
+    PA4,
+}
+
+impl NegativeInput {
+    pub const fn pin(self) -> Pin {
+        match self {
+            NegativeInput::PA4 => Pin::PA4,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum InputMode {
+    SingleEnded(PositiveInput),
+    Differential {
+        pos: PositiveInput,
+        neg: NegativeInput,
+    },
+}
+
+impl InputMode {
+    pub const fn pos(self) -> PositiveInput {
+        match self {
+            InputMode::SingleEnded(p) => p,
+            InputMode::Differential { pos, .. } => pos,
+        }
+    }
+
+    pub const fn neg_pin(self) -> Option<Pin> {
+        match self {
+            InputMode::SingleEnded(_) => None,
+            InputMode::Differential { neg, .. } => Some(neg.pin()),
+        }
+    }
+}
+
+/// PGA output bias (RM 17.2.1.4 / OPA_CTLR1.VBEN + VBSEL).
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Bias {
+    /// ~VDD/2 quiescent.
+    MidRail = 0,
+    /// ~VDD/4 quiescent.
+    QuarterRail = 1,
+}
+
+impl Bias {
+    pub const fn quiescent_raw(self) -> u16 {
+        match self {
+            Bias::MidRail => 2048,
+            Bias::QuarterRail => 1024,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Output {
+    PD4 = 0b00,
+    PA5 = 0b01,
+    /// CMP2 input + ADC channel 9, no pin.
+    Internal = 0b11,
+}
+
+#[derive(Copy, Clone)]
+pub struct Config {
+    pub input: InputMode,
+    pub gain: Gain,
+    pub bias: Bias,
+    pub output: Output,
+}
+
+fn unlock() {
+    OPA.opa_key().write(|w| w.set_opa_key(KEY1));
+    OPA.opa_key().write(|w| w.set_opa_key(KEY2));
+}
+
+/// Configures OPA1 as a PGA (RM 17.2.1.2-4). Caller settles before sampling.
+pub fn init(cfg: &Config) {
+    unlock();
+    OPA.ctlr1().write(|w| {
+        w.set_opa_hs1(true);
+        // VBCMPSEL feeds CMP2 only; 0b11 leaves it unselected.
+        w.set_vbcmpsel(0b11);
+        w.set_vbsel(matches!(cfg.bias, Bias::QuarterRail));
+        w.set_vben(true);
+        w.set_pgadif(matches!(cfg.input, InputMode::Differential { .. }));
+        w.set_fb_en1(true);
+        w.set_nsel1(cfg.gain as u8);
+        w.set_psel1(cfg.input.pos() as u8);
+        w.set_mode1(cfg.output as u8);
+        w.set_opa_en1(true);
+    });
+}

--- a/firmware/ch32/src/hal/pfic/mod.rs
+++ b/firmware/ch32/src/hal/pfic/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(pfic_rv2, path = "rv2.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/pfic/rv2.rs
+++ b/firmware/ch32/src/hal/pfic/rv2.rs
@@ -1,0 +1,78 @@
+use ch32_metapac::PFIC;
+use ch32_metapac::pfic::vals::Keycode;
+
+pub use ch32_metapac::Interrupt;
+
+/// QingKe V2 core IRQ for SysTick (not in metapac `Interrupt`).
+const SYSTICK_IRQ: u32 = 12;
+
+/// QingKe V2A IPRIORn bit 7 selects preemption class; subpriority bits unused.
+#[derive(Copy, Clone)]
+pub enum Priority {
+    High,
+    Low,
+}
+
+impl Priority {
+    #[inline]
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::High => 0x00,
+            Self::Low => 0x80,
+        }
+    }
+}
+
+#[inline]
+pub fn enable(irq: Interrupt) {
+    let n = irq as u16;
+    let bit = 1u32 << (n % 32);
+    match n / 32 {
+        0 => PFIC.ienr1().write(|w| w.0 = bit),
+        1 => PFIC.ienr2().write(|w| w.0 = bit),
+        2 => PFIC.ienr3().write(|w| w.0 = bit),
+        3 => PFIC.ienr4().write(|w| w.0 = bit),
+        _ => {}
+    }
+}
+
+/// qingke-rt v2 init sets STIE + mstatus.MIE but never writes PFIC IENR1
+/// bit 12; without this, CNTIF latches but the SysTick vector never fires.
+#[inline]
+pub fn enable_systick() {
+    PFIC.ienr1().write(|w| w.0 = 1 << SYSTICK_IRQ);
+}
+
+/// Force the SysTick IRQ to dispatch on the next vector entry, independent
+/// of CNT == CMP. Used by `FastLastScheduler::schedule` when the requested
+/// deadline is already in the past: writing CMP near `now` races the few
+/// HCLK cycles between reading CNT and the CMP store, often leaving CMP
+/// behind CNT -- at which point the next CNT == CMP match is a u32 wrap
+/// (~89 s) away, wedging the chip. Pending the IRQ directly via IPSR1
+/// sidesteps the match entirely. Write-only register; bit-set semantics
+/// (other bits unaffected).
+#[inline]
+pub fn pend_systick() {
+    PFIC.ipsr1().write(|w| w.0 = 1 << SYSTICK_IRQ);
+}
+
+#[inline]
+pub fn set_priority(irq: Interrupt, prio: Priority) {
+    PFIC.iprior(irq as usize).write_value(prio.as_u8());
+}
+
+#[inline]
+pub fn set_systick_priority(prio: Priority) {
+    PFIC.iprior(SYSTICK_IRQ as usize).write_value(prio.as_u8());
+}
+
+pub fn software_reset() -> ! {
+    ch32_metapac::RCC.rstsckr().write(|w| w.0 = 1 << 24);
+    PFIC.cfgr().write(|w| {
+        w.set_keycode(Keycode(0xBEEF));
+        w.set_resetsys(true);
+    });
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/firmware/ch32/src/hal/rcc/mod.rs
+++ b/firmware/ch32/src/hal/rcc/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(rcc_v00x, path = "v00x.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/rcc/v00x.rs
+++ b/firmware/ch32/src/hal/rcc/v00x.rs
@@ -1,0 +1,81 @@
+use ch32_metapac::{
+    FLASH, RCC,
+    rcc::vals::{Pllsrc, Sw},
+};
+
+use crate::hal::clocks::{HSI_HZ, HSI_TRIM_STEP_HZ, adcpre_val, hpre_val};
+
+pub fn init_pll() {
+    const HPRE: ch32_metapac::rcc::vals::Hpre = hpre_val();
+    const ADCPRE: ch32_metapac::rcc::vals::Adcpre = adcpre_val();
+
+    FLASH.actlr().modify(|w| w.set_latency(2));
+
+    RCC.cfgr0().modify(|w| {
+        w.set_pllsrc(Pllsrc::HSI);
+        w.set_hpre(HPRE);
+        w.set_adcpre(ADCPRE);
+    });
+
+    RCC.ctlr().modify(|w| w.set_pllon(true));
+    while !RCC.ctlr().read().pllrdy() {}
+
+    RCC.cfgr0().modify(|w| w.set_sw(Sw::PLL));
+    while RCC.cfgr0().read().sws() != Sw::PLL {}
+}
+
+#[inline]
+pub fn enable_gpio(port_index: usize) {
+    RCC.pb2pcenr().modify(|w| w.0 |= 1 << (2 + port_index));
+}
+
+#[inline]
+pub fn enable_afio() {
+    RCC.pb2pcenr().modify(|w| w.set_afioen(true));
+}
+
+#[inline]
+pub fn enable_tim1() {
+    RCC.pb2pcenr().modify(|w| w.set_tim1en(true));
+}
+
+#[inline]
+pub fn enable_adc1() {
+    RCC.pb2pcenr().modify(|w| w.set_adcen(true));
+}
+
+#[inline]
+pub fn enable_dma1() {
+    RCC.hbpcenr().modify(|w| w.set_dma1en(true));
+}
+
+#[inline]
+pub fn enable_usart1() {
+    RCC.pb2pcenr().modify(|w| w.set_usart1en(true));
+}
+
+#[inline]
+pub fn enable_spi1() {
+    RCC.pb2pcenr().modify(|w| w.set_spi1en(true));
+}
+
+/// HSITRIM[4:0] reset value -- the V006 factory mid-trim default.
+const HSITRIM_DEFAULT: i16 = 16;
+/// HSITRIM[4:0] valid range upper bound.
+const HSITRIM_MAX: i16 = 31;
+
+/// u64 inside the const eval: STEP_HZ * 1_000_000 overflows u32.
+pub const CLOCK_TRIM_PPM_PER_STEP: u32 =
+    (HSI_TRIM_STEP_HZ as u64 * 1_000_000 / HSI_HZ as u64) as u32;
+
+/// Apply the driver-level trim total (`TrimLoop` contract: signed steps
+/// from the factory default, positive = SLOW the oscillator). The register
+/// direction is this adapter's to know: V006 HSITRIM runs higher = faster
+/// (measured: register 6 ran ~2% slow; a same-sign mapping fed the trim
+/// loop positive and railed the fleet in -4 clamps) -- so the mapping
+/// negates. ~0.25% HSI rate per step; clamped to the register.
+#[inline]
+pub fn apply_clock_trim(slow_steps: i8) {
+    let v = (HSITRIM_DEFAULT - slow_steps as i16).clamp(0, HSITRIM_MAX) as u8;
+    RCC.ctlr().modify(|w| w.set_hsitrim(v));
+}

--- a/firmware/ch32/src/hal/systick/mod.rs
+++ b/firmware/ch32/src/hal/systick/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(systick_rv2, path = "rv2.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/systick/rv2.rs
+++ b/firmware/ch32/src/hal/systick/rv2.rs
@@ -1,0 +1,48 @@
+use ch32_metapac::SYSTICK;
+use ch32_metapac::systick::vals::Stclk;
+
+pub use crate::hal::clocks::SYSTICK_TICKS_PER_US as TICKS_PER_US;
+
+pub fn init() {
+    SYSTICK.cmp().write_value(u32::MAX);
+    SYSTICK.cnt().write_value(0);
+    SYSTICK.ctlr().write(|w| {
+        w.set_ste(true);
+        w.set_stclk(Stclk::HCLK);
+    });
+}
+
+#[inline(always)]
+pub fn ticks() -> u32 {
+    SYSTICK.cnt().read()
+}
+
+#[inline(always)]
+pub fn set_cmp(value: u32) {
+    SYSTICK.cmp().write_value(value);
+}
+
+#[inline(always)]
+pub fn cmp() -> u32 {
+    SYSTICK.cmp().read()
+}
+
+// SAFETY: see hal/SAFETY.md. CTLR is written from MAIN and HIGH ISRs (SysTick
+// and USART1 TC); CS keeps STIE RMW atomic.
+#[inline(always)]
+pub fn set_irq(enable: bool) {
+    critical_section::with(|_| {
+        SYSTICK.ctlr().modify(|w| w.set_stie(enable));
+    });
+}
+
+/// CNTIF latched -- a compare match occurred since the last clear.
+#[inline(always)]
+pub fn matched() -> bool {
+    SYSTICK.sr().read().cntif()
+}
+
+#[inline(always)]
+pub fn clear_match() {
+    SYSTICK.sr().write(|w| w.set_cntif(false));
+}

--- a/firmware/ch32/src/hal/timer/mod.rs
+++ b/firmware/ch32/src/hal/timer/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(timer_v3, path = "v3.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/timer/v3.rs
+++ b/firmware/ch32/src/hal/timer/v3.rs
@@ -1,0 +1,113 @@
+use ch32_metapac::TIM1;
+use ch32_metapac::timer::vals::{Cms, Mms, Ocm};
+
+use crate::hal::clocks::TIM_CLK_HZ;
+
+#[derive(Copy, Clone)]
+pub enum Polarity {
+    ActiveHigh,
+    ActiveLow,
+}
+
+/// Center-aligned period = `2 * arr * (psc + 1)` timer ticks; picks smallest psc that fits ARR in u16.
+pub const fn pwm_dividers_from_hz(freq_hz: u32) -> (u16, u16) {
+    let denom = 2 * freq_hz;
+    let mut psc: u32 = 0;
+    loop {
+        let arr = TIM_CLK_HZ / (denom * (psc + 1));
+        if arr > 0 && arr <= u16::MAX as u32 {
+            return (psc as u16, arr as u16);
+        }
+        psc += 1;
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(u8)]
+pub enum Channel {
+    CH1 = 1,
+    CH2 = 2,
+    CH3 = 3,
+    CH4 = 4,
+}
+
+/// Sets ARPE: CCR/ARR writes take effect at next UEV, not immediately.
+pub fn init_center_aligned_pwm(prescaler: u16, period: u16) {
+    TIM1.psc().write_value(prescaler);
+    TIM1.atrlr().write_value(period);
+    TIM1.ctlr1().modify(|w| {
+        w.set_cms(Cms::CENTERALIGNED3);
+        w.set_arpe(true);
+    });
+}
+
+pub fn configure_pwm_channel(ch: Channel, polarity: Polarity) {
+    let n = (ch as u8 - 1) as usize;
+    TIM1.chctlr_output(n / 2).modify(|w| {
+        w.set_ocm(n % 2, Ocm::PWMMODE1);
+        w.set_ocpe(n % 2, true);
+    });
+    TIM1.ccer().modify(|w| {
+        w.set_cce(n, true);
+        w.set_ccp(n, matches!(polarity, Polarity::ActiveLow));
+    });
+}
+
+#[inline]
+pub fn set_duty(ch: Channel, value: u16) {
+    TIM1.chcvr((ch as u8 - 1) as usize).write_value(value);
+}
+
+/// RCR=0 with center-aligned -> UEV at both peak and trough.
+pub fn set_repetition(rcr: u8) {
+    TIM1.rptcr().write(|w| w.set_rptcr(rcr));
+}
+
+pub fn set_trgo_update() {
+    TIM1.ctlr2().modify(|w| w.set_mms(Mms::UPDATE));
+}
+
+/// Fires TRGO as a side effect -- arm ADC after, not before.
+pub fn force_update_event() {
+    TIM1.swevgr().write(|w| w.set_ug(true));
+}
+
+pub fn enable_main_output() {
+    TIM1.bdtr().modify(|w| w.set_moe(true));
+}
+
+pub fn start() {
+    TIM1.ctlr1().modify(|w| w.set_cen(true));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn realised_hz(psc: u16, arr: u16) -> u32 {
+        TIM_CLK_HZ / (2 * (psc as u32 + 1) * arr as u32)
+    }
+
+    #[test]
+    fn pwm_dividers_pin_production_freq() {
+        let (psc, arr) = pwm_dividers_from_hz(20_000);
+        assert_eq!((psc, arr), (0, 1200));
+        assert_eq!(realised_hz(psc, arr), 20_000);
+    }
+
+    #[test]
+    fn pwm_dividers_fits_low_freq() {
+        // 50 Hz needs a prescaler; product (psc+1)*arr fits u32.
+        let (psc, arr) = pwm_dividers_from_hz(50);
+        assert!(arr > 0);
+        let realised = realised_hz(psc, arr);
+        assert!((45..=55).contains(&realised), "got {realised}");
+    }
+
+    #[test]
+    fn pwm_dividers_high_freq() {
+        let (psc, arr) = pwm_dividers_from_hz(100_000);
+        assert_eq!(psc, 0);
+        assert_eq!(realised_hz(psc, arr), 100_000);
+    }
+}

--- a/firmware/ch32/src/hal/usart/mod.rs
+++ b/firmware/ch32/src/hal/usart/mod.rs
@@ -1,0 +1,4 @@
+#[cfg_attr(usart_common, path = "usart_common.rs")]
+mod family;
+
+pub use family::*;

--- a/firmware/ch32/src/hal/usart/usart_common.rs
+++ b/firmware/ch32/src/hal/usart/usart_common.rs
@@ -1,0 +1,153 @@
+pub use ch32_metapac::usart::Usart as Regs;
+
+/// osc-native bus bring-up, in the break-framing spike's exact order:
+/// wire mode (`hdsel` = true for the direct single-wire, false for plain
+/// full duplex behind the rev B buffer), break detector, TE/RE, BRR, UE --
+/// and only then DMAR in a second CTLR3 write. The sequencing is
+/// load-bearing for the released idle level on the direct wire: deviations
+/// (TE before HDSEL, or DMAR folded into the HDSEL write) leave the HDSEL
+/// TX signal latched LOW -- through the AF_OD listening pin that clamps the
+/// whole bus (wire stuck low at idle, rose the moment PC0 left AF mode).
+/// No IDLE interrupt -- the framer sources all timing from the ring cursor
+/// and SysTick, never from IDLE.
+///
+/// LBDIE is the ONLY receive interrupt (protocol sec 3.4): the
+/// length-qualified break detector runs with the LIN engine off (LINEN
+/// stays reset-0 -- F15, both chip families), and EIE is never set --
+/// FE/NE/ORE latch silently and nothing services them.
+#[inline]
+pub fn init_bus(r: Regs, brr: u32, hdsel: bool) {
+    r.ctlr3().modify(|w| w.set_hdsel(hdsel));
+    r.ctlr2().modify(|w| {
+        w.set_lbdl(false); // 10-bit detection: the protocol sec 3 law break is exactly 10
+        w.set_lbdie(true);
+    });
+    r.ctlr1().modify(|w| {
+        w.set_te(true);
+        w.set_re(true);
+    });
+    r.brr().write_value(ch32_metapac::usart::regs::Brr(brr));
+    r.ctlr1().modify(|w| w.set_ue(true));
+    r.ctlr3().modify(|w| w.set_dmar(true));
+}
+
+/// Send the protocol-law break (protocol sec 3): one 9-bit
+/// `0x00` character under a bracketed M=1 -- start + 9 data lows = 10 low
+/// bit-times, then a clean stop. Replaces SBK, whose ~14-bit shape is
+/// off-law and a byte-sync hazard at LIN-mode receivers (the pirate, and
+/// bridge-class hosts: their break detector re-arms start hunting at bit
+/// 10 while SBK still holds the line low -- measured per-servo
+/// phase-dependent head-of-reply corruption).
+///
+/// Blocks until the character's stop bit commits (TC), the same
+/// shifter-state contract the SBK path kept: when this returns the wire
+/// has carried the whole break, DR is free for arm0's first byte, and
+/// the M flips have bracketed a COMPLETED character -- no format change
+/// ever touches a shifting byte. Runs only inside the TX claim window,
+/// where RX is muted (HDSEL, F9) or held at mark (buffer), so the M
+/// flips are invisible to our own receiver. The wait bound is the
+/// no-panic plateau backstop, not a wait that ever runs in practice.
+#[inline(always)]
+pub fn send_break(r: Regs) {
+    r.ctlr1().modify(|w| w.set_m(true));
+    clear_tc(r);
+    r.datar().write(|w| w.set_dr(0));
+    let mut bound = BREAK_COMMIT_SPINS;
+    while !r.statr().read().tc() && bound > 0 {
+        bound -= 1;
+        core::hint::spin_loop();
+    }
+    r.ctlr1().modify(|w| w.set_m(false));
+}
+
+/// Break-commit poll bound: the law break is 11 bit-times (~22 us at the
+/// 0.5M rescue floor ~= 1050 HCLK cycles); 4096 covers it with slack.
+const BREAK_COMMIT_SPINS: u32 = 4096;
+
+/// Live BRR write -- no UE bounce. Caller must ensure no TX/RX is in flight
+/// (retuning mid-byte garbages the wire); the driver applies baud changes
+/// only on an idle bus (protocol sec 4.2 deferred config). The UE bounce
+/// is avoided for cause: dropping UE re-latches the HDSEL TX output to the
+/// inactive-AF level (0), and through the AF_OD listening pin that clamps
+/// the whole bus until the next own-TX (measured; the break-framing
+/// path never bounces UE and its idle line sits released-high).
+#[inline]
+pub fn set_baud(r: Regs, brr: u32) {
+    r.brr().write_value(ch32_metapac::usart::regs::Brr(brr));
+}
+
+// SAFETY: see hal/SAFETY.md. CTLR3 is written from MAIN and the USART1 TC
+// ISR; CS keeps RMW atomic against future different-bit additions.
+// `inline(always)` folds this into the TIM2 CC3 hot path so the wire-driver
+// activate sequence stays inside the `.highcode` body -- no standalone flash
+// fetch per call.
+#[inline(always)]
+pub fn set_dma_tx(r: Regs, enable: bool) {
+    critical_section::with(|_| {
+        r.ctlr3().modify(|w| w.set_dmat(enable));
+    });
+}
+
+#[inline]
+pub fn data_addr(r: Regs) -> u32 {
+    r.datar().as_ptr() as u32
+}
+
+// SAFETY: see hal/SAFETY.md. CTLR1 is written from MAIN and the USART1 TC
+// ISR (here, and the UE toggle in set_baud).
+// `inline(always)` folds this into the TIM2 CC3 hot path so the wire-driver
+// activate sequence stays inside the `.highcode` body -- no standalone flash
+// fetch per call.
+#[inline(always)]
+pub fn set_tc_irq(r: Regs, enable: bool) {
+    critical_section::with(|_| {
+        r.ctlr1().modify(|w| w.set_tcie(enable));
+    });
+}
+
+// SAFETY: see hal/SAFETY.md. STATR.modify is the only write-0-to-clear bit
+// path on this register today; CS guards against future write-clear additions.
+// `inline(always)` folds this into the TIM2 CC3 hot path so the wire-driver
+// activate sequence stays inside the `.highcode` body -- no standalone flash
+// fetch per call.
+#[inline(always)]
+pub fn clear_tc(r: Regs) {
+    critical_section::with(|_| {
+        r.statr().modify(|w| w.set_tc(false));
+    });
+}
+
+/// One STATR image per ISR entry -- the vector branches off this single
+/// read. The read is side-effect-free for the transport: it arms the SR
+/// half of the hardware's SR-then-DR pair, but nothing on the receive side
+/// ever performs the DR half (no DATAR reads, transport sec 7), so no flag
+/// state changes hang off it.
+#[inline(always)]
+pub fn statr(r: Regs) -> ch32_metapac::usart::regs::Statr {
+    r.statr().read()
+}
+
+/// Retire the serviced break flag: a flag-selective constant write -- every
+/// bit 1 (a no-op on rc_w0 bits), LBD's bit 0. NEVER an RMW: a
+/// read-modify-write races rc_w0 bits setting between the read and the
+/// write-back, and never a DATAR read: that kills a
+/// mid-reception byte in the shifter. LBD is the one
+/// STATR flag with a documented write-0 clear (RM: RW0); FE/NE/ORE are RO
+/// and are never cleared -- with EIE off they latch silently (transport sec 7).
+#[inline(always)]
+pub fn clear_lbd(r: Regs) {
+    r.statr().write(|w| {
+        w.0 = u32::MAX;
+        w.set_lbd(false);
+    });
+}
+
+#[inline]
+pub fn is_tc(r: Regs) -> bool {
+    r.statr().read().tc()
+}
+
+#[inline]
+pub fn is_tcie(r: Regs) -> bool {
+    r.ctlr1().read().tcie()
+}

--- a/firmware/ch32/src/lib.rs
+++ b/firmware/ch32/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+#![feature(sync_unsafe_cell)]
+#![allow(unexpected_cfgs)]
+
+pub use osc_core::bp;
+pub use osc_core::{BaudRate, ConfigDefaults};
+
+pub mod cfg;
+pub mod control;
+pub mod hal;
+pub mod log;
+pub mod prelude;
+pub(crate) mod providers;
+pub mod runtime;

--- a/firmware/ch32/src/log.rs
+++ b/firmware/ch32/src/log.rs
@@ -1,0 +1,7 @@
+//! Logging facade -- forwards to `defmt` or no-op via the shared `osc-log`
+//! crate; re-exported here so call sites keep using `crate::log::*`. ch32 is
+//! embedded-only (no host `log` arm): without `defmt` it no-ops. ch32 *invokes*
+//! the macros, so it keeps its own `defmt` dep and forwards `osc-log/defmt`
+//! (see osc-log).
+
+pub use osc_log::{debug, error, info, trace, warn};

--- a/firmware/ch32/src/prelude.rs
+++ b/firmware/ch32/src/prelude.rs
@@ -1,0 +1,11 @@
+pub use osc_drivers::Level;
+
+#[cfg(not(feature = "half-duplex"))]
+pub use crate::cfg::BusWiring;
+pub use crate::cfg::{
+    AdcPins, AnalogChannel, BoardConfig, BoardWiring, Calibration, CurrentSenseConfig, DigitalPin,
+    Divider, DrvEn, NtcCal,
+};
+pub use crate::hal::{Pin, opa};
+pub use crate::{BaudRate, ConfigDefaults};
+pub use osc_core::regions::config::DEFAULT_RESPONSE_DEADLINE_US;

--- a/firmware/ch32/src/providers/config_store.rs
+++ b/firmware/ch32/src/providers/config_store.rs
@@ -1,0 +1,132 @@
+//! ConfigStore provider (protocol sec 9.4): the two CONFIG flash slots with
+//! A/B alternation, plus the boot-time overlay. Both `save` and `wipe` are
+//! blocking -- the CPU fetch-stalls for every erase/program while code runs
+//! from flash -- which is exactly the protocol sec 9.4 contract (dispatch's
+//! torque gate makes the stall safe, the post-completion ack makes it visible).
+
+use core::cell::SyncUnsafeCell;
+
+use osc_core::persist::{self, CONFIG_LEN, HEADER_LEN, IMAGE_LEN, PROFILE_LEN, Slot, StoreError};
+
+use crate::hal::flash;
+use crate::runtime::statics::SHARED;
+
+/// Slot bases come from this crate's `osc-config.x` fragment (shipped into
+/// the link search path by build.rs; the board binary passes
+/// `-Tosc-config.x`), resolved against the board's CONFIG_A/B regions -- the
+/// flash layout has exactly one home. The target gate is deterministic host
+/// hygiene: an ungated extern symbol links on the host only while no pulled
+/// codegen unit references it, which is CGU-partition luck; host builds
+/// (unit tests) never call the store, so they get a stub instead of a
+/// link-time coupling.
+#[cfg(target_arch = "riscv32")]
+fn slot_addr(slot: Slot) -> u32 {
+    unsafe extern "C" {
+        static _config_a: u8;
+        static _config_b: u8;
+    }
+    match slot {
+        Slot::A => (&raw const _config_a) as u32,
+        Slot::B => (&raw const _config_b) as u32,
+    }
+}
+
+#[cfg(not(target_arch = "riscv32"))]
+fn slot_addr(_slot: Slot) -> u32 {
+    unimplemented!("host builds never touch the flash store")
+}
+
+/// The slot's stored image bytes, memory-mapped.
+fn slot_bytes(slot: Slot) -> &'static [u8] {
+    // SAFETY: memory.x reserves both windows inside main flash, which is
+    // always readable and never holds code.
+    unsafe { core::slice::from_raw_parts(slot_addr(slot) as *const u8, IMAGE_LEN) }
+}
+
+struct State {
+    next_slot: Slot,
+    next_seq: u16,
+}
+
+pub struct ConfigStore {
+    /// Written by `boot_load` (pre-IRQ), then only from HIGH dispatch (the
+    /// SESSION exclusivity invariant, `runtime::isr`) -- never concurrent.
+    state: SyncUnsafeCell<State>,
+}
+
+static CONFIG_STORE: ConfigStore = ConfigStore {
+    state: SyncUnsafeCell::new(State {
+        next_slot: Slot::A,
+        next_seq: 1,
+    }),
+};
+
+impl ConfigStore {
+    /// Boot-time load: overlay the newest valid image onto the (already
+    /// default-seeded) table, prime the A/B state, and seed the store into
+    /// `SHARED`. Bringup-only, pre-IRQ; sole writer (the
+    /// `seed_config_defaults` contract).
+    pub fn boot_load() {
+        let pick = persist::boot_overlay(&SHARED.table, slot_bytes(Slot::A), slot_bytes(Slot::B));
+        // SAFETY: pre-IRQ sole writer, see fn doc.
+        unsafe {
+            *CONFIG_STORE.state.get() = State {
+                next_slot: pick.next_slot,
+                next_seq: pick.next_seq,
+            }
+        };
+        SHARED.seed_store(&CONFIG_STORE);
+        crate::log::debug!(
+            "config store: loaded={} next_seq={}",
+            pick.loaded,
+            pick.next_seq,
+        );
+    }
+}
+
+impl osc_core::ConfigStore for ConfigStore {
+    /// Erase the older slot, stream header + regions straight into the page
+    /// buffer (no staging copy), then readback-verify -- the verify is what
+    /// lets the ack mean durable.
+    fn save(
+        &self,
+        config: &[u8; CONFIG_LEN],
+        profile: &[u8; PROFILE_LEN],
+    ) -> Result<(), StoreError> {
+        // SAFETY: HIGH-dispatch exclusive after boot, see the field doc.
+        let state = unsafe { &mut *self.state.get() };
+        let addr = slot_addr(state.next_slot);
+        let header = persist::header(state.next_seq, config, profile);
+        flash::erase(addr);
+        flash::write(addr, &[&header, config, profile]);
+
+        let stored = slot_bytes(state.next_slot);
+        let intact = stored[..HEADER_LEN] == header
+            && stored[HEADER_LEN..HEADER_LEN + CONFIG_LEN] == config[..]
+            && stored[HEADER_LEN + CONFIG_LEN..] == profile[..];
+        if !intact {
+            return Err(StoreError);
+        }
+        state.next_slot = state.next_slot.other();
+        state.next_seq = state.next_seq.wrapping_add(1);
+        Ok(())
+    }
+
+    fn wipe(&self) -> Result<(), StoreError> {
+        flash::erase(slot_addr(Slot::A));
+        flash::erase(slot_addr(Slot::B));
+        for slot in [Slot::A, Slot::B] {
+            if slot_bytes(slot).iter().any(|&b| b != 0xFF) {
+                return Err(StoreError);
+            }
+        }
+        // SAFETY: HIGH-dispatch exclusive after boot, see the field doc.
+        unsafe {
+            *self.state.get() = State {
+                next_slot: Slot::A,
+                next_seq: 1,
+            }
+        };
+        Ok(())
+    }
+}

--- a/firmware/ch32/src/providers/crc.rs
+++ b/firmware/ch32/src/providers/crc.rs
@@ -1,0 +1,185 @@
+//! CRC-engine provider (protocol sec 3.2, F6) -- SPI1 as a DMA-fed CRC
+//! coprocessor. DMA1_CH3 shifts the covered span through SPI1's CRC unit
+//! (16-bit LSB-first = natural-order CRC-16/ARC = osc-CRC-16, protocol sec 3.2); the
+//! accumulator holds across arms so a ring-wrap split or a multi-span read
+//! sums into one CRC.
+//!
+//! A remap places FUNCTIONS, used or not (the TIM1-Remap7 CH1N-on-PC0
+//! lesson): SPI1's reset mapping puts SCK/PC5 and MOSI/PC6 on the motor's
+//! TIM1 AF pins, where every CRC feed would burst 24 MHz clock into the
+//! gate-drive mux. Remap 101 parks SCK/PA1 and MOSI/PA2 on analog-mode
+//! pins (digital driver disconnected -- provably inert on this board),
+//! MISO/PB5 is an input, and NSS stays internal under SSM.
+//!
+//! Register recipe ported from the `spi_crc` bringup spike (case 9: CRCEN
+//! held across feeds accumulates).
+
+use core::cell::SyncUnsafeCell;
+
+use ch32_metapac::SPI1;
+use ch32_metapac::spi::vals::BaudRate as SpiBaud;
+use osc_drivers::traits::bus;
+use osc_protocol::wire::MAX_PAYLOAD;
+
+use crate::hal::{afio, dma, rcc};
+
+/// osc-CRC-16 polynomial (protocol sec 3.2: CRC-16/ARC; the engine register takes the
+/// non-reflected form, LSBFIRST supplies the reflection).
+const OSC_CRC_POLY: u16 = 0x8005;
+
+/// Bounded drain spin between successive feeds (the engine runs ~8x wire
+/// speed, F6). An expiry leaves a partial accumulator -> the frame fails CRC
+/// and drops, which is the sanctioned "spin miss = fail" outcome (protocol sec 3.2).
+const FEED_DRAIN_SPIN: u32 = 4096;
+
+/// The snapshot buffer (protocol sec 4.2): a reply payload is CH6-copied here once, and
+/// both the CRC feed (CH3) and the wire arms (CH4) stream the copy -- the reply
+/// CRC covers exactly the transmitted bytes. RX CRC feeds the ring directly
+/// (no staging), so this holds only a reply payload -- one `MAX_PAYLOAD` span.
+/// Even base (`repr(align(2))`): the feed reads halfwords from it.
+const SNAPSHOT_LEN: usize = MAX_PAYLOAD as usize;
+
+#[repr(align(2))]
+struct Snapshot([u8; SNAPSHOT_LEN]);
+
+static SNAPSHOT: SyncUnsafeCell<Snapshot> = SyncUnsafeCell::new(Snapshot([0; SNAPSHOT_LEN]));
+
+/// Production binding to SPI1 + DMA1_CH3.
+pub struct Crc;
+
+impl Crc {
+    /// One-shot peripheral bring-up (driver-pattern sec 5.5): clock-gate SPI1,
+    /// lock master / SSM / 16-bit mode, load the poly, enable the calculator
+    /// last (resets it with the mode fixed), then SPE + TX-DMA. Held live for
+    /// the whole program -- `reset` re-zeros the accumulator per frame.
+    pub fn init() {
+        rcc::enable_spi1();
+        // Park the SPI functions off the motor pins (module doc). Verify
+        // by behavior (CRC stays bit-exact): a debugger PCFR1 dump has
+        // disagreed with behaviorally-proven remap state before.
+        afio::set_spi_remap(1, 0b101);
+        SPI1.ctlr1().write(|w| {
+            w.set_mstr(true);
+            w.set_ssm(true);
+            w.set_ssi(true);
+            w.set_br(SpiBaud::DIV_2);
+            // 16-bit LSB-first: each little-endian halfword shifts low byte
+            // first, low bit first -- natural wire byte order, so the engine
+            // computes CRC-16/ARC with no pair packing (protocol sec 3.2, spike
+            // spi_crc_lsb_copy). TCRCR holds the bit-reversed checksum;
+            // `result` un-reverses it.
+            w.set_dff(true);
+            w.set_lsbfirst(true);
+        });
+        SPI1.crcr().write(|w| w.set_crcpoly(OSC_CRC_POLY));
+        SPI1.ctlr1().modify(|w| w.set_crcen(true));
+        SPI1.ctlr2().write(|w| w.set_txdmaen(true));
+        SPI1.ctlr1().modify(|w| w.set_spe(true));
+    }
+
+    /// DMA emptied and the shifter idled (spike `drain` predicate).
+    #[inline(always)]
+    fn drained() -> bool {
+        dma::remaining(dma::Channel::CH3) == 0
+            && SPI1.statr().read().txe()
+            && !SPI1.statr().read().bsy()
+    }
+
+    fn arm(maddr: u32, halfwords: u16) {
+        dma::disable(dma::Channel::CH3);
+        let cfg = dma::Config {
+            dir: dma::Dir::FROMMEMORY,
+            circ: false,
+            pinc: false,
+            minc: true,
+            size: dma::Size::BITS16,
+            htie: false,
+            tcie: false,
+            // MEDIUM: the feed sits at the ladder floor (see `hal::dma`), below
+            // CH6 so a reply snapshot is written before this reads it.
+            pl: dma::Pl::MEDIUM,
+        };
+        dma::configure(
+            dma::Channel::CH3,
+            &cfg,
+            SPI1.datar().as_ptr() as u32,
+            maddr,
+            halfwords,
+        );
+        dma::enable(dma::Channel::CH3);
+    }
+}
+
+impl bus::CrcEngine for Crc {
+    fn reset(&mut self) {
+        // Toggling CRCEN off->on clears the accumulator with the mode locked.
+        // DMA channels are deliberately untouched: disabling one mid-transfer
+        // freezes CNTR nonzero, so every later drain spin runs its full
+        // backstop budget (~2.1 ms) -- and a killed CH6
+        // snapshot copy ships a stale reply tail (the wire arms read it,
+        // protocol sec 4.2). Left alone, in-flight transfers drain to zero in us.
+        SPI1.ctlr1().modify(|w| w.set_crcen(false));
+        SPI1.ctlr1().modify(|w| w.set_crcen(true));
+    }
+
+    fn feed(&mut self, span: &[u8]) {
+        // Drain a prior arm before re-pointing the channel (bounded).
+        let mut budget = FEED_DRAIN_SPIN;
+        while !Self::drained() && budget != 0 {
+            budget -= 1;
+            core::hint::spin_loop();
+        }
+        // Sources are even-based by construction (frame buffer head or the
+        // snapshot buffer, trait contract); even length per the fold contract.
+        Self::arm(span.as_ptr() as u32, (span.len() / 2) as u16);
+    }
+
+    fn snapshot(&mut self, off: u16, src: &[u8]) -> *const u8 {
+        // Best-effort streaming copy of a reply payload, fire-and-forget: CH6
+        // runs HIGH, above CH3 (the CRC feed, MEDIUM), so the feed can't
+        // overtake the copy it reads (producer -> consumer, see `hal::dma`). The
+        // wire (CH4) reads it too but only reaches the payload arm byte-times
+        // later, by which point this us-scale copy is long done. No spin, no
+        // lock: a kernel tick tearing the image by a us-window is fine -- wire
+        // and CRC both read the copy, so the reply stays CRC-consistent (protocol sec 4.2).
+        // RX CRC no longer snapshots (it feeds the ring directly), so this
+        // holds one reply payload per exchange -- a gathered reply (protocol sec 5.2) lands
+        // as several spans at cumulative offsets; only the LAST copy stays
+        // fire-and-forget, so drain any prior span still in flight before
+        // re-pointing the channel (bounded; M2M outruns this spin by design).
+        debug_assert!(off as usize + src.len() <= SNAPSHOT_LEN);
+        let mut budget = FEED_DRAIN_SPIN;
+        while dma::remaining(dma::Channel::CH6) != 0 && budget != 0 {
+            budget -= 1;
+            core::hint::spin_loop();
+        }
+        // SAFETY: single writer per exchange -- snapshot calls are serialized
+        // by the bus driver, and consumers are ordered behind CH6 by the ladder.
+        let dst = unsafe { (*SNAPSHOT.get()).0.as_ptr().add(off as usize) };
+        dma::disable(dma::Channel::CH6);
+        dma::configure_m2m(
+            dma::Channel::CH6,
+            src.as_ptr() as u32,
+            dst as u32,
+            src.len() as u16,
+            dma::Pl::HIGH,
+        );
+        dst
+    }
+
+    fn result(&mut self) -> Option<u16> {
+        if Self::drained() {
+            dma::disable(dma::Channel::CH3);
+            // LSB-first shifter mirrors the reflected algorithm: TCRCR is the
+            // bit-reversed osc-CRC-16 (protocol sec 3.2). Un-reverse once per frame:
+            // three parallel in-byte swap stages, then the byte swap.
+            let mut x = SPI1.tcrcr().read().txcrc() as u32;
+            x = ((x & 0x5555) << 1) | ((x >> 1) & 0x5555);
+            x = ((x & 0x3333) << 2) | ((x >> 2) & 0x3333);
+            x = ((x & 0x0f0f) << 4) | ((x >> 4) & 0x0f0f);
+            Some((x as u16).swap_bytes())
+        } else {
+            None
+        }
+    }
+}

--- a/firmware/ch32/src/providers/deadline.rs
+++ b/firmware/ch32/src/providers/deadline.rs
@@ -1,0 +1,46 @@
+//! Deadline provider (protocol sec 4.1) -- SysTick's free-running CNT for
+//! `now()`, its 32-bit CMP + STIE compare for the wake.
+//!
+//! The compare is EQUALITY-ONLY: CNTIF latches when CNT counts up through
+//! CMP exactly; a CMP the counter has already passed never matches until
+//! the ~89 s wrap. Two disciplines make that safe (both long soak-proven):
+//! CNTIF is cleared before every arm so a stale latch can't fire a ghost
+//! wake, and a set that lands behind the running counter -- the CMP store
+//! races CNT by a few HCLK cycles -- is caught by the post-arm recheck and
+//! converted into a PFIC software pend (`pend_systick`), which dispatches
+//! the same vector without needing the comparator. The mux due-checks every
+//! wake against fresh `now` (protocol sec 4.1), so an extra wake is harmless.
+
+use osc_drivers::traits::bus::{self, tick_reached};
+
+use crate::hal::{pfic, systick};
+
+/// Production binding: SysTick CNT + CMP/STIE on HCLK (48 MHz).
+pub struct Deadline;
+
+impl bus::Deadline for Deadline {
+    const TICKS_PER_US: u32 = systick::TICKS_PER_US;
+    const CLOCK_TRIM_STEP_PPM: u32 = crate::hal::rcc::CLOCK_TRIM_PPM_PER_STEP;
+
+    #[inline(always)]
+    fn now(&self) -> u32 {
+        systick::ticks()
+    }
+
+    fn set(&mut self, at: u32) {
+        crate::log::trace!("dl.set at={}", at);
+        systick::set_irq(false);
+        systick::clear_match();
+        systick::set_cmp(at);
+        systick::set_irq(true);
+        if tick_reached(systick::ticks(), at) && !systick::matched() {
+            pfic::pend_systick();
+        }
+    }
+
+    #[inline(always)]
+    fn cancel(&mut self) {
+        crate::log::trace!("dl.cancel");
+        systick::set_irq(false);
+    }
+}

--- a/firmware/ch32/src/providers/digital_out.rs
+++ b/firmware/ch32/src/providers/digital_out.rs
@@ -1,0 +1,28 @@
+//! Digital-output provider -- binds `DigitalOut` to a single GPIO pin.
+
+use osc_drivers::Level;
+use osc_drivers::traits;
+
+use crate::hal::Pin;
+use crate::hal::gpio::{self, PinMode};
+
+/// Push-pull output bound to one pin. Configures the pin and drives its
+/// initial level at construction; `set` thereafter is one BSHR/BCR write.
+pub struct DigitalOut {
+    pin: Pin,
+}
+
+impl DigitalOut {
+    pub fn new(pin: Pin, initial: Level) -> Self {
+        gpio::configure(pin, PinMode::OUTPUT_PUSH_PULL);
+        gpio::set_level(pin, initial);
+        Self { pin }
+    }
+}
+
+impl traits::DigitalOut for DigitalOut {
+    #[inline(always)]
+    fn set(&mut self, level: Level) {
+        gpio::set_level(self.pin, level);
+    }
+}

--- a/firmware/ch32/src/providers/mod.rs
+++ b/firmware/ch32/src/providers/mod.rs
@@ -1,0 +1,13 @@
+//! Provider layer -- implements consumer-owned interfaces (`osc_drivers::traits`
+//! for the bus composite, `osc_core` ports like `ConfigStore`) over HAL
+//! primitives. Consumers depend on providers only via their trait surface;
+//! this folder is the only place that talks to both layers.
+
+pub mod config_store;
+pub mod crc;
+pub mod deadline;
+pub mod digital_out;
+pub mod monotonic;
+pub mod ring;
+pub mod tx_wire;
+pub mod usart_baud;

--- a/firmware/ch32/src/providers/monotonic.rs
+++ b/firmware/ch32/src/providers/monotonic.rs
@@ -1,0 +1,16 @@
+//! Monotonic provider -- supplies `Monotonic` from HCLK-driven SysTick.
+
+use osc_drivers::traits;
+
+use crate::hal::systick;
+
+pub struct Monotonic;
+
+impl traits::Monotonic for Monotonic {
+    const TICKS_PER_US: u32 = systick::TICKS_PER_US;
+
+    #[inline(always)]
+    fn ticks(&self) -> u32 {
+        systick::ticks()
+    }
+}

--- a/firmware/ch32/src/providers/ring.rs
+++ b/firmware/ch32/src/providers/ring.rs
@@ -1,0 +1,49 @@
+//! RX ring provider (protocol sec 4.1) -- binds `RxRing` to DMA1_CH5, the
+//! USART1 RX byte ring armed once at boot and read as a counted cursor.
+//!
+//! The ring is `#[repr(align(2))]`: an even base is load-bearing so every
+//! frame anchor lands halfword-aligned for the SPI-CRC engine (protocol sec 3.2), and
+//! V006 DMA cannot feed an odd address anyway (F12).
+
+use core::cell::SyncUnsafeCell;
+
+use osc_drivers::traits::bus;
+
+use crate::hal::dma;
+
+/// Ring depth (protocol sec 11): must exceed the 258 B max frame with lap margin.
+const RING_LEN: usize = 512;
+
+#[repr(align(2))]
+struct Ring([u8; RING_LEN]);
+
+static RING: SyncUnsafeCell<Ring> = SyncUnsafeCell::new(Ring([0; RING_LEN]));
+
+/// Production binding to DMA1_CH5 (USART1 RX -> the circular ring).
+pub struct RxRing;
+
+impl RxRing {
+    pub const LEN: usize = RING_LEN;
+
+    /// Ring base for the CH5 arm in `runtime::init`.
+    pub fn base_addr() -> u32 {
+        // SAFETY: address-of a `'static` cell; the returned pointer is stable
+        // for the whole program and only handed to the DMA controller.
+        unsafe { (*RING.get()).0.as_ptr() as u32 }
+    }
+}
+
+impl bus::RxRing for RxRing {
+    #[inline(always)]
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: DMA-owned storage; the driver reads it in place. All `&mut`
+        // access into the bus composite is serialized at PFIC HIGH, so no
+        // aliasing `&mut [u8]` to the ring exists.
+        unsafe { &(*RING.get()).0 }
+    }
+
+    #[inline(always)]
+    fn cursor(&self) -> u16 {
+        RING_LEN as u16 - dma::remaining(dma::Channel::CH5)
+    }
+}

--- a/firmware/ch32/src/providers/tx_wire.rs
+++ b/firmware/ch32/src/providers/tx_wire.rs
@@ -1,0 +1,132 @@
+//! TX-wire provider (protocol sec 4.2) -- half-duplex drive discipline, the
+//! break, and one DMA1_CH4 arm at a time. Arm completion surfaces as the
+//! USART1 TC ISR (shifter empty), never a CH4 TC -- so the final release's
+//! wire handback and any deferred config can never garble in-flight bits.
+//!
+//! Two wire modes, selected by the board via the `half-duplex` feature;
+//! `claim_wire`/`release_wire` are the only lines that differ:
+//!
+//! - **Direct** (rev C, and rev B with the buffer bypassed): PC0 under
+//!   HDSEL carries the bus. Drive discipline is purely PC0's CNF (spike
+//!   `pc0_drive`, break_framing): AF open-drain while listening -- released,
+//!   the external bus pull-up holds mark -- and AF push-pull for the servo's
+//!   own TX window, so both wire edges are driven at 3M instead of riding
+//!   the pull-up's RC rise. HDSEL and RE stay on throughout: V006 HDSEL
+//!   does not echo own TX [F9], and with RE on the USART hands the released
+//!   line back cleanly at transmission end.
+//! - **Buffered** (rev B as designed): TX drives only the 74LVC2G241's
+//!   buffer input, so its pin idles AF push-pull and the buffer's tri-state
+//!   is the drive discipline -- TX_EN high drives TX onto the wire and mutes
+//!   the receive path (inverted enable, same signal), low releases the wire
+//!   to the board pull-up. The mute reproduces both HDSEL observables: no
+//!   own-TX echo, and an RX input held at mark (the RX pull-up) through the
+//!   whole TX window.
+
+use ch32_metapac::USART1;
+use osc_drivers::traits::bus;
+
+use crate::hal::{dma, usart};
+
+#[cfg(not(feature = "half-duplex"))]
+use crate::cfg::BusWiring;
+#[cfg(feature = "half-duplex")]
+use crate::cfg::chip;
+#[cfg(feature = "half-duplex")]
+use crate::hal::gpio::{self, PinMode};
+#[cfg(not(feature = "half-duplex"))]
+use crate::hal::{Pin, gpio};
+#[cfg(not(feature = "half-duplex"))]
+use osc_drivers::Level;
+
+/// Production binding to the wire claim/release + USART1 SBK/TCIE + DMA1_CH4.
+#[cfg(feature = "half-duplex")]
+pub struct TxWire;
+
+/// Production binding to the wire claim/release + USART1 SBK/TCIE + DMA1_CH4.
+#[cfg(not(feature = "half-duplex"))]
+pub struct TxWire {
+    tx_en: Pin,
+}
+
+impl TxWire {
+    #[cfg(not(feature = "half-duplex"))]
+    pub fn new(bus: &BusWiring) -> Self {
+        Self { tx_en: bus.tx_en }
+    }
+
+    /// Claim the wire for the TX window.
+    fn claim_wire(&self) {
+        #[cfg(feature = "half-duplex")]
+        // PC0 -> AF push-pull: drive both wire edges ourselves.
+        gpio::configure(chip::BUS_USART_MAPPING.tx_pin(), PinMode::AF_PUSH_PULL);
+        #[cfg(not(feature = "half-duplex"))]
+        // TX_EN high: the buffer drives TX onto the wire and mutes RX.
+        gpio::set_level(self.tx_en, Level::High);
+    }
+
+    /// Hand the wire back: released, the bus pull-up holds mark.
+    fn release_wire(&self) {
+        #[cfg(feature = "half-duplex")]
+        // PC0 -> AF open-drain; HDSEL RX keeps hearing through the pin.
+        gpio::configure(chip::BUS_USART_MAPPING.tx_pin(), PinMode::AF_OPEN_DRAIN);
+        #[cfg(not(feature = "half-duplex"))]
+        // TX_EN low: the buffer releases the wire and resumes feeding it to RX.
+        gpio::set_level(self.tx_en, Level::Low);
+    }
+}
+
+impl bus::TxWire for TxWire {
+    fn start_frame(&mut self) {
+        crate::log::trace!("tx.start");
+        self.claim_wire();
+        // send_break (the protocol sec 3 law shape -- a bracketed-M 0x00 character)
+        // blocks until the break has committed through its stop bit. The
+        // shifter is therefore EMPTY when send(arm0) runs: TCIE must
+        // stay off until the arm's first byte is in flight, or the gap TC
+        // latches, reads as arm-drained on ISR return, and release() tears
+        // the reply down mid-byte-0 (bench signature: break, one garbled
+        // byte, silence). TCIE is armed per-arm in `send`.
+        usart::send_break(USART1);
+    }
+
+    fn send(&mut self, span: &[u8]) {
+        dma::disable(dma::Channel::CH4);
+        dma::clear_tc_flag(dma::Channel::CH4);
+        let cfg = dma::Config {
+            dir: dma::Dir::FROMMEMORY,
+            circ: false,
+            pinc: false,
+            minc: true,
+            size: dma::Size::BITS8,
+            htie: false,
+            tcie: false,
+            pl: dma::Pl::HIGH,
+        };
+        dma::configure(
+            dma::Channel::CH4,
+            &cfg,
+            usart::data_addr(USART1),
+            span.as_ptr() as u32,
+            span.len() as u16,
+        );
+        usart::set_dma_tx(USART1, true);
+        dma::enable(dma::Channel::CH4);
+        // Byte 0 is in DR within a couple of AHB cycles of the enable.
+        // Clear the TC that latched while the shifter sat empty (post-break
+        // or between arms), THEN arm the real arm-drained interrupt. A real
+        // drain can't race the clear: the shortest arm holds the shifter
+        // >= 10 bit-times, orders of magnitude past these two writes.
+        usart::clear_tc(USART1);
+        usart::set_tc_irq(USART1, true);
+    }
+
+    fn release(&mut self) {
+        // No flag hygiene on the way out (transport sec 7): FE/NE/ORE have no
+        // interrupt enable, so whatever latched during our TX window is
+        // inert -- no release-point SR-DR-SR retire is needed.
+        self.release_wire();
+        usart::set_tc_irq(USART1, false);
+        usart::set_dma_tx(USART1, false);
+        dma::disable(dma::Channel::CH4);
+    }
+}

--- a/firmware/ch32/src/providers/usart_baud.rs
+++ b/firmware/ch32/src/providers/usart_baud.rs
@@ -1,0 +1,36 @@
+//! USART-baud provider (transport sec 2 / protocol sec 9.1) -- binds `UsartBaud` to USART1's
+//! BRR register. Owns the `BaudRate` -> BRR map; the driver hands a rate and
+//! stays unaware of the divisor.
+
+use ch32_metapac::USART1;
+use osc_core::BaudRate;
+use osc_drivers::traits::bus;
+
+use crate::hal::clocks::PCLK_HZ;
+use crate::hal::usart;
+
+/// Production binding to USART1's BRR register.
+pub struct UsartBaud;
+
+impl bus::UsartBaud for UsartBaud {
+    #[inline(always)]
+    fn apply(&mut self, baud: BaudRate) {
+        usart::set_baud(USART1, brr_for(baud));
+    }
+}
+
+/// Round-to-nearest BRR divisor at PCLK for the four operational rates. Each
+/// arm folds to a literal via `const {}` — the board build targets +zmmul
+/// (no hardware divide), so no runtime division is emitted. Source of truth
+/// for both runtime `apply` and the `cfg::Precomputed` seed.
+pub const fn brr_for(baud: BaudRate) -> u32 {
+    const fn compute(baud_hz: u32) -> u32 {
+        (PCLK_HZ + baud_hz / 2) / baud_hz
+    }
+    match baud {
+        BaudRate::B500000 => const { compute(500_000) },
+        BaudRate::B1000000 => const { compute(1_000_000) },
+        BaudRate::B2000000 => const { compute(2_000_000) },
+        BaudRate::B3000000 => const { compute(3_000_000) },
+    }
+}

--- a/firmware/ch32/src/runtime/diag.rs
+++ b/firmware/ch32/src/runtime/diag.rs
@@ -1,0 +1,70 @@
+//! Post-init register snapshot at `trace` level. Covers every peripheral
+//! touched by `Ch32ControlIo::new` -- if a new init step writes a register that
+//! isn't dumped here, add it. PFIC IENR is write-only and intentionally omitted.
+
+use ch32_metapac::{ADC, AFIO, DMA1, GPIOA, GPIOC, GPIOD, OPA, RCC, TIM1};
+
+pub(super) fn dump_init_regs() {
+    crate::log::trace!(
+        "rcc: ctlr={=u32:08x} cfgr0={=u32:08x} hbpcenr={=u32:08x} pb2pcenr={=u32:08x} pb1pcenr={=u32:08x}",
+        RCC.ctlr().read().0,
+        RCC.cfgr0().read().0,
+        RCC.hbpcenr().read().0,
+        RCC.pb2pcenr().read().0,
+        RCC.pb1pcenr().read().0,
+    );
+    crate::log::trace!("afio: pcfr1={=u32:08x}", AFIO.pcfr1().read().0);
+    crate::log::trace!(
+        "gpio.cfglr: a={=u32:08x} c={=u32:08x} d={=u32:08x}",
+        GPIOA.cfglr().read().0,
+        GPIOC.cfglr().read().0,
+        GPIOD.cfglr().read().0,
+    );
+    crate::log::trace!(
+        "gpio.outdr: a={=u32:08x} c={=u32:08x} d={=u32:08x}",
+        GPIOA.outdr().read().0,
+        GPIOC.outdr().read().0,
+        GPIOD.outdr().read().0,
+    );
+    crate::log::trace!("opa: ctlr1={=u32:08x}", OPA.ctlr1().read().0);
+    crate::log::trace!(
+        "adc: ctlr1={=u32:08x} ctlr2={=u32:08x} ctlr3={=u32:08x}",
+        ADC.ctlr1().read().0,
+        ADC.ctlr2().read().0,
+        ADC.ctlr3().read().0,
+    );
+    crate::log::trace!(
+        "adc: samptr1={=u32:08x} samptr2={=u32:08x} rsqr1={=u32:08x} rsqr2={=u32:08x} rsqr3={=u32:08x}",
+        ADC.samptr1().read().0,
+        ADC.samptr2().read().0,
+        ADC.rsqr1().read().0,
+        ADC.rsqr2().read().0,
+        ADC.rsqr3().read().0,
+    );
+    let dma_ch = DMA1.ch(0);
+    crate::log::trace!(
+        "dma1.ch1: cr={=u32:08x} ndtr={=u32:08x} par={=u32:08x} mar={=u32:08x}",
+        dma_ch.cr().read().0,
+        dma_ch.ndtr().read().0,
+        dma_ch.par().read(),
+        dma_ch.mar().read(),
+    );
+    crate::log::trace!(
+        "tim1: ctlr1={=u32:08x} ctlr2={=u32:08x} bdtr={=u32:08x} ccer={=u32:08x} psc={=u16} atrlr={=u16}",
+        TIM1.ctlr1().read().0,
+        TIM1.ctlr2().read().0,
+        TIM1.bdtr().read().0,
+        TIM1.ccer().read().0,
+        TIM1.psc().read(),
+        TIM1.atrlr().read(),
+    );
+    crate::log::trace!(
+        "tim1: chctlr0={=u32:08x} chctlr1={=u32:08x} ccr1={=u16} ccr2={=u16} ccr3={=u16} ccr4={=u16}",
+        TIM1.chctlr_output(0).read().0,
+        TIM1.chctlr_output(1).read().0,
+        TIM1.chcvr(0).read(),
+        TIM1.chcvr(1).read(),
+        TIM1.chcvr(2).read(),
+        TIM1.chcvr(3).read(),
+    );
+}

--- a/firmware/ch32/src/runtime/init.rs
+++ b/firmware/ch32/src/runtime/init.rs
@@ -1,0 +1,286 @@
+use ch32_metapac::{ADC, adc::vals::Extsel, dma::vals::Dir};
+use osc_core::ConfigDefaults;
+#[cfg(not(feature = "half-duplex"))]
+use osc_drivers::Level;
+
+use crate::control::sensors::scan::{ADC_DMA_BUF, ADC_DMA_BUF_LEN, ADC_SCAN_LEN, ADC_SENSOR_COUNT};
+use crate::hal::{
+    adc, afio, delay_ms, dma, esig,
+    gpio::{self, PinMode},
+    opa, rcc, systick, timer, usart,
+};
+use crate::providers::config_store;
+use crate::providers::crc::Crc;
+use crate::providers::ring::RxRing;
+use crate::runtime::Drivers;
+use crate::runtime::statics::SHARED;
+
+use crate::cfg::{AdcPins, AnalogChannel, BoardWiring, CurrentSenseConfig, Precomputed, chip};
+
+const OPA_SETTLE_MS: u32 = 1;
+const VCAL_SAMPLE_TIME: adc::SampleTime = adc::SampleTime::CYCLES9;
+
+pub struct BringupResult {
+    pub shunt_bias_raw: u16,
+}
+
+pub fn bringup(
+    wiring: &BoardWiring,
+    defaults: &ConfigDefaults,
+    pre: &Precomputed,
+) -> BringupResult {
+    enable_clocks_and_remaps(wiring);
+    crate::log::debug!("clocks + remaps configured");
+
+    configure_pins(wiring);
+    crate::log::debug!("gpio configured");
+
+    // Sole writer to CONFIG: pre-IRQ, pre-`Drivers::install`. Board defaults
+    // first, then the saved image overlays them (protocol sec 9.4) -- `Drivers::install`
+    // reads the effective comms block from the table.
+    SHARED.table.seed_config_defaults(defaults);
+    config_store::ConfigStore::boot_load();
+    SHARED.seed_uid(esig::uid());
+
+    bring_up_analog_chain(&wiring.current_sense);
+    crate::log::debug!("opa settled");
+
+    // SysTick drives both `Monotonic` (LED blinker) and the transport
+    // deadline compare. Initialize *after* `bring_up_analog_chain` because
+    // `delay_ms` reinitializes SYSTICK on every call; doing it here puts
+    // SysTick in a known state (CMP=u32::MAX, CNT=0, STE=on, STIE=off)
+    // independent of any further `delay_ms` use.
+    systick::init();
+
+    let shunt_bias_raw = wiring.current_sense.bias.quiescent_raw();
+    configure_adc_dma_scan(&wiring.sensors);
+    crate::log::debug!(
+        "adc/dma scan armed: scan_len={} buf_len={} shunt_bias_raw={}",
+        ADC_SCAN_LEN,
+        ADC_DMA_BUF_LEN,
+        shunt_bias_raw,
+    );
+
+    bring_up_bus(pre.usart_brr);
+    crate::log::debug!("bus usart + rx ring + crc engine armed");
+
+    // Drivers::install runs after the bus peripherals are live: `ServoBus
+    // ::new` applies the table's effective baud to the already-configured BRR.
+    // SAFETY: bringup-only, pre-IRQ; sole writer.
+    unsafe { Drivers::install(wiring) };
+    crate::log::debug!("drivers installed");
+
+    start_center_aligned_pwm(pre.pwm_psc, pre.pwm_arr);
+    crate::log::debug!(
+        "pwm running ({} Hz, psc={}, arr={})",
+        chip::MOTOR_PWM_FREQ_HZ,
+        pre.pwm_psc,
+        pre.pwm_arr,
+    );
+
+    #[cfg(feature = "defmt")]
+    super::diag::dump_init_regs();
+
+    BringupResult { shunt_bias_raw }
+}
+
+// Order must mirror the scan tail in `configure_adc_dma_scan`.
+fn sensor_channels(s: &AdcPins) -> [AnalogChannel; ADC_SENSOR_COUNT] {
+    [s.pos, s.ntc, s.vbus, s.vmotor.0, s.vmotor.1]
+}
+
+fn enable_clocks_and_remaps(w: &BoardWiring) {
+    let opa_pos_pin = chip::CURRENT_SENSE_OPA_INPUT.pos().pin();
+
+    rcc::init_pll();
+    rcc::enable_afio();
+    rcc::enable_gpio(chip::STAT_LED_PIN.port_index());
+    rcc::enable_gpio(w.dbg.pin().port_index());
+    rcc::enable_gpio(chip::MOTOR_IN1_PIN.port_index());
+    rcc::enable_gpio(chip::MOTOR_IN2_PIN.port_index());
+    rcc::enable_gpio(w.drv_en.pin.pin().port_index());
+    rcc::enable_gpio(opa_pos_pin.port_index());
+    if let Some(neg_pin) = chip::CURRENT_SENSE_OPA_INPUT.neg_pin() {
+        rcc::enable_gpio(neg_pin.port_index());
+    }
+    for ch in sensor_channels(&w.sensors) {
+        rcc::enable_gpio(ch.pin().port_index());
+    }
+    rcc::enable_gpio(chip::BUS_USART_MAPPING.tx_pin().port_index());
+    rcc::enable_gpio(chip::BUS_LINE_PIN.port_index());
+    #[cfg(not(feature = "half-duplex"))]
+    rcc::enable_gpio(w.bus.tx_en.port_index());
+    rcc::enable_tim1();
+    rcc::enable_adc1();
+    rcc::enable_dma1();
+    rcc::enable_usart1();
+
+    afio::set_tim_remap(1, chip::MOTOR_TIM1_MAPPING.remap_value());
+    afio::set_usart_remap(
+        chip::BUS_USART_MAPPING.peripheral_index(),
+        chip::BUS_USART_MAPPING.remap_value(),
+    );
+}
+
+fn configure_pins(w: &BoardWiring) {
+    let drv_en_pin = w.drv_en.pin.pin();
+    // Boot to the inactive level (driver disabled) before flipping to output.
+    gpio::configure(drv_en_pin, PinMode::OUTPUT_PUSH_PULL);
+    gpio::set_level(drv_en_pin, w.drv_en.inactive());
+
+    gpio::configure(chip::MOTOR_IN1_PIN, PinMode::AF_PUSH_PULL);
+    gpio::configure(chip::MOTOR_IN2_PIN, PinMode::AF_PUSH_PULL);
+
+    let opa_pos_pin = chip::CURRENT_SENSE_OPA_INPUT.pos().pin();
+    gpio::configure(opa_pos_pin, PinMode::ANALOG);
+    if let Some(neg_pin) = chip::CURRENT_SENSE_OPA_INPUT.neg_pin() {
+        gpio::configure(neg_pin, PinMode::ANALOG);
+    }
+    for ch in sensor_channels(&w.sensors) {
+        gpio::configure(ch.pin(), PinMode::ANALOG);
+    }
+
+    configure_bus_pins(w);
+}
+
+#[cfg(feature = "half-duplex")]
+fn configure_bus_pins(_w: &BoardWiring) {
+    // PC0 idle: AF open-drain -- released, the external bus pull-up holds
+    // mark (spike break_framing `pc0_drive`; a bare wire with no pull-up
+    // floats low and trips rescue). TxWire flips to AF push-pull for the
+    // TX window so data edges never ride the pull-up (transport sec 2, F8).
+    gpio::configure(chip::BUS_USART_MAPPING.tx_pin(), PinMode::AF_OPEN_DRAIN);
+    // The dedicated RX pin (PC1) is left unconfigured -- HDSEL ties RX to
+    // the TX pin internally and ignores it. On a buffer-populated board
+    // running this direct wire (bypassed rev B), the board's TX_EN
+    // pull-down is what holds the buffer released -- no firmware involved.
+}
+
+#[cfg(not(feature = "half-duplex"))]
+fn configure_bus_pins(w: &BoardWiring) {
+    // TX drives only the 74LVC2G241's buffer input, never the shared
+    // wire, so it stays AF push-pull for good -- the buffer's tri-state
+    // (TX_EN) is the drive discipline (transport sec 2; F8 applies to the wire side
+    // of the buffer).
+    gpio::configure(chip::BUS_USART_MAPPING.tx_pin(), PinMode::AF_PUSH_PULL);
+    // RX listens through the receive buffer; the internal pull-up idles
+    // it at mark alongside the board pull-up and covers an open RX
+    // jumper.
+    gpio::configure(chip::BUS_USART_MAPPING.rx_pin(), PinMode::INPUT_PULL_UP);
+    // TX_EN low = listening (matches the board pull-down's boot state);
+    // TxWire raises it for the TX window.
+    gpio::configure(w.bus.tx_en, PinMode::OUTPUT_PUSH_PULL);
+    gpio::set_level(w.bus.tx_en, Level::Low);
+}
+
+fn bring_up_analog_chain(cs: &CurrentSenseConfig) {
+    opa::init(&opa::Config {
+        input: chip::CURRENT_SENSE_OPA_INPUT,
+        gain: cs.gain,
+        bias: cs.bias,
+        output: chip::CURRENT_SENSE_OPA_OUTPUT,
+    });
+    delay_ms(OPA_SETTLE_MS);
+}
+
+fn configure_adc_dma_scan(sensors: &AdcPins) {
+    adc::set_sample_time(adc::Channel::OpaOut, chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(sensors.pos.channel(), chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(sensors.ntc.channel(), chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(sensors.vmotor.0.channel(), chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(sensors.vmotor.1.channel(), chip::ADC_SAMPLE_TIME);
+    adc::set_sample_time(adc::Channel::Vcal, VCAL_SAMPLE_TIME);
+    adc::set_low_power(false);
+
+    let seq = [
+        adc::Channel::OpaOut,
+        sensors.pos.channel(),
+        sensors.ntc.channel(),
+        sensors.vmotor.0.channel(),
+        sensors.vmotor.1.channel(),
+        adc::Channel::Vcal,
+    ];
+    adc::set_sequence(&seq);
+    adc::set_scan_mode(true);
+    adc::set_dma(true);
+    adc::set_external_trigger(Extsel::TIM1_TRGO);
+    adc::enable();
+
+    let dma_cfg = dma::Config {
+        dir: Dir::FROMPERIPHERAL,
+        circ: true,
+        pinc: false,
+        minc: true,
+        size: dma::Size::BITS16,
+        htie: false,
+        tcie: true,
+        // HIGH, not VERYHIGH: RX (CH5) alone owns the top so an inbound byte's
+        // drain outranks everything (see the ladder in `hal::dma`). ADC is the
+        // lowest-numbered HIGH channel, so it still wins every HIGH tie and
+        // only ever yields to the sparse RX drain.
+        pl: dma::Pl::HIGH,
+    };
+    let paddr = ADC.rdatar().as_ptr() as u32;
+    let maddr = ADC_DMA_BUF.get() as u32;
+    dma::configure(
+        dma::Channel::CH1,
+        &dma_cfg,
+        paddr,
+        maddr,
+        ADC_DMA_BUF_LEN as u16,
+    );
+    dma::enable(dma::Channel::CH1);
+}
+
+/// osc-native transport bring-up: USART1 (single-wire HDSEL on the direct
+/// wire, plain full duplex behind the 74LVC2G241 on the buffered wire), the
+/// circular RX ring on DMA1_CH5 (armed once), and the SPI-CRC engine. TX arms
+/// (DMA1_CH4) are configured per-arm by `TxWire`, so no channel init here.
+fn bring_up_bus(brr: u32) {
+    let regs = chip::BUS_USART_MAPPING.regs();
+
+    // Arm the RX ring before UE/DMAR come up so the channel is live the
+    // moment the first byte's DMA request fires (spike ordering).
+    let rx_cfg = dma::Config {
+        dir: Dir::FROMPERIPHERAL,
+        circ: true,
+        pinc: false,
+        minc: true,
+        size: dma::Size::BITS8,
+        htie: false,
+        tcie: false,
+        // VERYHIGH, alone at the top of the ladder (see `hal::dma`): an inbound
+        // byte's drain preempts every other channel per-beat, so it always
+        // lands in the ring before the break IRQ reads the cursor.
+        pl: dma::Pl::VERYHIGH,
+    };
+    dma::configure(
+        dma::Channel::CH5,
+        &rx_cfg,
+        usart::data_addr(regs),
+        RxRing::base_addr(),
+        RxRing::LEN as u16,
+    );
+    dma::enable(dma::Channel::CH5);
+
+    // Wire mode, TE/RE, BRR, UE, then RX-DMA + error IRQ. No IDLE IRQ.
+    usart::init_bus(regs, brr, cfg!(feature = "half-duplex"));
+
+    // One-shot SPI-CRC engine setup (clock-gate + config; held live).
+    Crc::init();
+}
+
+fn start_center_aligned_pwm(psc: u16, arr: u16) {
+    timer::init_center_aligned_pwm(psc, arr);
+    // Start both channels active-high; the control loop owns CCP per-cycle
+    // from the first tick for direction / decay-mode control.
+    timer::configure_pwm_channel(chip::MOTOR_IN1_CH, timer::Polarity::ActiveHigh);
+    timer::configure_pwm_channel(chip::MOTOR_IN2_CH, timer::Polarity::ActiveHigh);
+    timer::set_duty(chip::MOTOR_IN1_CH, 0);
+    timer::set_duty(chip::MOTOR_IN2_CH, 0);
+    timer::set_repetition(0);
+    timer::set_trgo_update();
+    timer::enable_main_output();
+    timer::force_update_event();
+    timer::start();
+}

--- a/firmware/ch32/src/runtime/isr.rs
+++ b/firmware/ch32/src/runtime/isr.rs
@@ -1,0 +1,183 @@
+use ch32_metapac::{DMA1, USART1};
+use osc_core::traits::{Dispatch, Dispatched, Reply, Request, RequestCtx};
+use osc_core::{ControlIo, ConversionVariables, RegionStorageRaw, Sensors};
+
+use crate::hal::{pfic, usart};
+use crate::runtime::Drivers;
+use crate::runtime::statics::{KERNEL, SESSION, SHARED};
+
+/// Configures PFIC priorities and unmasks the transport + ADC IRQs. Called
+/// once during bringup, after the drivers and statics are installed.
+///
+/// The transport vectors (USART1 for break/TC, SysTick for the framer
+/// deadlines) share PFIC HIGH so all `&mut` access into the `ServoBus`
+/// composite serializes -- dispatch runs inline on these vectors. LOW holds
+/// only the motor kernel (DMA1_CH1 = 22), which HIGH preempts and which runs
+/// in the wire gaps between frames. DMA1_CH5 (RX ring) runs silent circular --
+/// no HT/TC IRQ -- and CH4/CH3 raise none either.
+pub fn install_irqs() {
+    pfic::set_priority(pfic::Interrupt::USART1, pfic::Priority::High);
+    pfic::set_systick_priority(pfic::Priority::High);
+    pfic::set_priority(pfic::Interrupt::DMA1_CHANNEL1, pfic::Priority::Low);
+    pfic::enable(pfic::Interrupt::USART1);
+    pfic::enable_systick();
+    pfic::enable(pfic::Interrupt::DMA1_CHANNEL1);
+    crate::log::info!("ISRs live");
+}
+
+/// HIGH-side dispatcher: materializes the `SESSION` borrow inside each
+/// `Dispatch` method instead of holding one across the whole ISR body.
+///
+/// SAFETY (the SESSION exclusivity invariant): `SESSION` is touched only by
+/// the HIGH transport ISRs (USART1 + SysTick), which share PFIC HIGH and so
+/// never preempt each other -- dispatch at the covered checkpoint / fast path
+/// and the verdict commit/revert all run to completion within one HIGH body.
+/// No other class reaches the session.
+struct HighDispatcher;
+
+impl HighDispatcher {
+    #[inline(always)]
+    fn with<R>(&mut self, f: impl FnOnce(&mut osc_core::Dispatcher<'_>) -> R) -> R {
+        // SAFETY: see type doc -- HIGH-exclusive, no concurrent borrow.
+        let session = unsafe { (*SESSION.get()).assume_init_mut() };
+        f(&mut session.dispatcher(&SHARED))
+    }
+}
+
+impl Dispatch for HighDispatcher {
+    fn dispatch<R: Reply>(
+        &mut self,
+        req: Request<'_>,
+        ctx: RequestCtx,
+        reply: &mut R,
+    ) -> Dispatched {
+        self.with(|d| d.dispatch(req, ctx, reply))
+    }
+
+    fn commit<R: Reply>(&mut self, reply: &mut R) {
+        self.with(|d| d.commit(reply))
+    }
+
+    fn revert(&mut self) {
+        self.with(|d| d.revert())
+    }
+}
+
+/// ADC DMA TC handler body -- wire into the vector table via [`crate::install_isrs!`].
+pub fn on_adc_dma_tc() {
+    DMA1.ifcr().write(|w| w.set_tcif(0, true));
+
+    unsafe {
+        // Volatile pair: load-bearing against optimizer hoisting in the pump.
+        let tick = &raw mut (*SHARED.table.region_ptr())
+            .telemetry
+            .intermediaries
+            .sample_tick;
+        tick.write_volatile(tick.read_volatile().wrapping_add(1));
+
+        // SAFETY: PFIC unmasks DMA1_CHANNEL1 only after install_kernel writes KERNEL.
+        let kernel = (*KERNEL.get()).assume_init_mut();
+        let vars = ConversionVariables::snapshot(&SHARED);
+        let sample = {
+            let (sensors, _motor) = kernel.io.parts();
+            sensors.sample(&vars)
+        };
+        kernel.on_tick(sample, &SHARED);
+    }
+}
+
+/// USART1 vector -- break detection (LBD) and TX arm completion.
+///
+/// SAFETY: the bus driver is installed before this vector unmasks, and USART1
+/// shares PFIC HIGH with SysTick, so no concurrent `&mut` into the composite
+/// is possible. Statement ordering is load-bearing: one STATR image is taken
+/// at entry, the break handler runs first, then the TC branch.
+pub fn on_usart1() {
+    crate::log::trace!("usart1 isr");
+    // One STATR image; the two enabled sources (LBDIE, TCIE) branch off it.
+    // This path never reads DATAR: a CPU DATAR read while a byte is
+    // mid-reception kills the byte in the shifter -- no flags, no ring
+    // entry, every later anchor shifts (measured; the DMA ladder
+    // only protects the byte already in RDR).
+    let sr = usart::statr(USART1);
+
+    // (a) LBD: a genuine >=10-bit dominant span -- a break, and the ONLY RX
+    // wake (protocol sec 3.4: garble never interrupts; FE/NE/ORE have no enable
+    // and latch silently). Cleared here by the flag-selective constant write,
+    // so the level pend is retired before the handler runs -- a break
+    // landing mid-body re-pends the vector, nothing is lost, and no flag
+    // can storm. on_break is idempotent (transport sec 5: position from ring data).
+    if sr.lbd() {
+        usart::clear_lbd(USART1);
+        // The break handler resolves complete frames from ring data in
+        // place (transport sec 5), so it carries the (lazy) HIGH dispatcher
+        // like the deadline body.
+        let mut dispatcher = HighDispatcher;
+        // SAFETY: see fn doc.
+        unsafe { Drivers::bus() }.on_break(&mut dispatcher);
+    }
+
+    // (b) TC: an armed TX arm drained (shifter empty). TCIE gates arbitration
+    // -- the shared vector fans in LBD + TC, and a break entry could land
+    // with a stale reset-value TC. Gate on TCIE so it can't walk into
+    // on_tx_complete before the first reply is armed.
+    //
+    // TC is NOT cleared here -- `TxWire::send` clears it per-arm once the
+    // next arm's first byte is in flight, and the final arm's release drops
+    // TCIE, leaving TC=1 as the natural idle state (STATR reset 0xC0).
+    if sr.tc() && usart::is_tcie(USART1) {
+        // SAFETY: see fn doc.
+        unsafe { Drivers::bus() }.on_tx_complete();
+    }
+
+    // Trailing on purpose (statement order above is jitter-tuned): any
+    // wire event marks the bus as talking for the main loop's LED policy.
+    crate::runtime::registry::BUS_ACTIVITY.store(true, portable_atomic::Ordering::Relaxed);
+}
+
+/// SysTick compare -- one or more framer/chain/rescue deadlines are due, or a
+/// `pend_systick` late-arm wake. CNTIF is cleared first: a final deadline body
+/// returns without re-arming and a stale-but-latched flag would re-fire
+/// the IRQ the moment we return.
+///
+/// SAFETY: SysTick shares PFIC HIGH with USART1, so no concurrent `&mut`
+/// into the composite is possible; SESSION access goes through the lazy
+/// [`HighDispatcher`] under its exclusivity invariant.
+pub fn on_deadline_irq() {
+    crate::log::trace!("deadline isr");
+    crate::hal::systick::clear_match();
+    let mut dispatcher = HighDispatcher;
+    // SAFETY: see fn doc.
+    unsafe { Drivers::bus() }.on_deadline(&mut dispatcher);
+}
+
+/// Wires osc-ch32 ISR bodies into the vector table via the stock
+/// `#[qingke_rt::interrupt]` trampolines (save-ra + HPE hardware stacking,
+/// INTSYSCR=0x3 from qingke-rt's startup).
+///
+/// The "HPE corrupts t0/t2" concern is DEBUNKED (bringup `hpe_matrix`):
+/// stock trampolines survived ~8M IRQ crossings across
+/// single/nested/tail-chain/critical-section/100 kHz-storm legs with zero
+/// corruption. The corruptor was `wlink write-mem`, which resumes the hart
+/// with its scratch registers leaked into the running context -- t0 = the
+/// poked address, t2 = the poked value (canary-captured verbatim). Debug
+/// pokes perturb t0/t2; the runtime is sound.
+#[macro_export]
+macro_rules! install_isrs {
+    () => {
+        #[::qingke_rt::interrupt]
+        fn DMA1_CHANNEL1() {
+            $crate::runtime::isr::on_adc_dma_tc();
+        }
+
+        #[::qingke_rt::interrupt]
+        fn USART1() {
+            $crate::runtime::isr::on_usart1();
+        }
+
+        #[::qingke_rt::interrupt(core)]
+        fn SysTick() {
+            $crate::runtime::isr::on_deadline_irq();
+        }
+    };
+}

--- a/firmware/ch32/src/runtime/mod.rs
+++ b/firmware/ch32/src/runtime/mod.rs
@@ -1,0 +1,10 @@
+#[cfg(feature = "defmt")]
+pub mod diag;
+pub mod init;
+pub mod isr;
+pub mod registry;
+pub mod run;
+pub mod statics;
+
+pub use init::bringup;
+pub use registry::Drivers;

--- a/firmware/ch32/src/runtime/registry.rs
+++ b/firmware/ch32/src/runtime/registry.rs
@@ -1,0 +1,169 @@
+//! Driver registry -- owns the static storage for each driver *instance*
+//! and exposes typed accessors. Driver types themselves stay pure (no
+//! statics, no `install`, no `get`); the registry is the only place that
+//! knows which instance a driver type plays in this build.
+//!
+//! Adding an instance is a three-line change here (cell, install line,
+//! accessor) -- the driver type stays untouched.
+//!
+//! Each instance has its own [`SyncUnsafeCell`], so simultaneous mutable
+//! access to two different instances (e.g. main loop touching `stat_led`
+//! while a transport ISR touches `bus`) doesn't pass through a shared
+//! `&mut Drivers` -- no aliasing UB.
+
+use core::cell::SyncUnsafeCell;
+
+use osc_core::RegionStorage;
+use osc_drivers::Level;
+use osc_drivers::bus::ServoBus;
+use osc_drivers::led::Led;
+use osc_drivers::traits::bus::Providers;
+use portable_atomic::AtomicBool;
+
+use crate::cfg::board_wiring::BoardWiring;
+use crate::providers::crc::Crc;
+use crate::providers::deadline::Deadline;
+use crate::providers::digital_out::DigitalOut;
+use crate::providers::monotonic::Monotonic;
+use crate::providers::ring::RxRing;
+use crate::providers::tx_wire::TxWire;
+use crate::providers::usart_baud::UsartBaud;
+
+type StatLed = Led<DigitalOut, Monotonic>;
+
+/// Cross-cell wire-activity latch (driver-pattern sec 9.3 channel, not a
+/// driver cell): the USART1 vector's tail stores, the main-loop LED
+/// policy swaps. One relaxed store per wire IRQ.
+pub static BUS_ACTIVITY: AtomicBool = AtomicBool::new(false);
+
+/// Bundle of the chip-side providers the `ServoBus` composite consumes
+/// (driver-pattern sec 5.4). Each associated type maps to its zero-sized
+/// provider impl (one per `providers/<role>.rs`).
+pub struct V006Providers;
+
+impl Providers for V006Providers {
+    type Ring = RxRing;
+    type Deadline = Deadline;
+    type Crc = Crc;
+    type Tx = TxWire;
+    type Baud = UsartBaud;
+}
+
+type Bus = ServoBus<V006Providers>;
+
+/// `Bus` holds raw span pointers (zero-copy TX arms, driver-pattern sec 4.2) and
+/// is therefore `!Sync`. All access is serialized: `&mut` only from the HIGH
+/// transport ISRs (which never preempt each other), and the main loop reaches
+/// in for `take_reboot` only under a critical section. This wrapper asserts
+/// that discipline so the cell can live in a `static`.
+struct BusCell(SyncUnsafeCell<Option<Bus>>);
+// SAFETY: see `BusCell` doc -- access is serialized by PFIC priority + CS.
+unsafe impl Sync for BusCell {}
+
+struct Cells {
+    dbg: SyncUnsafeCell<Option<DigitalOut>>,
+    stat_led: SyncUnsafeCell<Option<StatLed>>,
+    bus: BusCell,
+}
+
+static CELLS: Cells = Cells {
+    dbg: SyncUnsafeCell::new(None),
+    stat_led: SyncUnsafeCell::new(None),
+    bus: BusCell(SyncUnsafeCell::new(None)),
+};
+
+pub struct Drivers;
+
+// `SAFETY:` prose in each fn's doc comment is the project convention; the
+// markdown-`# Safety`-section form clippy expects would add a one-off style
+// island here. Keep the convention; allow the lint.
+#[allow(clippy::missing_safety_doc)]
+impl Drivers {
+    /// SAFETY: bringup-only, pre-IRQ; sole writer. Must be called exactly
+    /// once, after `runtime::init::bring_up_bus` has configured USART1, the
+    /// CH5 ring, and the SPI-CRC engine, and after the table's comms block is
+    /// final (defaults seeded + saved image overlaid) -- `ServoBus::new`
+    /// applies the effective baud to the live BRR.
+    pub unsafe fn install(w: &BoardWiring) {
+        // SAFETY: see fn doc.
+        let dbg = unsafe { &mut *CELLS.dbg.get() };
+        debug_assert!(dbg.is_none(), "Drivers: dbg already installed");
+        *dbg = Some(DigitalOut::new(w.dbg.pin(), Level::Low));
+
+        // SAFETY: see fn doc.
+        let stat_led = unsafe { &mut *CELLS.stat_led.get() };
+        debug_assert!(stat_led.is_none(), "Drivers: stat_led already installed");
+        *stat_led = Some(Led::new(
+            DigitalOut::new(crate::cfg::chip::STAT_LED_PIN, Level::High),
+            Monotonic,
+        ));
+
+        // The table is the comms authority here -- a saved image's id/baud
+        // must be what the bus comes up as, not the board defaults.
+        let (id, baud, deadline_us) = crate::runtime::statics::SHARED.table.with(|t| {
+            (
+                t.config.comms.id,
+                t.config.comms.baud_rate_idx,
+                t.config.comms.response_deadline_us,
+            )
+        });
+
+        // SAFETY: see fn doc.
+        let bus = unsafe { &mut *CELLS.bus.0.get() };
+        debug_assert!(bus.is_none(), "Drivers: bus already installed");
+        #[cfg(feature = "half-duplex")]
+        let tx_wire = TxWire;
+        #[cfg(not(feature = "half-duplex"))]
+        let tx_wire = TxWire::new(&w.bus);
+        *bus = Some(ServoBus::new(
+            RxRing,
+            Deadline,
+            Crc,
+            tx_wire,
+            UsartBaud,
+            id,
+            baud,
+            deadline_us,
+        ));
+    }
+
+    /// SAFETY: bringup installs `dbg` before any ISR runs; runtime access is
+    /// from the ADC ISR at PFIC LOW or main-loop with IRQs masked.
+    ///
+    /// Only used under `--features bench`; kept always-available so the API
+    /// doesn't change with the feature.
+    #[inline(always)]
+    #[allow(dead_code)]
+    pub unsafe fn dbg() -> &'static mut DigitalOut {
+        // SAFETY: see fn doc.
+        let cell = unsafe { &mut *CELLS.dbg.get() };
+        debug_assert!(cell.is_some(), "Drivers::dbg() before install");
+        // SAFETY: bringup ensures Some before any ISR fires.
+        unsafe { cell.as_mut().unwrap_unchecked() }
+    }
+
+    /// SAFETY: bringup installs `stat_led` before main loop runs; runtime
+    /// access is from main-loop callers only.
+    #[inline(always)]
+    pub unsafe fn stat_led() -> &'static mut StatLed {
+        // SAFETY: see fn doc.
+        let cell = unsafe { &mut *CELLS.stat_led.get() };
+        debug_assert!(cell.is_some(), "Drivers::stat_led() before install");
+        // SAFETY: bringup ensures Some before main loop runs.
+        unsafe { cell.as_mut().unwrap_unchecked() }
+    }
+
+    /// SAFETY: bringup installs `bus` before any IRQ runs; runtime `&mut`
+    /// access is from the USART1 and SysTick ISRs, both at PFIC HIGH, so
+    /// same-priority no-preemption serializes the composite's interior
+    /// state. The main loop reaches in only for `take_reboot`, and does so
+    /// inside a critical section (see `runtime::run`).
+    #[inline(always)]
+    pub unsafe fn bus() -> &'static mut Bus {
+        // SAFETY: see fn doc.
+        let cell = unsafe { &mut *CELLS.bus.0.get() };
+        debug_assert!(cell.is_some(), "Drivers::bus() before install");
+        // SAFETY: bringup ensures Some before any IRQ fires.
+        unsafe { cell.as_mut().unwrap_unchecked() }
+    }
+}

--- a/firmware/ch32/src/runtime/run.rs
+++ b/firmware/ch32/src/runtime/run.rs
@@ -1,0 +1,181 @@
+//! Top-level program entry. `run!` is the board binary's main: it validates
+//! the `BoardConfig` literal at compile time, calls into bringup, installs
+//! the kernel + IRQs, and enters the main loop.
+
+use osc_core::{BootMode, RegionStorageRaw};
+use osc_drivers::led::Pattern;
+use osc_drivers::traits::Monotonic as _;
+use portable_atomic::Ordering;
+
+use osc_drivers::bus::RESCUE_LOW_US;
+
+use crate::cfg::{BoardConfig, Precomputed, chip};
+use crate::control::Ch32ControlIo;
+use crate::hal::{dma, flash, gpio, pfic, rcc};
+use crate::providers::monotonic::Monotonic;
+
+/// STAT LED talk-blink: full blink cycle while the bus is talking (the
+/// pirate's cadence), and how long "talking" outlives the last wire IRQ
+/// so gapped exchanges read as one episode.
+const TALK_BLINK_PERIOD_US: u32 = 100_000;
+const TALK_HOLD_US: u32 = 200_000;
+
+/// Const-asserts pin-uniqueness on the `BoardConfig` literal, then runs.
+#[macro_export]
+macro_rules! run {
+    ($cfg:expr) => {{
+        const __OSC_CH32_CFG: $crate::cfg::BoardConfig = $cfg;
+        const __OSC_CH32_PRE: $crate::cfg::Precomputed =
+            $crate::cfg::Precomputed::compute(&__OSC_CH32_CFG);
+        const _: () = __OSC_CH32_CFG.wiring.assert_valid();
+        // qingke-rt sets WFITOWFE=1; undo it so `wfi` wakes on pending IRQs.
+        // INTSYSCR stays at qingke-rt's 0x3 (HPE + nesting): the "HPE
+        // corrupts t0/t2" episode was a wlink write-mem artifact (see
+        // runtime/isr.rs).
+        unsafe { ::qingke::pfic::wfi_to_wfe(false) };
+        $crate::runtime::run::__run(__OSC_CH32_CFG, __OSC_CH32_PRE)
+    }};
+}
+
+#[doc(hidden)]
+pub fn __run(cfg: BoardConfig, pre: Precomputed) -> ! {
+    let io = Ch32ControlIo::new(cfg, pre);
+    crate::runtime::statics::install(io);
+    crate::runtime::isr::install_irqs();
+    // Last-published transport counters: the table gets DELTAS, so a host
+    // zero-write (the rw clear contract, `TelemetryBusLink`) sticks instead
+    // of being clobbered by the next publish of a monotonic total.
+    let mut published = osc_drivers::bus::LinkDiag {
+        crc_fail_count: 0,
+        framing_drop_count: 0,
+    };
+    let talk_hold_ticks = TALK_HOLD_US * Monotonic::TICKS_PER_US;
+    let mut last_talk = Monotonic.ticks().wrapping_sub(talk_hold_ticks);
+    let rescue_low_ticks = RESCUE_LOW_US * Monotonic::TICKS_PER_US;
+    let mut rescue_low_since: Option<u32> = None;
+    let mut rescue_ndtr: u16 = dma::remaining(dma::Channel::CH5);
+    loop {
+        // Transport RX/TX/deadlines are ISR-driven (USART1 + SysTick, PFIC
+        // HIGH). Main loop owns LED housekeeping, the link-diagnostics
+        // publish, the deferred-reboot poll, and sleep.
+        //
+        // STAT LED: solid when idle, blinking while the bus talks -- any
+        // USART1 wire event latches `BUS_ACTIVITY`, and the blink holds
+        // past the last event so an exchange reads as one episode. The
+        // `wfi` wake cadence is the poll cadence: wire IRQs while talking,
+        // the 20 kHz kernel tick otherwise.
+        if crate::runtime::registry::BUS_ACTIVITY.swap(false, Ordering::Relaxed) {
+            last_talk = Monotonic.ticks();
+        }
+        let talking = Monotonic.ticks().wrapping_sub(last_talk) < talk_hold_ticks;
+        // SAFETY: stat_led installed in bringup; main-loop sole accessor.
+        let led = unsafe { crate::runtime::Drivers::stat_led() };
+        led.set_pattern(if talking {
+            Pattern::Blink {
+                period_us: TALK_BLINK_PERIOD_US,
+            }
+        } else {
+            Pattern::SolidOn
+        });
+        led.poll();
+
+        // Publish transport health into the telemetry region (protocol sec 5.3 layer 1:
+        // dropped frames are counted, never answered). The critical section
+        // makes the `bus()` reach-in non-aliasing (HIGH owns it otherwise)
+        // and folds the read-modify-write against a concurrent host clear
+        // committing from HIGH.
+        critical_section::with(|_| {
+            // SAFETY: bus installed in bringup; ISRs masked by the CS.
+            let diag = unsafe { crate::runtime::Drivers::bus() }.diag();
+            // SAFETY: table storage is 'static; field access is volatile and
+            // ISR-masked, mirroring the sample_tick idiom in `isr.rs`.
+            unsafe {
+                let link = &raw mut (*crate::runtime::statics::SHARED.table.region_ptr())
+                    .telemetry
+                    .link;
+                let crc = &raw mut (*link).crc_fail_count;
+                crc.write_volatile(
+                    crc.read_volatile()
+                        .wrapping_add(diag.crc_fail_count.wrapping_sub(published.crc_fail_count)),
+                );
+                let drops = &raw mut (*link).framing_drop_count;
+                drops.write_volatile(
+                    drops.read_volatile().wrapping_add(
+                        diag.framing_drop_count
+                            .wrapping_sub(published.framing_drop_count),
+                    ),
+                );
+            }
+            published = diag;
+        });
+
+        // Clock-trim loop (protocol sec 9.3): the transport measures
+        // host-instruction byte cadence ISR-side; the correction lands here,
+        // outside any transport ISR. A correction is <= 4 steps (~1%) -- well
+        // inside the framing budget vs a crystal host, so trimming over a live
+        // wire is safe (measured: the manual-knob experiment trimmed the
+        // fleet mid-traffic with zero errors). The applied total mirrors
+        // into telemetry, read-only, for fleet diagnosis.
+        let trim = critical_section::with(|_| {
+            // SAFETY: bus installed in bringup; ISRs masked by the CS.
+            unsafe { crate::runtime::Drivers::bus() }.poll_clock_trim()
+        });
+        if let Some(total) = trim {
+            rcc::apply_clock_trim(total);
+            // SAFETY: table storage is 'static; single-byte volatile store
+            // to a read-only field (regmap can't race it).
+            unsafe {
+                (&raw mut (*crate::runtime::statics::SHARED.table.region_ptr())
+                    .telemetry
+                    .clock
+                    .trim_steps)
+                    .write_volatile(total);
+            }
+        }
+
+        // Deferred reboot (protocol sec 9.5), honored after the ack has drained. The
+        // critical section is load-bearing: `bus()` is otherwise `&mut`-owned
+        // by the HIGH transport ISRs, so masking them is what makes this
+        // main-loop reach-in non-aliasing. Flash writes stay out of the ISR
+        // bodies -- the stall is lethal under a live control loop.
+        let reboot: Option<BootMode> =
+            critical_section::with(|_| unsafe { crate::runtime::Drivers::bus() }.take_reboot());
+        if let Some(mode) = reboot {
+            flash::set_boot_mode(matches!(mode, BootMode::Bootloader));
+            pfic::software_reset();
+        }
+
+        // Rescue sampler (protocol sec 9.1). The break detector latches only at a
+        // dominant span's END, so no transport wake can
+        // observe a rescue pulse in progress -- the slow loop measures it
+        // instead, which is where a 300 us-scale signal belongs. One sample
+        // per wfi wake; the 20 kHz ADC tick is the idle metronome, so the
+        // worst-case cadence is ~50 us against a >= 300 us window. The window
+        // requires every sample low AND the RX ring frozen: any completed
+        // character moves NDTR (a real dominant low delivers no start
+        // edges), so UART traffic at any baud -- including the pulse's own
+        // ringed 0x00, which re-anchors the window ~a byte-time in -- can
+        // never impersonate a pulse. Declaration runs under a critical
+        // section (the bus is otherwise HIGH-ISR-owned) while the pulse
+        // still holds the line, so the driver resyncs at a provably-still
+        // cursor; the window restart afterwards makes a continuing low
+        // redeclare idempotently rather than repeat-fire.
+        let ndtr = dma::remaining(dma::Channel::CH5);
+        if !gpio::is_low(chip::BUS_LINE_PIN) || ndtr != rescue_ndtr {
+            rescue_low_since = None;
+            rescue_ndtr = ndtr;
+        } else if let Some(t0) = rescue_low_since {
+            if Monotonic.ticks().wrapping_sub(t0) >= rescue_low_ticks {
+                rescue_low_since = None;
+                critical_section::with(|_| {
+                    // SAFETY: bus installed in bringup; ISRs masked by the CS.
+                    unsafe { crate::runtime::Drivers::bus() }.on_rescue_break()
+                });
+            }
+        } else {
+            rescue_low_since = Some(Monotonic.ticks());
+        }
+
+        riscv::asm::wfi();
+    }
+}

--- a/firmware/ch32/src/runtime/statics.rs
+++ b/firmware/ch32/src/runtime/statics.rs
@@ -1,0 +1,39 @@
+use core::cell::SyncUnsafeCell;
+use core::mem::MaybeUninit;
+use osc_core::{Kernel, RegionStorageRaw, Session, Shared};
+
+use crate::control::Ch32ControlIo;
+
+pub static SHARED: Shared = Shared::new();
+
+/// Initialised by `install`; the ADC DMA TC IRQ is PFIC-masked until then.
+pub(crate) static KERNEL: SyncUnsafeCell<MaybeUninit<Kernel<Ch32ControlIo>>> =
+    SyncUnsafeCell::new(MaybeUninit::uninit());
+
+/// The per-servo dispatch session (write staging + the pending-verdict slot).
+/// Borrowed only by the HIGH transport ISRs (USART1 + SysTick), which
+/// materialize it per `Dispatch` call and share PFIC HIGH -- so dispatch,
+/// commit, and revert never overlap (the `HighDispatcher` invariant in
+/// `runtime::isr`). The main loop never reaches in.
+pub(crate) static SESSION: SyncUnsafeCell<MaybeUninit<Session>> =
+    SyncUnsafeCell::new(MaybeUninit::uninit());
+
+pub fn install(io: Ch32ControlIo) {
+    unsafe {
+        (*KERNEL.get()).write(Kernel::new(io));
+        (*SESSION.get()).write(Session::new());
+    }
+    crate::log::info!("kernel + session installed");
+}
+
+/// `read_volatile` is load-bearing: a plain read gets hoisted out of spin loops
+/// because LLVM can't see the DMA TC ISR writing this asynchronously.
+pub fn read_sample_tick() -> u32 {
+    unsafe {
+        let p = &raw const (*SHARED.table.region_ptr())
+            .telemetry
+            .intermediaries
+            .sample_tick;
+        p.read_volatile()
+    }
+}


### PR DESCRIPTION
The CH32 chip crate, from #20's tip — the orchestration layer where chip-shaped things actually live.

Everything the driver pattern doc calls the orchestration crate: HAL primitives (USART with LBD break detection, DMA, SysTick, SPI-as-CRC-engine, flash, ADC/OPA), the providers that implement the driver traits over them, the services binding osc-core, the driver registry, the two ISR vectors, and the bringup sequence. The DMA priority ladder and the no-DATAR rule from the transport doc are enforced here.

Host-runnable unit tests cover the provider/table glue (23 tests); the register-level truth is gear 3's job on the bench. CI picks up the ch32 job, including a check of the `bench` probe-counter feature combo that never used to get compiled in CI.
