### PR TITLE
host: osc-host engine + link + host-in-the-loop DES

### DIFF
--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["control-table", "control-table-derive", "core", "drivers", "integration", "log", "osc-protocol", "units"]
+members = ["control-table", "control-table-derive", "core", "drivers", "host", "integration", "log", "osc-protocol", "units"]
 
 [workspace.package]
 edition = "2024"
@@ -19,5 +19,6 @@ osc-log              = { path = "log" }
 osc-protocol         = { path = "osc-protocol" }
 osc-servo-core             = { path = "core" }
 osc-servo-drivers          = { path = "drivers" }
+osc-host             = { path = "host" }
 control-table        = { path = "control-table" }
 control-table-derive = { path = "control-table-derive" }

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -283,7 +283,7 @@ mod tests {
         // A CRC-valid image planting an out-of-range discriminant must not
         // parse -- overlay would construct an invalid enum (UB).
         let (mut config, profile) = body();
-        config[addr::comms::BAUD_RATE_IDX as usize] = 4;
+        config[addr::stall::STALL_RESPONSE as usize] = 2;
         let mut img = [0u8; IMAGE_LEN];
         assemble(&mut img, 1, &config, &profile);
         assert!(Image::parse(&img).is_none());

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -1,48 +1,13 @@
 use control_table::{Block, Enum, Section};
 
-/// osc-native operational baud (sec 2). Recovery is the rescue break's job, not a
-/// crawl-speed fallback, so only the four operational rates exist.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Enum)]
-#[repr(u8)]
-pub enum BaudRate {
-    // Default = the sec 9.1 rescue floor, the always-reachable rate -- and the
-    // zero value, which keeps the table's const image all-zero so SHARED
-    // lands in .bss (no 1 KB flash init image). The operational default is
-    // the board's `ConfigDefaults.baud`, seeded at boot before the bus runs.
-    #[default]
-    B500000 = 0,
-    B1000000 = 1,
-    B2000000 = 2,
-    B3000000 = 3,
-}
+// Wire vocabulary, hoisted to the foundation crate so the host column can
+// name it (grid law 2). The table field below stays a raw index because the
+// `Enum` derive impls a control-table trait -- orphan-rule-bound to whichever
+// crate defines the type.
+pub use osc_protocol::wire::BaudRate;
 
 /// osc-native sec 7 default: chain reclaim + host timeout, not a reply-time floor.
 pub const DEFAULT_RESPONSE_DEADLINE_US: u16 = 60;
-
-impl BaudRate {
-    pub const fn as_idx(self) -> u8 {
-        self as u8
-    }
-
-    pub const fn as_hz(self) -> u32 {
-        match self {
-            BaudRate::B500000 => 500_000,
-            BaudRate::B1000000 => 1_000_000,
-            BaudRate::B2000000 => 2_000_000,
-            BaudRate::B3000000 => 3_000_000,
-        }
-    }
-
-    pub const fn from_idx(idx: u8) -> Option<Self> {
-        match idx {
-            0 => Some(BaudRate::B500000),
-            1 => Some(BaudRate::B1000000),
-            2 => Some(BaudRate::B2000000),
-            3 => Some(BaudRate::B3000000),
-            _ => None,
-        }
-    }
-}
 
 /// Stall detector policy. `repr(u8)`; constructing from an unlisted discriminant is UB,
 /// so validators MUST gate writes to `StallResponse::ALLOWED`.
@@ -75,8 +40,11 @@ pub struct ConfigIdentity {
 pub struct ConfigComms {
     #[ct_field(ge = 1u8, le = 249u8, hook = on_id_write)]
     pub id: u8,
-    #[ct_field(hook = on_baud_rate_idx_write)]
-    pub baud_rate_idx: BaudRate,
+    // `BaudRate` index; le gate = the enum ceiling. Zero (0.5M, the rescue
+    // floor) keeps the const image all-zero so SHARED lands in .bss; the
+    // operational default is `ConfigDefaults.baud`, seeded at boot.
+    #[ct_field(le = 3u8, hook = on_baud_rate_idx_write)]
+    pub baud_rate_idx: u8,
     #[ct_field(hook = on_response_deadline_us_write)]
     pub response_deadline_us: u16,
 }

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -4,10 +4,7 @@ use control_table::{Block, Enum, Section};
 // name it (grid law 2). The table field below stays a raw index because the
 // `Enum` derive impls a control-table trait -- orphan-rule-bound to whichever
 // crate defines the type.
-pub use osc_protocol::wire::BaudRate;
-
-/// osc-native sec 7 default: chain reclaim + host timeout, not a reply-time floor.
-pub const DEFAULT_RESPONSE_DEADLINE_US: u16 = 60;
+pub use osc_protocol::wire::{BaudRate, DEFAULT_RESPONSE_DEADLINE_US};
 
 /// Stall detector policy. `repr(u8)`; constructing from an unlisted discriminant is UB,
 /// so validators MUST gate writes to `StallResponse::ALLOWED`.

--- a/firmware/lib/core/src/regions/hooks.rs
+++ b/firmware/lib/core/src/regions/hooks.rs
@@ -14,7 +14,7 @@ use crate::traits::Reply;
 
 pub(crate) trait ControlTableHookEvents {
     fn on_id_write(&mut self, value: u8);
-    fn on_baud_rate_idx_write(&mut self, value: BaudRate);
+    fn on_baud_rate_idx_write(&mut self, value: u8);
     fn on_response_deadline_us_write(&mut self, value: u16);
 }
 
@@ -32,8 +32,12 @@ impl<R: Reply + ?Sized> ControlTableHookEvents for ControlTableHooks<'_, R> {
     fn on_id_write(&mut self, value: u8) {
         self.reply.stage_id(value);
     }
-    fn on_baud_rate_idx_write(&mut self, value: BaudRate) {
-        self.reply.stage_baud(value);
+    fn on_baud_rate_idx_write(&mut self, value: u8) {
+        // The le=3 table rule makes from_idx infallible here; a violated
+        // invariant drops the stage rather than panicking.
+        if let Some(baud) = BaudRate::from_idx(value) {
+            self.reply.stage_baud(baud);
+        }
     }
     fn on_response_deadline_us_write(&mut self, value: u16) {
         self.reply.set_response_deadline(value);

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -82,7 +82,7 @@ impl ControlTableCell {
             cfg.pos_limits.pos_max_soft_urad = defaults.pos_max_phys_urad;
             cfg.calibration.vdd_mv = defaults.vdd_mv;
             cfg.comms.id = defaults.id;
-            cfg.comms.baud_rate_idx = defaults.baud;
+            cfg.comms.baud_rate_idx = defaults.baud.as_idx();
             cfg.comms.response_deadline_us = defaults.response_deadline_us;
         });
     }

--- a/firmware/lib/drivers/src/bus/framer.rs
+++ b/firmware/lib/drivers/src/bus/framer.rs
@@ -90,7 +90,7 @@ const COVERED_TAIL_BYTES: u32 = 2;
 // horizon sacrificed live partials), waiting is free under break framing
 // (position, not the clock, is the truth), and the real bounds are the
 // host's retry timeout (~ms) and ring pressure (512 byte-times).
-const STARVE_GIVEUP_BYTES: u32 = 64;
+const STARVE_GIVEUP_BYTES: u32 = osc_protocol::wire::STARVE_HORIZON_BYTE_TIMES;
 
 // Hunt scan bound per resolve call, so a desynced wake stays bounded; the
 // composite's drive loop re-enters via pend-on-past.

--- a/firmware/lib/host/Cargo.toml
+++ b/firmware/lib/host/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "osc-host"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+osc-protocol = { workspace = true, features = ["software-crc"] }

--- a/firmware/lib/host/src/engine/framer.rs
+++ b/firmware/lib/host/src/engine/framer.rs
@@ -15,12 +15,15 @@ use osc_protocol::FrameBytes;
 use osc_protocol::crc::{osc_crc, osc_crc_continue};
 use osc_protocol::wire::{self, Id, Inst};
 
-/// One CRC-clean frame view over the ring.
+/// One CRC-clean frame view over the ring. `payload_pos` names the
+/// payload's ring index so a caller can re-materialize the view after the
+/// borrow ends (see [`payload_view`]).
 #[derive(Debug)]
 pub struct Frame<'a> {
     pub id: Id,
     pub inst: Inst,
     pub payload: FrameBytes<'a>,
+    pub payload_pos: usize,
 }
 
 /// Outcome of one [`Framer::step`]; callers loop until `Idle` or `Partial`.
@@ -103,13 +106,15 @@ impl Framer {
             return Step::Garble(self.hunt(ring, mask, avail));
         }
 
-        let payload = ring_bytes(
-            ring,
-            (self.anchor + 4) & mask,
-            wire::payload_len(len) as usize,
-        );
+        let payload_pos = (self.anchor + 4) & mask;
+        let payload = payload_view(ring, payload_pos, wire::payload_len(len) as usize);
         self.anchor = (self.anchor + footprint) & mask;
-        Step::Frame(Frame { id, inst, payload })
+        Step::Frame(Frame {
+            id,
+            inst,
+            payload,
+            payload_pos,
+        })
     }
 
     /// Advance past a dead candidate to the next `0x00` within `avail`
@@ -136,8 +141,10 @@ fn ring_crc(ring: &[u8], start: usize, n: usize) -> u16 {
     }
 }
 
-/// Zero-copy view over a possibly-wrapped ring span.
-fn ring_bytes(ring: &[u8], start: usize, n: usize) -> FrameBytes<'_> {
+/// Zero-copy view over a possibly-wrapped ring span. Public within the
+/// engine so a consumed frame's payload can be re-materialized from its
+/// [`Frame::payload_pos`] once the walk's borrow has ended.
+pub(crate) fn payload_view(ring: &[u8], start: usize, n: usize) -> FrameBytes<'_> {
     let head = n.min(ring.len() - start);
     FrameBytes::new(&ring[start..start + head], &ring[..n - head])
 }

--- a/firmware/lib/host/src/engine/framer.rs
+++ b/firmware/lib/host/src/engine/framer.rs
@@ -1,0 +1,345 @@
+//! Host RX framer: a pure ring walker.
+//!
+//! The host has no break wake -- all RX is solicited -- so frames are found
+//! entirely from ring data: a candidate starts at a `0x00` ring byte (the
+//! break's ring image), the header makes its end computable (LEN at byte 2),
+//! and the CRC verdict is the only accept authority. This is the fault
+//! contract (protocol sec 3.4) with the wake deleted: positions from ring
+//! data only; every clock stays in the engine.
+//!
+//! Resync after garble is the hunt: skip to the next `0x00` in the
+//! available span. A data `0x00` can masquerade as an anchor; it dies by
+//! geometry or CRC and costs bounded ring bytes, never the stream.
+
+use osc_protocol::FrameBytes;
+use osc_protocol::crc::{osc_crc, osc_crc_continue};
+use osc_protocol::wire::{self, Id, Inst};
+
+/// One CRC-clean frame view over the ring.
+#[derive(Debug)]
+pub struct Frame<'a> {
+    pub id: Id,
+    pub inst: Inst,
+    pub payload: FrameBytes<'a>,
+}
+
+/// Outcome of one [`Framer::step`]; callers loop until `Idle` or `Partial`.
+#[derive(Debug)]
+pub enum Step<'a> {
+    /// No unconsumed bytes.
+    Idle,
+    /// A candidate frame has started but not fully ringed; positions hold.
+    /// Whether it ever completes is the engine's deadline to keep.
+    Partial,
+    /// One frame consumed.
+    Frame(Frame<'a>),
+    /// `n` ring bytes skipped that anchored no frame.
+    Garble(u16),
+}
+
+/// The walker: one cursor (`anchor`) into the ring, always in `[0, len)`.
+#[derive(Default)]
+pub struct Framer {
+    anchor: usize,
+}
+
+impl Framer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Jump to `cursor`, discarding anything unconsumed. Called only when
+    /// the bus is provably quiet (before a TX window opens) -- the host-side
+    /// analog of the servo's bootstrap-only cursor read.
+    pub fn resync(&mut self, cursor: usize) {
+        self.anchor = cursor;
+    }
+
+    /// Walk one step against the ring state. `cursor` is the next-write
+    /// index in `[0, ring.len())`; the ring length must be a power of two.
+    /// Lap hazard (same as the servo's): more than one ring of unconsumed
+    /// bytes is indistinguishable from an empty ring -- the caller's poll
+    /// cadence keeps consumption within a lap.
+    pub fn step<'a>(&mut self, ring: &'a [u8], cursor: usize) -> Step<'a> {
+        debug_assert!(ring.len().is_power_of_two());
+        let mask = ring.len() - 1;
+        let avail = cursor.wrapping_sub(self.anchor) & mask;
+        if avail == 0 {
+            return Step::Idle;
+        }
+
+        // A frame candidate starts at the break's 0x00 ring byte.
+        if ring[self.anchor] != 0x00 {
+            return Step::Garble(self.hunt(ring, mask, avail));
+        }
+        if avail < 4 {
+            return Step::Partial;
+        }
+
+        let id = Id::new(ring[(self.anchor + 1) & mask]);
+        let len = ring[(self.anchor + 2) & mask];
+        let inst = Inst(ring[(self.anchor + 3) & mask]);
+        let valid_shape = len >= 3
+            && id.is_valid()
+            && (inst.is_status() || inst.opcode().is_some())
+            && wire::footprint(len) <= ring.len();
+        if !valid_shape {
+            return Step::Garble(self.hunt(ring, mask, avail));
+        }
+
+        let footprint = wire::footprint(len);
+        if avail < footprint {
+            return Step::Partial;
+        }
+
+        // CRC over the anchor-inclusive covered span: the leading 0x00 is an
+        // init-0 no-op (protocol sec 3.2), so feeding from the anchor equals
+        // the wire checksum over ID..payload.
+        let clen = wire::covered_len(len);
+        let crc = ring_crc(ring, self.anchor, clen);
+        let lo = ring[(self.anchor + clen) & mask];
+        let hi = ring[(self.anchor + clen + 1) & mask];
+        if crc != u16::from_le_bytes([lo, hi]) {
+            return Step::Garble(self.hunt(ring, mask, avail));
+        }
+
+        let payload = ring_bytes(
+            ring,
+            (self.anchor + 4) & mask,
+            wire::payload_len(len) as usize,
+        );
+        self.anchor = (self.anchor + footprint) & mask;
+        Step::Frame(Frame { id, inst, payload })
+    }
+
+    /// Advance past a dead candidate to the next `0x00` within `avail`
+    /// (skipping the current anchor -- it already failed), or consume the
+    /// whole span if none. Returns the bytes skipped.
+    fn hunt(&mut self, ring: &[u8], mask: usize, avail: usize) -> u16 {
+        let mut n = 1;
+        while n < avail && ring[(self.anchor + n) & mask] != 0x00 {
+            n += 1;
+        }
+        self.anchor = (self.anchor + n) & mask;
+        n as u16
+    }
+}
+
+/// osc-CRC over a possibly-wrapped ring span.
+fn ring_crc(ring: &[u8], start: usize, n: usize) -> u16 {
+    let head = n.min(ring.len() - start);
+    let crc = osc_crc(&ring[start..start + head]);
+    if head == n {
+        crc
+    } else {
+        osc_crc_continue(crc, &ring[..n - head])
+    }
+}
+
+/// Zero-copy view over a possibly-wrapped ring span.
+fn ring_bytes(ring: &[u8], start: usize, n: usize) -> FrameBytes<'_> {
+    let head = n.min(ring.len() - start);
+    FrameBytes::new(&ring[start..start + head], &ring[..n - head])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use osc_protocol::reply::FrameBuf;
+    use osc_protocol::wire::{Opcode, ResultCode};
+
+    /// A 64-byte test ring with a write cursor.
+    struct Ring {
+        buf: [u8; 64],
+        cursor: usize,
+    }
+
+    impl Ring {
+        fn new() -> Self {
+            Ring {
+                buf: [0xFF; 64],
+                cursor: 0,
+            }
+        }
+
+        fn feed(&mut self, bytes: &[u8]) {
+            for &b in bytes {
+                self.buf[self.cursor] = b;
+                self.cursor = (self.cursor + 1) & 63;
+            }
+        }
+    }
+
+    fn status_frame(id: u8, result: ResultCode, payload: &[u8]) -> heapless_vec::Vec {
+        let mut b = FrameBuf::<64>::new();
+        b.start(Id::new(id), Inst::status(result, false));
+        b.payload_mut()[..payload.len()].copy_from_slice(payload);
+        b.finish(payload.len() as u8);
+        heapless_vec::Vec::from(b.seal())
+    }
+
+    /// Minimal fixed vec so tests stay no_std-friendly without heapless.
+    mod heapless_vec {
+        pub struct Vec {
+            buf: [u8; 64],
+            len: usize,
+        }
+        impl Vec {
+            pub fn from(s: &[u8]) -> Self {
+                let mut buf = [0u8; 64];
+                buf[..s.len()].copy_from_slice(s);
+                Vec { buf, len: s.len() }
+            }
+            pub fn as_slice(&self) -> &[u8] {
+                &self.buf[..self.len]
+            }
+        }
+    }
+
+    fn expect_frame<'a>(step: Step<'a>) -> Frame<'a> {
+        match step {
+            Step::Frame(f) => f,
+            other => panic!("expected Frame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clean_status_frame_parses() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        let frame = status_frame(5, ResultCode::Ok, &[0xAA, 0xBB]);
+        ring.feed(frame.as_slice());
+
+        let got = expect_frame(f.step(&ring.buf, ring.cursor));
+        assert_eq!(got.id, Id::new(5));
+        assert!(got.inst.is_status());
+        assert_eq!(got.inst.result(), Some(ResultCode::Ok));
+        assert!(got.payload.bytes().eq([0xAA, 0xBB]));
+        assert!(matches!(f.step(&ring.buf, ring.cursor), Step::Idle));
+    }
+
+    #[test]
+    fn back_to_back_frames_walk_in_order() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        ring.feed(status_frame(1, ResultCode::Ok, &[1]).as_slice());
+        ring.feed(status_frame(2, ResultCode::Ok, &[2]).as_slice());
+
+        assert_eq!(expect_frame(f.step(&ring.buf, ring.cursor)).id, Id::new(1));
+        assert_eq!(expect_frame(f.step(&ring.buf, ring.cursor)).id, Id::new(2));
+        assert!(matches!(f.step(&ring.buf, ring.cursor), Step::Idle));
+    }
+
+    #[test]
+    fn frame_split_across_the_wrap_parses() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        // Park the cursor near the top so the frame wraps.
+        ring.feed(&[0xEE; 60]);
+        f.resync(60);
+        ring.feed(status_frame(7, ResultCode::Ok, &[0x11, 0x22, 0x33]).as_slice());
+
+        let got = expect_frame(f.step(&ring.buf, ring.cursor));
+        assert_eq!(got.id, Id::new(7));
+        assert!(got.payload.bytes().eq([0x11, 0x22, 0x33]));
+    }
+
+    #[test]
+    fn junk_before_a_frame_is_skipped_then_parsed() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        ring.feed(&[0xAA, 0xBB, 0xCC]);
+        ring.feed(status_frame(3, ResultCode::Ok, &[]).as_slice());
+
+        assert!(matches!(f.step(&ring.buf, ring.cursor), Step::Garble(3)));
+        assert_eq!(expect_frame(f.step(&ring.buf, ring.cursor)).id, Id::new(3));
+    }
+
+    #[test]
+    fn corrupt_crc_dies_by_hunt() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        let good = status_frame(4, ResultCode::Ok, &[9, 9]);
+        let mut bad = [0u8; 64];
+        let n = good.as_slice().len();
+        bad[..n].copy_from_slice(good.as_slice());
+        bad[n - 1] ^= 0xFF;
+        ring.feed(&bad[..n]);
+
+        // The corrupt frame anchors, fails CRC, and the hunt walks off it;
+        // successive steps consume the remaining junk without ever yielding
+        // a frame.
+        let mut frames = 0;
+        loop {
+            match f.step(&ring.buf, ring.cursor) {
+                Step::Frame(_) => frames += 1,
+                Step::Garble(_) | Step::Partial => continue,
+                Step::Idle => break,
+            }
+        }
+        assert_eq!(frames, 0);
+    }
+
+    #[test]
+    fn partial_frame_holds_then_completes() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        let frame = status_frame(6, ResultCode::Ok, &[1, 2, 3, 4]);
+        let bytes = frame.as_slice();
+        ring.feed(&bytes[..3]);
+        assert!(matches!(f.step(&ring.buf, ring.cursor), Step::Partial));
+        ring.feed(&bytes[3..5]);
+        assert!(matches!(f.step(&ring.buf, ring.cursor), Step::Partial));
+        ring.feed(&bytes[5..]);
+        assert_eq!(expect_frame(f.step(&ring.buf, ring.cursor)).id, Id::new(6));
+    }
+
+    #[test]
+    fn payload_zeros_do_not_confuse_the_walk() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        ring.feed(status_frame(8, ResultCode::Ok, &[0, 0, 0, 0]).as_slice());
+        ring.feed(status_frame(9, ResultCode::Ok, &[0]).as_slice());
+
+        assert_eq!(expect_frame(f.step(&ring.buf, ring.cursor)).id, Id::new(8));
+        assert_eq!(expect_frame(f.step(&ring.buf, ring.cursor)).id, Id::new(9));
+    }
+
+    #[test]
+    fn masquerading_zero_dies_by_geometry_and_the_real_frame_survives() {
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        // 0x00 followed by an invalid id (0x00): a fake anchor that fails
+        // shape validation; the hunt must find the real frame behind it.
+        ring.feed(&[0x00, 0x00, 0x55]);
+        ring.feed(status_frame(2, ResultCode::Ok, &[7]).as_slice());
+
+        let mut got = None;
+        for _ in 0..8 {
+            match f.step(&ring.buf, ring.cursor) {
+                Step::Frame(fr) => {
+                    got = Some(fr.id);
+                    break;
+                }
+                _ => continue,
+            }
+        }
+        assert_eq!(got, Some(Id::new(2)));
+    }
+
+    #[test]
+    fn instruction_frames_parse_too() {
+        // The walker is direction-neutral: a snooped instruction (or a
+        // rogue-talker frame) parses and classifies by INST bit 7.
+        let mut ring = Ring::new();
+        let mut f = Framer::new();
+        let mut b = FrameBuf::<64>::new();
+        b.start(Id::new(1), Inst::instruction(Opcode::Ping, 0));
+        b.finish(0);
+        ring.feed(b.seal());
+
+        let got = expect_frame(f.step(&ring.buf, ring.cursor));
+        assert!(!got.inst.is_status());
+        assert_eq!(got.inst.opcode(), Some(Opcode::Ping));
+    }
+}

--- a/firmware/lib/host/src/engine/mod.rs
+++ b/firmware/lib/host/src/engine/mod.rs
@@ -1,0 +1,6 @@
+//! The host engine: framer (ring walk), schedule (await modes + deadlines),
+//! and the `HostBus` composite that runs one command at a time.
+
+pub mod framer;
+
+pub use framer::{Frame, Framer, Step};

--- a/firmware/lib/host/src/engine/mod.rs
+++ b/firmware/lib/host/src/engine/mod.rs
@@ -1,6 +1,466 @@
-//! The host engine: framer (ring walk), schedule (await modes + deadlines),
-//! and the `HostBus` composite that runs one command at a time.
+//! `HostBus`: the host engine composite. One outstanding command; every
+//! protocol deadline (RESPONSE_DEADLINE windows, fault pacing, the CAL
+//! train grid, the rescue pulse) executes here, never client-side.
+//!
+//! Sans-io surface: `submit` accepts one [`Command`], the chip (or DES)
+//! calls `poll` freely plus `on_tx_complete`/`on_deadline` from its ISRs,
+//! and `poll` yields [`Event`]s -- streamed statuses, then exactly one
+//! [`Terminal`]. Only the CAL train is time-critical inside `on_deadline`
+//! (break placement rides ISR entry); every other transition times off
+//! `now()` in `poll`, so the hardware compare is just a wake.
 
 pub mod framer;
+pub mod shape;
 
-pub use framer::{Frame, Framer, Step};
+#[cfg(test)]
+mod tests;
+
+use osc_protocol::FrameBytes;
+use osc_protocol::reply::FrameBuf;
+use osc_protocol::wire::{self, BaudRate, Id, Inst};
+
+use crate::traits::{Deadline, Providers, RxRing, TxWire, UsartBaud, tick_reached};
+use framer::{Framer, Step};
+use shape::{InvalidReason, Replies, Shape};
+
+pub use framer::Frame;
+
+/// One logical command; exactly one [`Terminal`] answers it.
+pub enum Command<'a> {
+    /// Any wire instruction, MGMT included. The payload is raw instruction
+    /// payload bytes; [`Shape::derive`] validates per-opcode before anything
+    /// touches the wire. MGMT CAL additionally paces the break train after
+    /// the announce; broadcast ENUM selects collect-until-quiet.
+    Exchange {
+        id: Id,
+        inst: Inst,
+        payload: &'a [u8],
+    },
+    /// Rescue pulse (protocol sec 9.1: ~1 ms dominant low), then the host
+    /// UART drops to 0.5M in the same verb -- rescued servos are at the
+    /// rescue rate by definition, so there is no way to half-do it.
+    Rescue,
+    /// Host-side UART rate only. Servo-first ordering is the client
+    /// choreography's job (write the fleet's baud registers, then this).
+    HostBaud(BaudRate),
+    /// Engine-held copy of the fleet's RESPONSE_DEADLINE register.
+    SetResponseDeadline { us: u16 },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum SubmitError {
+    /// One outstanding command, ever -- including an unconsumed terminal.
+    Busy,
+    Invalid(InvalidReason),
+}
+
+/// Wire-level evidence gathered over one command, attached to its terminal.
+/// The ENUM walk's collision verdicts (clean / garble / quiet) are client
+/// policy over these counts -- the walk never lives in the engine.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WireEvidence {
+    /// CRC-clean status frames delivered.
+    pub statuses: u8,
+    /// Ring bytes that anchored no clean status (junk, CRC failures, and
+    /// any rogue non-status frame).
+    pub garble: u16,
+    /// Garble arrived after the last clean frame -- the sec 9.2 trailing-
+    /// energy signal.
+    pub garble_after_last_frame: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// No reply owed: completed at wire-TX end (NOREPLY, silent broadcast,
+    /// GWRITE, CAL train end, rescue pulse end).
+    Sent,
+    /// Every owed status delivered, or collect-until-quiet went quiet.
+    Complete,
+    /// Slot `slot` produced nothing within its window.
+    Timeout { slot: u8 },
+}
+
+/// The one record that closes a command. `tick` is raw engine ticks
+/// (`Deadline::TICKS_PER_US` converts); the link layer advertises the rate
+/// once rather than converting per record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Terminal {
+    pub outcome: Outcome,
+    pub tick: u32,
+    pub evidence: WireEvidence,
+}
+
+/// Pulled by the caller until `None`; the link server turns these into pipe
+/// records. Statuses stream before their terminal. Status payloads borrow
+/// the ring zero-copy -- consumed before the next call by construction.
+#[derive(Debug)]
+pub enum Event<'a> {
+    Status {
+        /// GREAD list position; 0 for unicast; arrival order under Collect.
+        slot: u8,
+        id: Id,
+        inst: Inst,
+        payload: FrameBytes<'a>,
+    },
+    Done(Terminal),
+}
+
+enum State {
+    Idle,
+    /// Post-garble / post-baud enforced silence before the TX (sec 3.4).
+    Pacing,
+    /// Frame armed on the wire; waiting for the chip's `on_tx_complete`.
+    Transmitting,
+    /// CAL train: `left` breaks still to send on the `gap`-tick grid.
+    Training {
+        left: u8,
+        gap: u32,
+    },
+    /// Rescue pulse held dominant until the deadline.
+    RescueHold,
+    Awaiting,
+}
+
+/// Rescue pulse hold: the sec 9.1 300 us sampler floor plus generous
+/// sampler-jitter margin under load (protocol guidance ~1 ms).
+const RESCUE_HOLD_US: u32 = 1_000;
+/// Await-window slack beyond deadline + reply frame time, in byte-times --
+/// covers the reply gap and scheduling fuzz at any baud.
+const WINDOW_MARGIN_BYTES: u32 = 16;
+/// SAVE/FACTORY flash-stall allowance (sec 9.4: erase + program run
+/// 5-10 ms; ~50 ms is the protocol's comfortable guidance).
+const SLOW_OP_EXTRA_US: u32 = 50_000;
+/// TX scratch: the largest legal frame (258 ring bytes) plus alignment.
+type TxBuf = FrameBuf<264>;
+
+pub struct HostBus<P: Providers> {
+    ring: P::Ring,
+    deadline: P::Deadline,
+    tx: P::Tx,
+    baud: P::Baud,
+    framer: Framer,
+    buf: TxBuf,
+    state: State,
+    /// The active Exchange's derived plan; `None` outside one.
+    plan: Option<Shape>,
+    rate: BaudRate,
+    response_deadline_us: u16,
+    /// Enforced-quiet end after garble evidence / a baud change.
+    pace_until: Option<u32>,
+    /// Current state's deadline tick (window end, pulse end, train slot).
+    deadline_at: u32,
+    /// Await re-arm span: any wire progress pushes the window out by this.
+    window: u32,
+    /// Statuses delivered for the active command.
+    got: u8,
+    last_cursor: u16,
+    evidence: WireEvidence,
+    pending_done: Option<Terminal>,
+}
+
+impl<P: Providers> HostBus<P> {
+    /// `rate` is the UART's current rate as the provider configured it.
+    pub fn new(ring: P::Ring, deadline: P::Deadline, tx: P::Tx, baud: P::Baud) -> Self {
+        Self {
+            ring,
+            deadline,
+            tx,
+            baud,
+            framer: Framer::new(),
+            buf: TxBuf::new(),
+            state: State::Idle,
+            plan: None,
+            rate: BaudRate::B1000000,
+            response_deadline_us: wire::DEFAULT_RESPONSE_DEADLINE_US,
+            pace_until: None,
+            deadline_at: 0,
+            window: 0,
+            got: 0,
+            last_cursor: 0,
+            evidence: WireEvidence::default(),
+            pending_done: None,
+        }
+    }
+
+    pub fn submit(&mut self, cmd: Command<'_>) -> Result<(), SubmitError> {
+        if !matches!(self.state, State::Idle) || self.pending_done.is_some() {
+            return Err(SubmitError::Busy);
+        }
+        self.evidence = WireEvidence::default();
+        match cmd {
+            Command::SetResponseDeadline { us } => {
+                self.response_deadline_us = us;
+                self.finish(Outcome::Complete);
+            }
+            Command::HostBaud(rate) => {
+                self.baud.apply(rate);
+                self.rate = rate;
+                self.pace();
+                self.finish(Outcome::Complete);
+            }
+            Command::Rescue => {
+                self.tx.claim();
+                self.tx.hold_low();
+                self.state = State::RescueHold;
+                self.arm(
+                    self.deadline
+                        .now()
+                        .wrapping_add(RESCUE_HOLD_US * P::Deadline::TICKS_PER_US),
+                );
+            }
+            Command::Exchange { id, inst, payload } => {
+                let plan = Shape::derive(id, inst, payload).map_err(SubmitError::Invalid)?;
+                self.buf.start(id, inst);
+                self.buf.payload_mut()[..payload.len()].copy_from_slice(payload);
+                self.buf.finish(payload.len() as u8);
+                self.buf.seal();
+                self.plan = Some(plan);
+                // Quiet-bus bootstrap: drop anything unconsumed before the
+                // TX window opens (host-side analog of the servo's rule).
+                self.framer.resync(self.ring.cursor() as usize);
+                match self.pace_until.take() {
+                    Some(until) if !tick_reached(self.deadline.now(), until) => {
+                        self.state = State::Pacing;
+                        self.arm(until);
+                    }
+                    _ => self.start_tx(),
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Chip TC ISR: the armed frame span drained (never fired for bare
+    /// breaks -- see [`TxWire::send_break`]).
+    pub fn on_tx_complete(&mut self) {
+        if !matches!(self.state, State::Transmitting) {
+            return;
+        }
+        let Some(plan) = self.plan else {
+            // SAFETY-net: a plan always exists while Transmitting; releasing
+            // the wire beats wedging it if the invariant ever breaks.
+            self.tx.release();
+            self.finish(Outcome::Sent);
+            return;
+        };
+        if let Some((gap_us, gaps)) = plan.train {
+            // The wire stays claimed for the whole train: broadcast CAL
+            // draws no reply, and steady drive keeps the break edges crisp.
+            let gap = gap_us as u32 * P::Deadline::TICKS_PER_US;
+            self.state = State::Training {
+                left: gaps + 1,
+                gap,
+            };
+            self.arm(self.deadline.now().wrapping_add(gap));
+        } else if matches!(plan.replies, Replies::None) {
+            self.tx.release();
+            self.finish(Outcome::Sent);
+        } else {
+            self.tx.release();
+            self.window = self.window_for(&plan);
+            self.got = 0;
+            self.last_cursor = self.ring.cursor();
+            self.state = State::Awaiting;
+            self.arm(self.deadline.now().wrapping_add(self.window));
+        }
+    }
+
+    /// Chip tick-compare ISR. Only the CAL train acts here (break placement
+    /// is time-critical); everything else treats the compare as a wake and
+    /// advances in `poll`.
+    pub fn on_deadline(&mut self) {
+        if let State::Training { left, gap } = self.state {
+            self.tx.send_break();
+            if left <= 1 {
+                self.tx.release();
+                self.finish(Outcome::Sent);
+            } else {
+                self.state = State::Training {
+                    left: left - 1,
+                    gap,
+                };
+                // Next slot on the grid from the previous target, not from
+                // `now` -- ISR entry jitter must not accumulate down the
+                // train (sec 9.3: the host crystal keeps the spacing).
+                self.deadline_at = self.deadline_at.wrapping_add(gap);
+                self.deadline.set(self.deadline_at);
+            }
+        }
+    }
+
+    /// Advance the engine from ring + clock state; at most one event per
+    /// call, so callers loop until `None`. Callable at any frequency.
+    pub fn poll(&mut self) -> Option<Event<'_>> {
+        if let Some(done) = self.pending_done.take() {
+            return Some(Event::Done(done));
+        }
+        let now = self.deadline.now();
+        match self.state {
+            State::Idle | State::Transmitting | State::Training { .. } => {}
+            State::Pacing => {
+                if tick_reached(now, self.deadline_at) {
+                    self.start_tx();
+                }
+            }
+            State::RescueHold => {
+                if tick_reached(now, self.deadline_at) {
+                    self.tx.release();
+                    self.baud.apply(BaudRate::RESCUE);
+                    self.rate = BaudRate::RESCUE;
+                    self.pace();
+                    self.finish(Outcome::Sent);
+                }
+            }
+            State::Awaiting => return self.poll_await(now),
+        }
+        self.pending_done.take().map(Event::Done)
+    }
+
+    fn poll_await(&mut self, now: u32) -> Option<Event<'_>> {
+        let plan = self.plan?;
+        let expected = match plan.replies {
+            Replies::Single => Some(1),
+            Replies::Chain(n) => Some(n),
+            Replies::Collect => None,
+            // Unreachable by construction (Replies::None never awaits);
+            // fall back to a single-reply window rather than wedging.
+            Replies::None => Some(1),
+        };
+        // Precomputed: the status arm below runs under a live ring borrow,
+        // where whole-`self` helpers can't be called.
+        let pace_at = now.wrapping_add(wire::STARVE_HORIZON_BYTE_TIMES * self.byte_ticks());
+        // A yielded status is recorded as coordinates and materialized only
+        // after every mutation -- returning the ring borrow from inside the
+        // walk would pin it across the timeout path below.
+        let mut emit: Option<(u8, Id, Inst, usize, usize)> = None;
+        loop {
+            let cursor = self.ring.cursor() as usize;
+            match self.framer.step(self.ring.bytes(), cursor) {
+                Step::Frame(f) if f.inst.is_status() => {
+                    self.got = self.got.saturating_add(1);
+                    self.evidence.statuses = self.evidence.statuses.saturating_add(1);
+                    self.evidence.garble_after_last_frame = false;
+                    if expected == Some(self.got) {
+                        self.deadline.cancel();
+                        self.state = State::Idle;
+                        if self.evidence.garble > 0 {
+                            self.pace_until = Some(pace_at);
+                        }
+                        self.pending_done = Some(Terminal {
+                            outcome: Outcome::Complete,
+                            tick: now,
+                            evidence: core::mem::take(&mut self.evidence),
+                        });
+                        self.plan = None;
+                    } else {
+                        self.deadline_at = now.wrapping_add(self.window);
+                        self.deadline.set(self.deadline_at);
+                    }
+                    self.last_cursor = cursor as u16;
+                    emit = Some((self.got - 1, f.id, f.inst, f.payload_pos, f.payload.len()));
+                    break;
+                }
+                Step::Frame(f) => {
+                    // A CRC-clean non-status while awaiting: a rogue talker.
+                    // Junk for evidence purposes, but still wire progress.
+                    let footprint = f.payload.len() as u16 + 6;
+                    self.evidence.garble = self.evidence.garble.saturating_add(footprint);
+                    self.evidence.garble_after_last_frame = true;
+                    self.deadline_at = now.wrapping_add(self.window);
+                    self.deadline.set(self.deadline_at);
+                }
+                Step::Garble(n) => {
+                    self.evidence.garble = self.evidence.garble.saturating_add(n);
+                    self.evidence.garble_after_last_frame = true;
+                    self.deadline_at = now.wrapping_add(self.window);
+                    self.deadline.set(self.deadline_at);
+                }
+                Step::Partial | Step::Idle => break,
+            }
+        }
+        if let Some((slot, id, inst, pos, len)) = emit {
+            return Some(Event::Status {
+                slot,
+                id,
+                inst,
+                payload: framer::payload_view(self.ring.bytes(), pos, len),
+            });
+        }
+        // Byte-level progress since the previous poll extends the window;
+        // ring-derived, never IDLE-derived.
+        let cursor = self.ring.cursor();
+        let progressed = cursor != self.last_cursor;
+        self.last_cursor = cursor;
+        if progressed {
+            self.deadline_at = now.wrapping_add(self.window);
+            self.deadline.set(self.deadline_at);
+        } else if tick_reached(now, self.deadline_at) {
+            self.deadline.cancel();
+            let outcome = match plan.replies {
+                // Quiet horizon reached: that IS collect's completion.
+                Replies::Collect => Outcome::Complete,
+                _ => Outcome::Timeout { slot: self.got },
+            };
+            self.finish(outcome);
+        }
+        self.pending_done.take().map(Event::Done)
+    }
+
+    fn start_tx(&mut self) {
+        self.tx.claim();
+        self.tx.send_break();
+        self.tx.send(&self.buf.frame()[1..]);
+        self.state = State::Transmitting;
+    }
+
+    /// Close the command: garble evidence arms the sec 3.4 pacing gap, the
+    /// terminal is queued for the next `poll`.
+    fn finish(&mut self, outcome: Outcome) {
+        if self.evidence.garble > 0 {
+            self.pace();
+        }
+        self.pending_done = Some(Terminal {
+            outcome,
+            tick: self.deadline.now(),
+            evidence: core::mem::take(&mut self.evidence),
+        });
+        self.state = State::Idle;
+        self.plan = None;
+    }
+
+    /// One starve horizon of enforced bus silence at the current rate.
+    fn pace(&mut self) {
+        let quiet = wire::STARVE_HORIZON_BYTE_TIMES * self.byte_ticks();
+        self.pace_until = Some(self.deadline.now().wrapping_add(quiet));
+    }
+
+    fn arm(&mut self, at: u32) {
+        self.deadline_at = at;
+        self.deadline.set(at);
+    }
+
+    /// Full await window: RESPONSE_DEADLINE + the expected reply's wire
+    /// time + margin (+ the ENUM slot draw under Collect, + the flash-stall
+    /// allowance on slow ops). An upper bound for failure detection, not a
+    /// grid -- transport sec 9.4's "elastically late" rule made concrete.
+    fn window_for(&self, plan: &Shape) -> u32 {
+        let t = P::Deadline::TICKS_PER_US;
+        let byte = self.byte_ticks();
+        let mut w = self.response_deadline_us as u32 * t
+            + plan.reply_footprint as u32 * byte
+            + WINDOW_MARGIN_BYTES * byte;
+        if matches!(plan.replies, Replies::Collect) {
+            w += wire::ENUM_REPLY_SLOTS as u32 * byte;
+        }
+        if plan.slow {
+            w += SLOW_OP_EXTRA_US * t;
+        }
+        w
+    }
+
+    /// Ticks per 10-bit character at the current rate. Exact for every
+    /// operational baud; `TICKS_PER_US` up to ~420 stays inside u32.
+    fn byte_ticks(&self) -> u32 {
+        P::Deadline::TICKS_PER_US * 10_000_000 / self.rate.as_hz()
+    }
+}

--- a/firmware/lib/host/src/engine/mod.rs
+++ b/firmware/lib/host/src/engine/mod.rs
@@ -160,7 +160,13 @@ pub struct HostBus<P: Providers> {
 
 impl<P: Providers> HostBus<P> {
     /// `rate` is the UART's current rate as the provider configured it.
-    pub fn new(ring: P::Ring, deadline: P::Deadline, tx: P::Tx, baud: P::Baud) -> Self {
+    pub fn new(
+        ring: P::Ring,
+        deadline: P::Deadline,
+        tx: P::Tx,
+        baud: P::Baud,
+        rate: BaudRate,
+    ) -> Self {
         Self {
             ring,
             deadline,
@@ -170,7 +176,7 @@ impl<P: Providers> HostBus<P> {
             buf: TxBuf::new(),
             state: State::Idle,
             plan: None,
-            rate: BaudRate::B1000000,
+            rate,
             response_deadline_us: wire::DEFAULT_RESPONSE_DEADLINE_US,
             pace_until: None,
             deadline_at: 0,

--- a/firmware/lib/host/src/engine/shape.rs
+++ b/firmware/lib/host/src/engine/shape.rs
@@ -1,0 +1,401 @@
+//! Exchange validation + await-shape derivation: the host-direction mirror
+//! of the servo's decode. Every submitted Exchange runs through [`derive`]
+//! before anything touches the wire -- this is where "clients cannot emit a
+//! malformed frame" lives. The gate is parse-level validity (exactly what
+//! the servo-side parsers accept); semantic verdicts (id ranges, table
+//! addressing, `limit`) stay the servo's nack, reachable by construction.
+
+use osc_protocol::FrameBytes;
+use osc_protocol::frame::{AssignReq, CalReq, EnumReq, MgmtReq, ProfileReq, ReadReq, WriteReq};
+use osc_protocol::group::{
+    GreadPerTarget, GreadProfilePerTarget, GreadProfileUniform, GreadUniform, GwritePerTarget,
+    GwriteUniform,
+};
+use osc_protocol::wire::{self, Id, Inst, MgmtOp, Opcode};
+
+/// Why a submit was refused before reaching the wire.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum InvalidReason {
+    /// Not a wire-valid target (`0x00`, `0xFF`, reserved band).
+    BadId,
+    /// Status bit set or reserved opcode -- hosts send instructions.
+    BadInst,
+    /// Payload does not parse for the opcode/flag combination (includes a
+    /// unicast CAL: its ack would collide with the train, protocol sec 9.3).
+    BadPayload,
+    /// Past the sec 5.1 payload ceiling.
+    TooLong,
+}
+
+/// How many status frames answer the command.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Replies {
+    /// None owed: NOREPLY, non-acking broadcast, GWRITE, CAL.
+    None,
+    /// One status (unicast with reply; broadcast ASSIGN's sole matcher).
+    Single,
+    /// A GREAD status chain, one per listed slot (protocol sec 6).
+    Chain(u8),
+    /// Broadcast ENUM: 0..N replies, gathered until the bus goes quiet.
+    Collect,
+}
+
+/// The engine's plan for one Exchange, derived purely from the instruction.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Shape {
+    pub replies: Replies,
+    /// Ring footprint of the largest expected reply frame (bytes) -- the
+    /// per-slot allowance inside the engine's timeout window.
+    pub reply_footprint: u16,
+    /// MGMT CAL: `(gap_us, gaps)` break train paced after the announce.
+    pub train: Option<(u16, u8)>,
+    /// Flash-stall op (SAVE/FACTORY): widen the window (protocol sec 9.4).
+    pub slow: bool,
+}
+
+/// Largest legal frame footprint -- the allowance when the reply size is
+/// unknowable host-side (profile reads, sec 5.2).
+const MAX_REPLY: u16 = wire::footprint(u8::MAX) as u16;
+/// Empty-payload status footprint (acks, nacks).
+const ACK_REPLY: u16 = wire::footprint(3) as u16;
+/// PING status: model(2) + fw(1).
+const PING_REPLY: u16 = wire::footprint(6) as u16;
+/// ENUM status: the full 16-byte UID.
+const ENUM_REPLY: u16 = wire::footprint(3 + wire::UID_LEN as u8) as u16;
+
+impl Shape {
+    pub fn derive(id: Id, inst: Inst, payload: &[u8]) -> Result<Shape, InvalidReason> {
+        if inst.is_status() {
+            return Err(InvalidReason::BadInst);
+        }
+        let Some(op) = inst.opcode() else {
+            return Err(InvalidReason::BadInst);
+        };
+        if !id.is_valid() {
+            return Err(InvalidReason::BadId);
+        }
+        if payload.len() > wire::MAX_PAYLOAD as usize {
+            return Err(InvalidReason::TooLong);
+        }
+        let pay = FrameBytes::from(payload);
+        let broadcast = id.is_broadcast();
+
+        let mut shape = match op {
+            Opcode::Ping => {
+                if !payload.is_empty() {
+                    return Err(InvalidReason::BadPayload);
+                }
+                Shape::plain(broadcast, PING_REPLY)
+            }
+            Opcode::Read if inst.profile() => {
+                ProfileReq::parse(pay).ok_or(InvalidReason::BadPayload)?;
+                Shape::plain(broadcast, MAX_REPLY)
+            }
+            Opcode::Read => {
+                let r = ReadReq::parse(pay).ok_or(InvalidReason::BadPayload)?;
+                Shape::plain(broadcast, read_reply(r.count))
+            }
+            Opcode::Write => {
+                WriteReq::parse(pay).ok_or(InvalidReason::BadPayload)?;
+                Shape::plain(broadcast, ACK_REPLY)
+            }
+            Opcode::Commit => {
+                if !payload.is_empty() {
+                    return Err(InvalidReason::BadPayload);
+                }
+                Shape::plain(broadcast, ACK_REPLY)
+            }
+            Opcode::Gread => gread(inst, pay)?,
+            Opcode::Gwrite => {
+                // Parse-gate both forms; replies are never owed (sec 5).
+                if inst.per_target() {
+                    GwritePerTarget::parse(pay).ok_or(InvalidReason::BadPayload)?;
+                } else {
+                    GwriteUniform::parse(pay).ok_or(InvalidReason::BadPayload)?;
+                }
+                Shape::silent()
+            }
+            Opcode::Mgmt => mgmt(pay, broadcast)?,
+        };
+
+        // NOREPLY suppresses the status everywhere the servo honors it --
+        // which excludes GREAD slots (a chain slot always replies, sec 6).
+        if inst.noreply() && !matches!(shape.replies, Replies::Chain(_)) {
+            shape.replies = Replies::None;
+        }
+        Ok(shape)
+    }
+
+    /// Plain-op reply rule (sec 5): unicast answers, broadcast is silent.
+    fn plain(broadcast: bool, reply_footprint: u16) -> Shape {
+        Shape {
+            replies: if broadcast {
+                Replies::None
+            } else {
+                Replies::Single
+            },
+            reply_footprint,
+            train: None,
+            slow: false,
+        }
+    }
+
+    fn silent() -> Shape {
+        Shape {
+            replies: Replies::None,
+            reply_footprint: 0,
+            train: None,
+            slow: false,
+        }
+    }
+}
+
+/// Reply footprint for a `count`-byte read; an over-ceiling request draws a
+/// `limit` nack, so the allowance never exceeds the largest legal frame.
+fn read_reply(count: u16) -> u16 {
+    wire::footprint(3 + count.min(wire::MAX_PAYLOAD as u16) as u8) as u16
+}
+
+fn gread(inst: Inst, pay: FrameBytes<'_>) -> Result<Shape, InvalidReason> {
+    let (slots, reply_footprint) = match (inst.profile(), inst.per_target()) {
+        (false, false) => {
+            let g = GreadUniform::parse(pay).ok_or(InvalidReason::BadPayload)?;
+            (g.ids().count(), read_reply(g.count))
+        }
+        (false, true) => {
+            let g = GreadPerTarget::parse(pay).ok_or(InvalidReason::BadPayload)?;
+            let widest = g.iter().map(|t| read_reply(t.count)).max().unwrap_or(0);
+            (g.iter().count(), widest)
+        }
+        (true, false) => {
+            let g = GreadProfileUniform::parse(pay).ok_or(InvalidReason::BadPayload)?;
+            (g.ids().count(), MAX_REPLY)
+        }
+        (true, true) => {
+            let g = GreadProfilePerTarget::parse(pay).ok_or(InvalidReason::BadPayload)?;
+            (g.iter().count(), MAX_REPLY)
+        }
+    };
+    Ok(Shape {
+        replies: Replies::Chain(slots as u8),
+        reply_footprint,
+        train: None,
+        slow: false,
+    })
+}
+
+fn mgmt(pay: FrameBytes<'_>, broadcast: bool) -> Result<Shape, InvalidReason> {
+    let m = MgmtReq::parse(pay).ok_or(InvalidReason::BadPayload)?;
+    Ok(match m.op {
+        MgmtOp::Enum => {
+            EnumReq::parse(m.args).ok_or(InvalidReason::BadPayload)?;
+            Shape {
+                replies: if broadcast {
+                    Replies::Collect
+                } else {
+                    Replies::Single
+                },
+                reply_footprint: ENUM_REPLY,
+                train: None,
+                slow: false,
+            }
+        }
+        MgmtOp::Assign => {
+            AssignReq::parse(m.args).ok_or(InvalidReason::BadPayload)?;
+            // The sole matcher acks even under broadcast (sec 9.2).
+            Shape {
+                replies: Replies::Single,
+                reply_footprint: ACK_REPLY,
+                train: None,
+                slow: false,
+            }
+        }
+        MgmtOp::Cal => {
+            let c = CalReq::parse(m.args).ok_or(InvalidReason::BadPayload)?;
+            // Broadcast-only (sec 9.3): a unicast CAL's ack would land where
+            // the train starts. Refused here, not discovered on the wire.
+            if !broadcast {
+                return Err(InvalidReason::BadPayload);
+            }
+            Shape {
+                replies: Replies::None,
+                reply_footprint: 0,
+                train: Some((c.gap_us, c.gaps)),
+                slow: false,
+            }
+        }
+        MgmtOp::Save | MgmtOp::Factory => {
+            if !m.args.is_empty() {
+                return Err(InvalidReason::BadPayload);
+            }
+            Shape {
+                slow: true,
+                ..Shape::plain(broadcast, ACK_REPLY)
+            }
+        }
+        // REBOOT args are implementation-defined (sec 9.5): pass through.
+        MgmtOp::Reboot => Shape::plain(broadcast, ACK_REPLY),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use osc_protocol::build;
+    use osc_protocol::wire::MAX_PAYLOAD;
+
+    const UNI: Id = Id(5);
+    const BC: Id = Id::BROADCAST;
+
+    fn inst(op: Opcode, flags: u8) -> Inst {
+        Inst::instruction(op, flags)
+    }
+
+    #[test]
+    fn ping_shapes() {
+        let s = Shape::derive(UNI, inst(Opcode::Ping, 0), &[]).unwrap();
+        assert_eq!(s.replies, Replies::Single);
+        assert_eq!(s.reply_footprint, 9);
+        let s = Shape::derive(BC, inst(Opcode::Ping, 0), &[]).unwrap();
+        assert_eq!(s.replies, Replies::None);
+        assert_eq!(
+            Shape::derive(UNI, inst(Opcode::Ping, 0), &[1]),
+            Err(InvalidReason::BadPayload)
+        );
+    }
+
+    #[test]
+    fn statuses_and_bad_ids_refuse() {
+        assert_eq!(
+            Shape::derive(UNI, Inst::status(wire::ResultCode::Ok, false), &[]),
+            Err(InvalidReason::BadInst)
+        );
+        assert_eq!(
+            Shape::derive(Id(0), inst(Opcode::Ping, 0), &[]),
+            Err(InvalidReason::BadId)
+        );
+        assert_eq!(
+            Shape::derive(Id(0xFA), inst(Opcode::Ping, 0), &[]),
+            Err(InvalidReason::BadId)
+        );
+        assert_eq!(
+            Shape::derive(UNI, Inst(0x00), &[]),
+            Err(InvalidReason::BadInst)
+        );
+    }
+
+    #[test]
+    fn read_reply_footprint_tracks_count() {
+        let mut b = [0u8; 8];
+        let n = build::read(&mut b, 0x0100, 16).unwrap();
+        let s = Shape::derive(UNI, inst(Opcode::Read, 0), &b[..n]).unwrap();
+        assert_eq!(s.reply_footprint, wire::footprint(3 + 16) as u16);
+        // Over-ceiling read: the allowance caps at the largest legal frame.
+        let n = build::read(&mut b, 0x0100, 4096).unwrap();
+        let s = Shape::derive(UNI, inst(Opcode::Read, 0), &b[..n]).unwrap();
+        assert_eq!(s.reply_footprint, MAX_REPLY);
+    }
+
+    #[test]
+    fn noreply_silences_plain_but_not_chains() {
+        let mut b = [0u8; 16];
+        let n = build::write(&mut b, 0x0180, &[1, 2]).unwrap();
+        let s = Shape::derive(UNI, inst(Opcode::Write, Inst::FLAG_NOREPLY), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::None);
+
+        let ids = [Id(1), Id(2)];
+        let n = build::gread_uniform(&mut b, 0, 4, &ids).unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Gread, Inst::FLAG_NOREPLY), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::Chain(2));
+    }
+
+    #[test]
+    fn gread_chain_counts_slots() {
+        let mut b = [0u8; 32];
+        let ids = [Id(1), Id(2), Id(9)];
+        let n = build::gread_uniform(&mut b, 0x0084, 8, &ids).unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Gread, 0), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::Chain(3));
+        assert_eq!(s.reply_footprint, wire::footprint(3 + 8) as u16);
+    }
+
+    #[test]
+    fn gread_per_target_takes_the_widest_slot() {
+        let mut b = [0u8; 32];
+        let ts = [
+            osc_protocol::group::GreadTarget {
+                id: Id(1),
+                addr: 0,
+                count: 2,
+            },
+            osc_protocol::group::GreadTarget {
+                id: Id(2),
+                addr: 0,
+                count: 40,
+            },
+        ];
+        let n = build::gread_per_target(&mut b, &ts).unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Gread, Inst::FLAG_PER_TARGET), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::Chain(2));
+        assert_eq!(s.reply_footprint, wire::footprint(3 + 40) as u16);
+    }
+
+    #[test]
+    fn gwrite_is_silent_and_parse_gated() {
+        let mut b = [0u8; 32];
+        let mut w = build::GwriteUniform::new(&mut b, 0x74, 4).unwrap();
+        w.push(Id(1), &[0, 8, 0, 0]).unwrap();
+        let n = w.finish().unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Gwrite, Inst::FLAG_HOLD), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::None);
+        // Ragged payload refuses.
+        assert_eq!(
+            Shape::derive(BC, inst(Opcode::Gwrite, 0), &b[..n - 1]),
+            Err(InvalidReason::BadPayload)
+        );
+    }
+
+    #[test]
+    fn mgmt_shapes() {
+        let mut b = [0u8; 32];
+
+        let prefix = [0u8; wire::UID_LEN];
+        let n = build::mgmt_enum(&mut b, 0, &prefix).unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Mgmt, 0), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::Collect);
+        let s = Shape::derive(UNI, inst(Opcode::Mgmt, 0), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::Single);
+
+        let uid = [3u8; wire::UID_LEN];
+        let n = build::mgmt_assign(&mut b, &uid, 7).unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Mgmt, 0), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::Single);
+
+        let n = build::mgmt(&mut b, MgmtOp::Save).unwrap();
+        let s = Shape::derive(UNI, inst(Opcode::Mgmt, 0), &b[..n]).unwrap();
+        assert!(s.slow);
+        assert_eq!(s.replies, Replies::Single);
+    }
+
+    #[test]
+    fn cal_is_broadcast_only_and_carries_the_train() {
+        let mut b = [0u8; 8];
+        let n = build::mgmt_cal(&mut b, 400, 8).unwrap();
+        let s = Shape::derive(BC, inst(Opcode::Mgmt, 0), &b[..n]).unwrap();
+        assert_eq!(s.replies, Replies::None);
+        assert_eq!(s.train, Some((400, 8)));
+        assert_eq!(
+            Shape::derive(UNI, inst(Opcode::Mgmt, 0), &b[..n]),
+            Err(InvalidReason::BadPayload)
+        );
+    }
+
+    #[test]
+    fn oversized_payload_refuses() {
+        let big = [0u8; MAX_PAYLOAD as usize + 1];
+        assert_eq!(
+            Shape::derive(UNI, inst(Opcode::Write, 0), &big),
+            Err(InvalidReason::TooLong)
+        );
+    }
+}

--- a/firmware/lib/host/src/engine/tests.rs
+++ b/firmware/lib/host/src/engine/tests.rs
@@ -1,168 +1,16 @@
 //! `HostBus` scenarios over recording fakes (the drivers-crate mock spirit:
 //! cloneable `Rc` state companions, one clone moved into the engine).
 
-use std::cell::{Cell, UnsafeCell};
-use std::rc::Rc;
 use std::vec;
 use std::vec::Vec;
 
 use osc_protocol::build;
-use osc_protocol::reply::FrameBuf;
 use osc_protocol::wire::{BaudRate, Id, Inst, Opcode, ResultCode, UID_LEN};
 
 use super::*;
-use crate::traits;
-
-const RING_LEN: usize = 512;
-
-struct RingState {
-    buf: UnsafeCell<[u8; RING_LEN]>,
-    cursor: Cell<u16>,
-}
-
-/// Counted RX ring the test feeds like the wire would.
-#[derive(Clone)]
-struct FakeRing(Rc<RingState>);
-
-impl FakeRing {
-    fn new() -> Self {
-        FakeRing(Rc::new(RingState {
-            buf: UnsafeCell::new([0xFF; RING_LEN]),
-            cursor: Cell::new(0),
-        }))
-    }
-
-    /// Ring bytes in at the cursor, advancing it -- one wire arrival.
-    fn feed(&self, bytes: &[u8]) {
-        // SAFETY: test-only, single-threaded; never called while a
-        // `bytes()` slice is live.
-        let buf = unsafe { &mut *self.0.buf.get() };
-        let mut c = self.0.cursor.get() as usize;
-        for &b in bytes {
-            buf[c] = b;
-            c = (c + 1) % RING_LEN;
-        }
-        self.0.cursor.set(c as u16);
-    }
-}
-
-impl traits::RxRing for FakeRing {
-    fn bytes(&self) -> &[u8] {
-        // SAFETY: test-only aliasing; the buffer is never fed while a
-        // returned slice is live (see `feed`).
-        let arr: &[u8; RING_LEN] = unsafe { &*self.0.buf.get() };
-        &arr[..]
-    }
-
-    fn cursor(&self) -> u16 {
-        self.0.cursor.get()
-    }
-}
-
-struct ClockState {
-    now: Cell<u32>,
-    armed: Cell<Option<u32>>,
-}
-
-/// Settable clock + a record of the armed compare.
-#[derive(Clone)]
-struct FakeDeadline(Rc<ClockState>);
-
-impl FakeDeadline {
-    fn new() -> Self {
-        FakeDeadline(Rc::new(ClockState {
-            now: Cell::new(0),
-            armed: Cell::new(None),
-        }))
-    }
-
-    fn advance(&self, ticks: u32) {
-        self.0.now.set(self.0.now.get().wrapping_add(ticks));
-    }
-
-    fn armed(&self) -> Option<u32> {
-        self.0.armed.get()
-    }
-}
-
-impl traits::Deadline for FakeDeadline {
-    const TICKS_PER_US: u32 = 1;
-
-    fn now(&self) -> u32 {
-        self.0.now.get()
-    }
-
-    fn set(&mut self, at: u32) {
-        self.0.armed.set(Some(at));
-    }
-
-    fn cancel(&mut self) {
-        self.0.armed.set(None);
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum WireOp {
-    Claim,
-    Break,
-    Send(Vec<u8>),
-    HoldLow,
-    Release,
-}
-
-#[derive(Clone, Default)]
-struct FakeWire(Rc<std::cell::RefCell<Vec<WireOp>>>);
-
-impl FakeWire {
-    fn log(&self) -> Vec<WireOp> {
-        self.0.borrow().clone()
-    }
-
-    fn clear(&self) {
-        self.0.borrow_mut().clear();
-    }
-}
-
-impl traits::TxWire for FakeWire {
-    fn claim(&mut self) {
-        self.0.borrow_mut().push(WireOp::Claim);
-    }
-    fn send_break(&mut self) {
-        self.0.borrow_mut().push(WireOp::Break);
-    }
-    fn send(&mut self, span: &[u8]) {
-        self.0.borrow_mut().push(WireOp::Send(span.to_vec()));
-    }
-    fn hold_low(&mut self) {
-        self.0.borrow_mut().push(WireOp::HoldLow);
-    }
-    fn release(&mut self) {
-        self.0.borrow_mut().push(WireOp::Release);
-    }
-}
-
-#[derive(Clone, Default)]
-struct FakeBaud(Rc<std::cell::RefCell<Vec<BaudRate>>>);
-
-impl FakeBaud {
-    fn applied(&self) -> Vec<BaudRate> {
-        self.0.borrow().clone()
-    }
-}
-
-impl traits::UsartBaud for FakeBaud {
-    fn apply(&mut self, baud: BaudRate) {
-        self.0.borrow_mut().push(baud);
-    }
-}
-
-struct TestProviders;
-impl traits::Providers for TestProviders {
-    type Ring = FakeRing;
-    type Deadline = FakeDeadline;
-    type Tx = FakeWire;
-    type Baud = FakeBaud;
-}
+use crate::testutil::{
+    FakeBaud, FakeDeadline, FakeRing, FakeWire, TestProviders, WireOp, sealed_status,
+};
 
 struct Rig {
     bus: HostBus<TestProviders>,
@@ -185,14 +33,6 @@ fn rig() -> Rig {
         wire,
         baud,
     }
-}
-
-fn sealed_status(id: u8, result: ResultCode, payload: &[u8]) -> Vec<u8> {
-    let mut b = FrameBuf::<264>::new();
-    b.start(Id::new(id), Inst::status(result, false));
-    b.payload_mut()[..payload.len()].copy_from_slice(payload);
-    b.finish(payload.len() as u8);
-    b.seal().to_vec()
 }
 
 fn ping(id: u8) -> (Id, Inst) {

--- a/firmware/lib/host/src/engine/tests.rs
+++ b/firmware/lib/host/src/engine/tests.rs
@@ -1,0 +1,571 @@
+//! `HostBus` scenarios over recording fakes (the drivers-crate mock spirit:
+//! cloneable `Rc` state companions, one clone moved into the engine).
+
+use std::cell::{Cell, UnsafeCell};
+use std::rc::Rc;
+use std::vec;
+use std::vec::Vec;
+
+use osc_protocol::build;
+use osc_protocol::reply::FrameBuf;
+use osc_protocol::wire::{BaudRate, Id, Inst, Opcode, ResultCode, UID_LEN};
+
+use super::*;
+use crate::traits;
+
+const RING_LEN: usize = 512;
+
+struct RingState {
+    buf: UnsafeCell<[u8; RING_LEN]>,
+    cursor: Cell<u16>,
+}
+
+/// Counted RX ring the test feeds like the wire would.
+#[derive(Clone)]
+struct FakeRing(Rc<RingState>);
+
+impl FakeRing {
+    fn new() -> Self {
+        FakeRing(Rc::new(RingState {
+            buf: UnsafeCell::new([0xFF; RING_LEN]),
+            cursor: Cell::new(0),
+        }))
+    }
+
+    /// Ring bytes in at the cursor, advancing it -- one wire arrival.
+    fn feed(&self, bytes: &[u8]) {
+        // SAFETY: test-only, single-threaded; never called while a
+        // `bytes()` slice is live.
+        let buf = unsafe { &mut *self.0.buf.get() };
+        let mut c = self.0.cursor.get() as usize;
+        for &b in bytes {
+            buf[c] = b;
+            c = (c + 1) % RING_LEN;
+        }
+        self.0.cursor.set(c as u16);
+    }
+}
+
+impl traits::RxRing for FakeRing {
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: test-only aliasing; the buffer is never fed while a
+        // returned slice is live (see `feed`).
+        let arr: &[u8; RING_LEN] = unsafe { &*self.0.buf.get() };
+        &arr[..]
+    }
+
+    fn cursor(&self) -> u16 {
+        self.0.cursor.get()
+    }
+}
+
+struct ClockState {
+    now: Cell<u32>,
+    armed: Cell<Option<u32>>,
+}
+
+/// Settable clock + a record of the armed compare.
+#[derive(Clone)]
+struct FakeDeadline(Rc<ClockState>);
+
+impl FakeDeadline {
+    fn new() -> Self {
+        FakeDeadline(Rc::new(ClockState {
+            now: Cell::new(0),
+            armed: Cell::new(None),
+        }))
+    }
+
+    fn advance(&self, ticks: u32) {
+        self.0.now.set(self.0.now.get().wrapping_add(ticks));
+    }
+
+    fn armed(&self) -> Option<u32> {
+        self.0.armed.get()
+    }
+}
+
+impl traits::Deadline for FakeDeadline {
+    const TICKS_PER_US: u32 = 1;
+
+    fn now(&self) -> u32 {
+        self.0.now.get()
+    }
+
+    fn set(&mut self, at: u32) {
+        self.0.armed.set(Some(at));
+    }
+
+    fn cancel(&mut self) {
+        self.0.armed.set(None);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WireOp {
+    Claim,
+    Break,
+    Send(Vec<u8>),
+    HoldLow,
+    Release,
+}
+
+#[derive(Clone, Default)]
+struct FakeWire(Rc<std::cell::RefCell<Vec<WireOp>>>);
+
+impl FakeWire {
+    fn log(&self) -> Vec<WireOp> {
+        self.0.borrow().clone()
+    }
+
+    fn clear(&self) {
+        self.0.borrow_mut().clear();
+    }
+}
+
+impl traits::TxWire for FakeWire {
+    fn claim(&mut self) {
+        self.0.borrow_mut().push(WireOp::Claim);
+    }
+    fn send_break(&mut self) {
+        self.0.borrow_mut().push(WireOp::Break);
+    }
+    fn send(&mut self, span: &[u8]) {
+        self.0.borrow_mut().push(WireOp::Send(span.to_vec()));
+    }
+    fn hold_low(&mut self) {
+        self.0.borrow_mut().push(WireOp::HoldLow);
+    }
+    fn release(&mut self) {
+        self.0.borrow_mut().push(WireOp::Release);
+    }
+}
+
+#[derive(Clone, Default)]
+struct FakeBaud(Rc<std::cell::RefCell<Vec<BaudRate>>>);
+
+impl FakeBaud {
+    fn applied(&self) -> Vec<BaudRate> {
+        self.0.borrow().clone()
+    }
+}
+
+impl traits::UsartBaud for FakeBaud {
+    fn apply(&mut self, baud: BaudRate) {
+        self.0.borrow_mut().push(baud);
+    }
+}
+
+struct TestProviders;
+impl traits::Providers for TestProviders {
+    type Ring = FakeRing;
+    type Deadline = FakeDeadline;
+    type Tx = FakeWire;
+    type Baud = FakeBaud;
+}
+
+struct Rig {
+    bus: HostBus<TestProviders>,
+    ring: FakeRing,
+    clock: FakeDeadline,
+    wire: FakeWire,
+    baud: FakeBaud,
+}
+
+fn rig() -> Rig {
+    let ring = FakeRing::new();
+    let clock = FakeDeadline::new();
+    let wire = FakeWire::default();
+    let baud = FakeBaud::default();
+    let bus = HostBus::new(ring.clone(), clock.clone(), wire.clone(), baud.clone());
+    Rig {
+        bus,
+        ring,
+        clock,
+        wire,
+        baud,
+    }
+}
+
+fn sealed_status(id: u8, result: ResultCode, payload: &[u8]) -> Vec<u8> {
+    let mut b = FrameBuf::<264>::new();
+    b.start(Id::new(id), Inst::status(result, false));
+    b.payload_mut()[..payload.len()].copy_from_slice(payload);
+    b.finish(payload.len() as u8);
+    b.seal().to_vec()
+}
+
+fn ping(id: u8) -> (Id, Inst) {
+    (Id::new(id), Inst::instruction(Opcode::Ping, 0))
+}
+
+/// Submit + drive the TX to completion (claim/break/send observed).
+fn exchange(r: &mut Rig, id: Id, inst: Inst, payload: &[u8]) {
+    r.bus
+        .submit(Command::Exchange { id, inst, payload })
+        .expect("valid exchange");
+    r.bus.on_tx_complete();
+}
+
+fn expect_done(r: &mut Rig) -> Terminal {
+    match r.bus.poll() {
+        Some(Event::Done(t)) => t,
+        other => panic!("expected Done, got {other:?}"),
+    }
+}
+
+fn expect_status(r: &mut Rig) -> (u8, Id) {
+    match r.bus.poll() {
+        Some(Event::Status { slot, id, .. }) => (slot, id),
+        other => panic!("expected Status, got {other:?}"),
+    }
+}
+
+#[test]
+fn ping_round_trip() {
+    let mut r = rig();
+    let (id, inst) = ping(1);
+    r.bus
+        .submit(Command::Exchange {
+            id,
+            inst,
+            payload: &[],
+        })
+        .unwrap();
+
+    // Claim -> law break -> one arm carrying the sealed frame sans the
+    // alignment byte (the break is the wire's 0x00). The bytes are the
+    // protocol sec 3.2 PING id 1 vector.
+    let log = r.wire.log();
+    assert_eq!(log[0], WireOp::Claim);
+    assert_eq!(log[1], WireOp::Break);
+    assert_eq!(log[2], WireOp::Send(vec![0x01, 0x03, 0x10, 0x50, 0xFC]));
+
+    r.bus.on_tx_complete();
+    assert_eq!(r.wire.log()[3], WireOp::Release);
+
+    r.ring
+        .feed(&sealed_status(1, ResultCode::Ok, &[0x2A, 0x00, 0x01]));
+    let (slot, sid) = expect_status(&mut r);
+    assert_eq!((slot, sid), (0, Id::new(1)));
+
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+    assert_eq!(t.evidence.statuses, 1);
+    assert_eq!(t.evidence.garble, 0);
+    assert!(r.bus.poll().is_none());
+
+    // The engine is idle again.
+    let (id, inst) = ping(5);
+    assert!(
+        r.bus
+            .submit(Command::Exchange {
+                id,
+                inst,
+                payload: &[]
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn one_outstanding_command_ever() {
+    let mut r = rig();
+    let (id, inst) = ping(5);
+    r.bus
+        .submit(Command::Exchange {
+            id,
+            inst,
+            payload: &[],
+        })
+        .unwrap();
+    assert_eq!(
+        r.bus.submit(Command::Rescue),
+        Err(SubmitError::Busy),
+        "mid-exchange"
+    );
+
+    r.bus.on_tx_complete();
+    r.ring.feed(&sealed_status(5, ResultCode::Ok, &[1, 2, 3]));
+    let _ = expect_status(&mut r);
+    // Terminal queued but unconsumed: still busy.
+    assert_eq!(r.bus.submit(Command::Rescue), Err(SubmitError::Busy));
+    let _ = expect_done(&mut r);
+    assert!(r.bus.submit(Command::Rescue).is_ok());
+}
+
+#[test]
+fn invalid_exchange_never_touches_the_wire() {
+    let mut r = rig();
+    let err = r.bus.submit(Command::Exchange {
+        id: Id::new(0),
+        inst: Inst::instruction(Opcode::Ping, 0),
+        payload: &[],
+    });
+    assert_eq!(err, Err(SubmitError::Invalid(shape::InvalidReason::BadId)));
+    assert!(r.wire.log().is_empty());
+    // And the engine stayed idle -- a refused submit costs nothing.
+    let (id, inst) = ping(1);
+    assert!(
+        r.bus
+            .submit(Command::Exchange {
+                id,
+                inst,
+                payload: &[]
+            })
+            .is_ok()
+    );
+}
+
+#[test]
+fn noreply_write_completes_at_wire_end() {
+    let mut r = rig();
+    let mut p = [0u8; 8];
+    let n = build::write(&mut p, 0x0180, &[0x2C, 0x01]).unwrap();
+    exchange(
+        &mut r,
+        Id::new(5),
+        Inst::instruction(Opcode::Write, Inst::FLAG_NOREPLY),
+        &p[..n],
+    );
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Sent);
+    assert_eq!(*r.wire.log().last().unwrap(), WireOp::Release);
+}
+
+#[test]
+fn timeout_when_the_bus_stays_silent() {
+    let mut r = rig();
+    let (id, inst) = ping(5);
+    exchange(&mut r, id, inst, &[]);
+    assert!(r.bus.poll().is_none());
+
+    // Window: RESPONSE_DEADLINE(60) + (9 + 16 margin) bytes x 10 us = 310.
+    r.clock.advance(311);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Timeout { slot: 0 });
+    assert_eq!(t.evidence.statuses, 0);
+}
+
+#[test]
+fn gread_chain_streams_slots_in_order() {
+    let mut r = rig();
+    let mut p = [0u8; 16];
+    let ids = [Id::new(1), Id::new(2), Id::new(3)];
+    let n = build::gread_uniform(&mut p, 0x0084, 4, &ids).unwrap();
+    exchange(
+        &mut r,
+        Id::BROADCAST,
+        Inst::instruction(Opcode::Gread, 0),
+        &p[..n],
+    );
+
+    for (k, id) in ids.iter().enumerate() {
+        r.ring
+            .feed(&sealed_status(id.as_byte(), ResultCode::Ok, &[0; 4]));
+        let (slot, sid) = expect_status(&mut r);
+        assert_eq!((slot, sid), (k as u8, *id));
+    }
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+    assert_eq!(t.evidence.statuses, 3);
+}
+
+#[test]
+fn chain_timeout_names_the_missing_slot() {
+    let mut r = rig();
+    let mut p = [0u8; 16];
+    let ids = [Id::new(1), Id::new(2), Id::new(3)];
+    let n = build::gread_uniform(&mut p, 0x0084, 4, &ids).unwrap();
+    exchange(
+        &mut r,
+        Id::BROADCAST,
+        Inst::instruction(Opcode::Gread, 0),
+        &p[..n],
+    );
+
+    r.ring.feed(&sealed_status(1, ResultCode::Ok, &[0; 4]));
+    let _ = expect_status(&mut r);
+    r.ring.feed(&sealed_status(2, ResultCode::Ok, &[0; 4]));
+    let _ = expect_status(&mut r);
+
+    r.clock.advance(10_000);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Timeout { slot: 2 });
+    assert_eq!(t.evidence.statuses, 2);
+}
+
+#[test]
+fn broadcast_enum_collects_until_quiet() {
+    let mut r = rig();
+    let mut p = [0u8; 24];
+    let prefix = [0u8; UID_LEN];
+    let n = build::mgmt_enum(&mut p, 0, &prefix).unwrap();
+    exchange(
+        &mut r,
+        Id::BROADCAST,
+        Inst::instruction(Opcode::Mgmt, 0),
+        &p[..n],
+    );
+
+    r.ring
+        .feed(&sealed_status(10, ResultCode::Ok, &[0xAA; UID_LEN]));
+    let (slot, _) = expect_status(&mut r);
+    assert_eq!(slot, 0);
+    r.ring
+        .feed(&sealed_status(11, ResultCode::Ok, &[0xBB; UID_LEN]));
+    let (slot, _) = expect_status(&mut r);
+    assert_eq!(slot, 1);
+
+    // Quiet horizon reached: collect completes rather than timing out.
+    r.clock.advance(10_000);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+    assert_eq!(t.evidence.statuses, 2);
+}
+
+#[test]
+fn garble_is_evidence_and_paces_the_next_exchange() {
+    let mut r = rig();
+    let (id, inst) = ping(5);
+    exchange(&mut r, id, inst, &[]);
+
+    // Junk, then the clean reply: garble counted, not trailing.
+    r.ring.feed(&[0xAA, 0xBB, 0xCC]);
+    r.ring.feed(&sealed_status(5, ResultCode::Ok, &[1, 2, 3]));
+    let _ = expect_status(&mut r);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+    assert_eq!(t.evidence.garble, 3);
+    assert!(!t.evidence.garble_after_last_frame);
+
+    // The sec 3.4 pacing gap: the next exchange holds off the wire for one
+    // starve horizon (64 byte-times = 640 us at 1M).
+    r.wire.clear();
+    let (id, inst) = ping(5);
+    r.bus
+        .submit(Command::Exchange {
+            id,
+            inst,
+            payload: &[],
+        })
+        .unwrap();
+    assert!(r.bus.poll().is_none());
+    assert!(r.wire.log().is_empty(), "paced: nothing on the wire yet");
+    r.clock.advance(641);
+    assert!(r.bus.poll().is_none());
+    assert_eq!(r.wire.log()[0], WireOp::Claim, "pacing gap elapsed -> TX");
+}
+
+#[test]
+fn trailing_energy_is_flagged() {
+    let mut r = rig();
+    let mut p = [0u8; 24];
+    let prefix = [0u8; UID_LEN];
+    let n = build::mgmt_enum(&mut p, 0, &prefix).unwrap();
+    exchange(
+        &mut r,
+        Id::BROADCAST,
+        Inst::instruction(Opcode::Mgmt, 0),
+        &p[..n],
+    );
+
+    r.ring
+        .feed(&sealed_status(10, ResultCode::Ok, &[0xAA; UID_LEN]));
+    let _ = expect_status(&mut r);
+    // Collision residue after the clean frame.
+    r.ring.feed(&[0x48, 0x12]);
+    assert!(r.bus.poll().is_none());
+
+    r.clock.advance(10_000);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+    assert!(t.evidence.garble_after_last_frame);
+}
+
+#[test]
+fn cal_train_rides_a_drift_free_grid() {
+    let mut r = rig();
+    let mut p = [0u8; 8];
+    let n = build::mgmt_cal(&mut p, 400, 3).unwrap();
+    exchange(
+        &mut r,
+        Id::BROADCAST,
+        Inst::instruction(Opcode::Mgmt, 0),
+        &p[..n],
+    );
+
+    // gaps + 1 = 4 breaks, each armed at the previous target + gap -- ISR
+    // lateness must not accumulate down the train.
+    let mut grid = Vec::new();
+    for _ in 0..4 {
+        grid.push(r.clock.armed().expect("train slot armed"));
+        r.bus.on_deadline();
+    }
+    assert_eq!(grid, vec![400, 800, 1200, 1600]);
+
+    let breaks = r
+        .wire
+        .log()
+        .iter()
+        .filter(|op| **op == WireOp::Break)
+        .count();
+    assert_eq!(breaks, 5, "announce break + 4 train breaks");
+    assert_eq!(*r.wire.log().last().unwrap(), WireOp::Release);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Sent);
+}
+
+#[test]
+fn rescue_pulses_then_drops_to_the_rescue_rate() {
+    let mut r = rig();
+    r.bus.submit(Command::Rescue).unwrap();
+    assert_eq!(r.wire.log(), vec![WireOp::Claim, WireOp::HoldLow]);
+    assert!(r.bus.poll().is_none(), "pulse still held");
+
+    r.clock.advance(1_001);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Sent);
+    assert_eq!(*r.wire.log().last().unwrap(), WireOp::Release);
+    assert_eq!(r.baud.applied(), vec![BaudRate::RESCUE]);
+
+    // Rescued servos need the pacing gap before crisp turnarounds.
+    r.wire.clear();
+    let (id, inst) = ping(5);
+    r.bus
+        .submit(Command::Exchange {
+            id,
+            inst,
+            payload: &[],
+        })
+        .unwrap();
+    assert!(r.wire.log().is_empty(), "paced after rescue");
+}
+
+#[test]
+fn host_baud_applies_and_completes() {
+    let mut r = rig();
+    r.bus.submit(Command::HostBaud(BaudRate::B3000000)).unwrap();
+    assert_eq!(r.baud.applied(), vec![BaudRate::B3000000]);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+}
+
+#[test]
+fn response_deadline_setting_stretches_the_window() {
+    let mut r = rig();
+    r.bus
+        .submit(Command::SetResponseDeadline { us: 1_000 })
+        .unwrap();
+    let _ = expect_done(&mut r);
+
+    let (id, inst) = ping(5);
+    exchange(&mut r, id, inst, &[]);
+    // The old 310-tick window would have expired; the widened one holds.
+    r.clock.advance(700);
+    assert!(r.bus.poll().is_none());
+    r.ring.feed(&sealed_status(5, ResultCode::Ok, &[1, 2, 3]));
+    let _ = expect_status(&mut r);
+    let t = expect_done(&mut r);
+    assert_eq!(t.outcome, Outcome::Complete);
+}

--- a/firmware/lib/host/src/engine/tests.rs
+++ b/firmware/lib/host/src/engine/tests.rs
@@ -25,7 +25,13 @@ fn rig() -> Rig {
     let clock = FakeDeadline::new();
     let wire = FakeWire::default();
     let baud = FakeBaud::default();
-    let bus = HostBus::new(ring.clone(), clock.clone(), wire.clone(), baud.clone());
+    let bus = HostBus::new(
+        ring.clone(),
+        clock.clone(),
+        wire.clone(),
+        baud.clone(),
+        BaudRate::B1000000,
+    );
     Rig {
         bus,
         ring,

--- a/firmware/lib/host/src/lib.rs
+++ b/firmware/lib/host/src/lib.rs
@@ -16,4 +16,8 @@
 extern crate std;
 
 pub mod engine;
+pub mod link;
 pub mod traits;
+
+#[cfg(test)]
+pub(crate) mod testutil;

--- a/firmware/lib/host/src/lib.rs
+++ b/firmware/lib/host/src/lib.rs
@@ -12,5 +12,8 @@
 //! design, not as a shared crate.
 #![no_std]
 
+#[cfg(test)]
+extern crate std;
+
 pub mod engine;
 pub mod traits;

--- a/firmware/lib/host/src/lib.rs
+++ b/firmware/lib/host/src/lib.rs
@@ -1,0 +1,16 @@
+//! osc-host: the host-side (bus-scheduler) core library -- engine + link.
+//!
+//! Grid position (driver-pattern sec 2.6): core-lib row, host column.
+//! Depends on the foundation row only; sans-io, alloc-free, no statics --
+//! multi-instance by construction. The engine schedules the wire (one
+//! outstanding command, every protocol deadline runs here, never
+//! client-side); link wraps the engine's vocabulary into pipe records.
+//!
+//! The provider traits deliberately mirror the servo shapes without sharing
+//! code: consumer-owned interfaces (driver-pattern sec 5.1) plus the
+//! never-across-columns law outrank DRY -- the pirate RX design ports as
+//! design, not as a shared crate.
+#![no_std]
+
+pub mod engine;
+pub mod traits;

--- a/firmware/lib/host/src/link/mod.rs
+++ b/firmware/lib/host/src/link/mod.rs
@@ -1,0 +1,8 @@
+//! The link layer: record formats over a reliable ordered byte pipe plus
+//! the chip-agnostic server that bridges pipe records to the engine.
+//! Depends on `engine`; the engine never depends on this (settled).
+
+pub mod record;
+pub mod server;
+
+pub use server::{LinkServer, RecordSink};

--- a/firmware/lib/host/src/link/record.rs
+++ b/firmware/lib/host/src/link/record.rs
@@ -1,0 +1,138 @@
+//! Pipe record formats: the adapter <-> client vocabulary over a reliable
+//! ordered byte pipe. USB bulk is the first carrier, not the definition --
+//! records are length-prefixed (`len(2 LE)` covering `type(1) + body`), so
+//! carrier transfer boundaries carry no meaning and the format ports to any
+//! ordered pipe.
+//!
+//! Contract (host-band settled decisions): each SUBMIT names a client
+//! `seq`; exactly one REJECTED-or-TERMINAL answers it; STATUS records
+//! stream before their terminal, `(seq, slot)`-tagged. NOREPLY commands
+//! still terminate ("sent at tick"). Ticks are raw engine ticks; INFO
+//! advertises the tick rate once instead of converting per record.
+
+use crate::engine::shape::InvalidReason;
+use crate::engine::{Outcome, Terminal};
+
+/// Record type bytes. `0x00..=0x3F` client->adapter, `0x80..=0xBF`
+/// adapter->client. Reserved families (documented now, served later):
+/// `0x40..=0x4F` firmware update -- ENTER_BOOTLOADER first (the mandatory
+/// revert-to-stock path, wlink-iap flow) -- and `0x60..=0x6F` bench (the
+/// IF1 personality; deliberate protocol-breaking lives only there).
+pub const REC_HELLO: u8 = 0x00;
+pub const REC_SUBMIT: u8 = 0x01;
+pub const REC_INFO: u8 = 0x80;
+pub const REC_STATUS: u8 = 0x81;
+pub const REC_TERMINAL: u8 = 0x82;
+pub const REC_REJECTED: u8 = 0x83;
+/// Adapter's answer to a record type it does not serve.
+pub const REC_UNKNOWN: u8 = 0x84;
+
+/// SUBMIT verb byte (body: `seq(2 LE) verb(1) args`).
+pub const VERB_EXCHANGE: u8 = 0x00; // args: id(1) inst(1) payload(rest)
+pub const VERB_RESCUE: u8 = 0x01; // no args
+pub const VERB_HOST_BAUD: u8 = 0x02; // args: rate idx(1)
+pub const VERB_SET_RESPONSE_DEADLINE: u8 = 0x03; // args: us(2 LE)
+
+/// REJECTED reason byte.
+pub const REASON_BAD_ID: u8 = 0x00;
+pub const REASON_BAD_INST: u8 = 0x01;
+pub const REASON_BAD_PAYLOAD: u8 = 0x02;
+pub const REASON_TOO_LONG: u8 = 0x03;
+pub const REASON_BUSY: u8 = 0x04;
+/// SUBMIT body itself did not parse (short, bad verb, bad args).
+pub const REASON_MALFORMED: u8 = 0x05;
+
+/// TERMINAL outcome byte.
+pub const OUTCOME_SENT: u8 = 0x00;
+pub const OUTCOME_COMPLETE: u8 = 0x01;
+pub const OUTCOME_TIMEOUT: u8 = 0x02;
+
+/// TERMINAL flags byte.
+pub const FLAG_GARBLE_AFTER_LAST_FRAME: u8 = 1 << 0;
+
+pub const LINK_VERSION: u8 = 1;
+
+/// The `seq` a record carries when no command owns it (a status or
+/// terminal surfacing outside any active seq -- a server invariant breach
+/// made visible rather than silent).
+pub const SEQ_NONE: u16 = 0xFFFF;
+
+pub fn reason_code(r: InvalidReason) -> u8 {
+    match r {
+        InvalidReason::BadId => REASON_BAD_ID,
+        InvalidReason::BadInst => REASON_BAD_INST,
+        InvalidReason::BadPayload => REASON_BAD_PAYLOAD,
+        InvalidReason::TooLong => REASON_TOO_LONG,
+    }
+}
+
+/// Prefix `dst` with the record length and return the full record span:
+/// `body_len` counts type + body bytes already written at `dst[2..]`.
+fn sealed(dst: &mut [u8], body_len: usize) -> &[u8] {
+    dst[..2].copy_from_slice(&(body_len as u16).to_le_bytes());
+    &dst[..2 + body_len]
+}
+
+pub fn info(dst: &mut [u8], ticks_per_us: u32) -> &[u8] {
+    dst[2] = REC_INFO;
+    dst[3] = LINK_VERSION;
+    dst[4..8].copy_from_slice(&ticks_per_us.to_le_bytes());
+    sealed(dst, 6)
+}
+
+pub fn rejected(dst: &mut [u8], seq: u16, reason: u8) -> &[u8] {
+    dst[2] = REC_REJECTED;
+    dst[3..5].copy_from_slice(&seq.to_le_bytes());
+    dst[5] = reason;
+    sealed(dst, 4)
+}
+
+pub fn unknown(dst: &mut [u8], rtype: u8) -> &[u8] {
+    dst[2] = REC_UNKNOWN;
+    dst[3] = rtype;
+    sealed(dst, 2)
+}
+
+/// STATUS: `seq(2) slot(1) id(1) inst(1) payload`. The payload arrives as
+/// the ring view's two segments.
+pub fn status<'a>(
+    dst: &'a mut [u8],
+    seq: u16,
+    slot: u8,
+    id: u8,
+    inst: u8,
+    payload: (&[u8], &[u8]),
+) -> &'a [u8] {
+    dst[2] = REC_STATUS;
+    dst[3..5].copy_from_slice(&seq.to_le_bytes());
+    dst[5] = slot;
+    dst[6] = id;
+    dst[7] = inst;
+    let n = payload.0.len();
+    dst[8..8 + n].copy_from_slice(payload.0);
+    dst[8 + n..8 + n + payload.1.len()].copy_from_slice(payload.1);
+    sealed(dst, 6 + n + payload.1.len())
+}
+
+/// TERMINAL: `seq(2) outcome(1) slot(1) tick(4 LE) statuses(1) garble(2 LE)
+/// flags(1)`.
+pub fn terminal<'a>(dst: &'a mut [u8], seq: u16, t: &Terminal) -> &'a [u8] {
+    let (outcome, slot) = match t.outcome {
+        Outcome::Sent => (OUTCOME_SENT, 0),
+        Outcome::Complete => (OUTCOME_COMPLETE, 0),
+        Outcome::Timeout { slot } => (OUTCOME_TIMEOUT, slot),
+    };
+    dst[2] = REC_TERMINAL;
+    dst[3..5].copy_from_slice(&seq.to_le_bytes());
+    dst[5] = outcome;
+    dst[6] = slot;
+    dst[7..11].copy_from_slice(&t.tick.to_le_bytes());
+    dst[11] = t.evidence.statuses;
+    dst[12..14].copy_from_slice(&t.evidence.garble.to_le_bytes());
+    dst[14] = if t.evidence.garble_after_last_frame {
+        FLAG_GARBLE_AFTER_LAST_FRAME
+    } else {
+        0
+    };
+    sealed(dst, 13)
+}

--- a/firmware/lib/host/src/link/server.rs
+++ b/firmware/lib/host/src/link/server.rs
@@ -224,7 +224,13 @@ mod tests {
         let clock = FakeDeadline::new();
         let wire = FakeWire::default();
         let baud = FakeBaud::default();
-        let bus = HostBus::new(ring.clone(), clock.clone(), wire.clone(), baud.clone());
+        let bus = HostBus::new(
+            ring.clone(),
+            clock.clone(),
+            wire.clone(),
+            baud.clone(),
+            BaudRate::B1000000,
+        );
         Rig {
             server: LinkServer::new(),
             bus,

--- a/firmware/lib/host/src/link/server.rs
+++ b/firmware/lib/host/src/link/server.rs
@@ -1,0 +1,378 @@
+//! The chip-agnostic link server: pipe bytes in, engine commands down,
+//! engine events up, records out. Sans-io -- the chip (or a DES harness)
+//! feeds `on_pipe` with whatever the carrier delivered and drains records
+//! through a [`RecordSink`]; nothing here knows about USB.
+
+use osc_protocol::wire::{BaudRate, Id, Inst};
+
+use crate::engine::{Command, Event, HostBus, SubmitError};
+use crate::traits::{Deadline, Providers};
+
+use super::record::{self, SEQ_NONE};
+
+/// Where outbound records go (USB IN endpoint queue, a test log, a DES
+/// pipe). Called once per complete record.
+pub trait RecordSink {
+    fn record(&mut self, record: &[u8]);
+}
+
+/// Accumulation bound: comfortably past the largest legal record
+/// (EXCHANGE with a 252 B payload = 262 pipe bytes).
+const RX_CAP: usize = 512;
+/// Outbound scratch: the largest record is a STATUS carrying a full reply
+/// payload.
+const OUT_CAP: usize = 300;
+
+pub struct LinkServer {
+    rx: [u8; RX_CAP],
+    rx_len: usize,
+    /// The seq owning the engine's outstanding command.
+    active: Option<u16>,
+    out: [u8; OUT_CAP],
+}
+
+impl Default for LinkServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LinkServer {
+    pub fn new() -> Self {
+        Self {
+            rx: [0; RX_CAP],
+            rx_len: 0,
+            active: None,
+            out: [0; OUT_CAP],
+        }
+    }
+
+    /// Feed bytes as the pipe delivered them (any framing); complete
+    /// records drive the engine, replies stream to `sink`.
+    pub fn on_pipe<P: Providers>(
+        &mut self,
+        mut bytes: &[u8],
+        bus: &mut HostBus<P>,
+        sink: &mut impl RecordSink,
+    ) {
+        while !bytes.is_empty() {
+            let room = RX_CAP - self.rx_len;
+            let take = room.min(bytes.len());
+            self.rx[self.rx_len..self.rx_len + take].copy_from_slice(&bytes[..take]);
+            self.rx_len += take;
+            bytes = &bytes[take..];
+            self.extract(bus, sink);
+            if take == 0 {
+                // A full buffer that yields no record is an over-length or
+                // desynced prefix; a reliable pipe never produces one, so
+                // the client is broken -- drop the buffer and say so.
+                self.rx_len = 0;
+                sink.record(record::unknown(&mut self.out, 0xFF));
+            }
+        }
+    }
+
+    /// Drain engine events into records. Call freely (idle loop, after ISR
+    /// wakes, after `on_pipe`).
+    pub fn pump<P: Providers>(&mut self, bus: &mut HostBus<P>, sink: &mut impl RecordSink) {
+        loop {
+            match bus.poll() {
+                Some(Event::Status {
+                    slot,
+                    id,
+                    inst,
+                    payload,
+                }) => {
+                    let seq = self.active.unwrap_or(SEQ_NONE);
+                    sink.record(record::status(
+                        &mut self.out,
+                        seq,
+                        slot,
+                        id.as_byte(),
+                        inst.0,
+                        payload.segments(),
+                    ));
+                }
+                Some(Event::Done(t)) => {
+                    let seq = self.active.take().unwrap_or(SEQ_NONE);
+                    sink.record(record::terminal(&mut self.out, seq, &t));
+                }
+                None => return,
+            }
+        }
+    }
+
+    fn extract<P: Providers>(&mut self, bus: &mut HostBus<P>, sink: &mut impl RecordSink) {
+        loop {
+            if self.rx_len < 2 {
+                return;
+            }
+            let len = u16::from_le_bytes([self.rx[0], self.rx[1]]) as usize;
+            if len == 0 || len > RX_CAP - 2 {
+                // Framing breach on a reliable pipe = client bug; there is
+                // no resync point in a length-prefixed stream, so drop.
+                self.rx_len = 0;
+                sink.record(record::unknown(&mut self.out, 0xFF));
+                return;
+            }
+            if self.rx_len < 2 + len {
+                return;
+            }
+            handle(
+                &mut self.active,
+                &self.rx[2..2 + len],
+                bus,
+                &mut self.out,
+                sink,
+            );
+            self.rx.copy_within(2 + len..self.rx_len, 0);
+            self.rx_len -= 2 + len;
+        }
+    }
+}
+
+/// One complete record (type + body).
+fn handle<P: Providers>(
+    active: &mut Option<u16>,
+    rec: &[u8],
+    bus: &mut HostBus<P>,
+    out: &mut [u8],
+    sink: &mut impl RecordSink,
+) {
+    match rec[0] {
+        record::REC_HELLO => {
+            sink.record(record::info(out, P::Deadline::TICKS_PER_US));
+        }
+        record::REC_SUBMIT => {
+            if rec.len() < 4 {
+                sink.record(record::unknown(out, record::REC_SUBMIT));
+                return;
+            }
+            let seq = u16::from_le_bytes([rec[1], rec[2]]);
+            let args = &rec[4..];
+            let cmd = match rec[3] {
+                record::VERB_EXCHANGE if args.len() >= 2 => Command::Exchange {
+                    id: Id::new(args[0]),
+                    inst: Inst(args[1]),
+                    payload: &args[2..],
+                },
+                record::VERB_RESCUE if args.is_empty() => Command::Rescue,
+                record::VERB_HOST_BAUD if args.len() == 1 => match BaudRate::from_idx(args[0]) {
+                    Some(rate) => Command::HostBaud(rate),
+                    None => {
+                        sink.record(record::rejected(out, seq, record::REASON_MALFORMED));
+                        return;
+                    }
+                },
+                record::VERB_SET_RESPONSE_DEADLINE if args.len() == 2 => {
+                    Command::SetResponseDeadline {
+                        us: u16::from_le_bytes([args[0], args[1]]),
+                    }
+                }
+                _ => {
+                    sink.record(record::rejected(out, seq, record::REASON_MALFORMED));
+                    return;
+                }
+            };
+            match bus.submit(cmd) {
+                Ok(()) => *active = Some(seq),
+                Err(SubmitError::Busy) => {
+                    sink.record(record::rejected(out, seq, record::REASON_BUSY));
+                }
+                Err(SubmitError::Invalid(r)) => {
+                    sink.record(record::rejected(out, seq, record::reason_code(r)));
+                }
+            }
+        }
+        rtype => sink.record(record::unknown(out, rtype)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::vec;
+    use std::vec::Vec;
+
+    use osc_protocol::wire::{Opcode, ResultCode};
+
+    use super::super::record::*;
+    use super::*;
+    use crate::testutil::{
+        FakeBaud, FakeDeadline, FakeRing, FakeWire, TestProviders, WireOp, sealed_status,
+    };
+
+    #[derive(Default)]
+    struct Sink(Vec<Vec<u8>>);
+
+    impl RecordSink for Sink {
+        fn record(&mut self, record: &[u8]) {
+            self.0.push(record.to_vec());
+        }
+    }
+
+    struct Rig {
+        server: LinkServer,
+        bus: HostBus<TestProviders>,
+        ring: FakeRing,
+        clock: FakeDeadline,
+        wire: FakeWire,
+        sink: Sink,
+    }
+
+    fn rig() -> Rig {
+        let ring = FakeRing::new();
+        let clock = FakeDeadline::new();
+        let wire = FakeWire::default();
+        let baud = FakeBaud::default();
+        let bus = HostBus::new(ring.clone(), clock.clone(), wire.clone(), baud.clone());
+        Rig {
+            server: LinkServer::new(),
+            bus,
+            ring,
+            clock,
+            wire,
+            sink: Sink::default(),
+        }
+    }
+
+    /// Length-prefix a type+body into pipe bytes.
+    fn rec(body: &[u8]) -> Vec<u8> {
+        let mut v = vec![body.len() as u8, (body.len() >> 8) as u8];
+        v.extend_from_slice(body);
+        v
+    }
+
+    fn submit_ping(seq: u16, id: u8) -> Vec<u8> {
+        let inst = Inst::instruction(Opcode::Ping, 0);
+        rec(&[
+            REC_SUBMIT,
+            seq as u8,
+            (seq >> 8) as u8,
+            VERB_EXCHANGE,
+            id,
+            inst.0,
+        ])
+    }
+
+    #[test]
+    fn hello_answers_info() {
+        let mut r = rig();
+        let bytes = rec(&[REC_HELLO]);
+        r.server.on_pipe(&bytes, &mut r.bus, &mut r.sink);
+        assert_eq!(
+            r.sink.0,
+            vec![vec![6, 0, REC_INFO, LINK_VERSION, 1, 0, 0, 0]]
+        );
+    }
+
+    #[test]
+    fn exchange_round_trip_tags_seq() {
+        let mut r = rig();
+        r.server
+            .on_pipe(&submit_ping(0x1234, 5), &mut r.bus, &mut r.sink);
+        assert!(r.sink.0.is_empty(), "no reply yet");
+        assert_eq!(r.wire.log()[0], WireOp::Claim, "engine took the wire");
+
+        r.bus.on_tx_complete();
+        r.ring.feed(&sealed_status(5, ResultCode::Ok, &[7, 0, 1]));
+        r.server.pump(&mut r.bus, &mut r.sink);
+
+        // STATUS then TERMINAL, both carrying seq 0x1234.
+        let status = &r.sink.0[0];
+        assert_eq!(status[2], REC_STATUS);
+        assert_eq!(u16::from_le_bytes([status[3], status[4]]), 0x1234);
+        assert_eq!(status[5], 0, "slot");
+        assert_eq!(status[6], 5, "responder id");
+        assert_eq!(&status[8..11], &[7, 0, 1], "payload");
+
+        let term = &r.sink.0[1];
+        assert_eq!(term[2], REC_TERMINAL);
+        assert_eq!(u16::from_le_bytes([term[3], term[4]]), 0x1234);
+        assert_eq!(term[5], OUTCOME_COMPLETE);
+        assert_eq!(term[11], 1, "statuses");
+
+        // The seq is retired: a new submit is accepted.
+        r.server
+            .on_pipe(&submit_ping(0x1235, 5), &mut r.bus, &mut r.sink);
+        assert_eq!(r.sink.0.len(), 2, "accepted, no rejection");
+    }
+
+    #[test]
+    fn busy_and_invalid_reject_with_reasons() {
+        let mut r = rig();
+        r.server
+            .on_pipe(&submit_ping(1, 5), &mut r.bus, &mut r.sink);
+        r.server
+            .on_pipe(&submit_ping(2, 5), &mut r.bus, &mut r.sink);
+        let rej = r.sink.0.last().unwrap();
+        assert_eq!(rej[2], REC_REJECTED);
+        assert_eq!(u16::from_le_bytes([rej[3], rej[4]]), 2);
+        assert_eq!(rej[5], REASON_BUSY);
+
+        let mut r = rig();
+        r.server
+            .on_pipe(&submit_ping(9, 0), &mut r.bus, &mut r.sink);
+        let rej = r.sink.0.last().unwrap();
+        assert_eq!(rej[5], REASON_BAD_ID);
+        assert!(r.wire.log().is_empty(), "nothing reached the wire");
+    }
+
+    #[test]
+    fn records_reassemble_across_pipe_chunks() {
+        let mut r = rig();
+        let bytes = submit_ping(7, 5);
+        let (a, b) = bytes.split_at(3);
+        r.server.on_pipe(a, &mut r.bus, &mut r.sink);
+        assert!(r.wire.log().is_empty(), "partial record: not submitted");
+        r.server.on_pipe(b, &mut r.bus, &mut r.sink);
+        assert_eq!(r.wire.log()[0], WireOp::Claim);
+
+        // Two records in one delivery both land.
+        let mut r = rig();
+        let mut two = rec(&[REC_HELLO]);
+        two.extend_from_slice(&rec(&[REC_HELLO]));
+        r.server.on_pipe(&two, &mut r.bus, &mut r.sink);
+        assert_eq!(r.sink.0.len(), 2);
+    }
+
+    #[test]
+    fn unknown_types_and_malformed_submits_answer() {
+        let mut r = rig();
+        r.server
+            .on_pipe(&rec(&[0x55, 1, 2]), &mut r.bus, &mut r.sink);
+        assert_eq!(r.sink.0[0][2], REC_UNKNOWN);
+        assert_eq!(r.sink.0[0][3], 0x55);
+
+        // SUBMIT with an unserved verb: rejected on its seq.
+        r.server
+            .on_pipe(&rec(&[REC_SUBMIT, 3, 0, 0x7F]), &mut r.bus, &mut r.sink);
+        let rej = r.sink.0.last().unwrap();
+        assert_eq!(rej[2], REC_REJECTED);
+        assert_eq!(rej[5], REASON_MALFORMED);
+    }
+
+    #[test]
+    fn instant_verbs_terminate_on_their_seq() {
+        let mut r = rig();
+        let body = [REC_SUBMIT, 0x0A, 0x00, VERB_SET_RESPONSE_DEADLINE, 200, 0];
+        r.server.on_pipe(&rec(&body), &mut r.bus, &mut r.sink);
+        r.server.pump(&mut r.bus, &mut r.sink);
+        let term = r.sink.0.last().unwrap();
+        assert_eq!(term[2], REC_TERMINAL);
+        assert_eq!(u16::from_le_bytes([term[3], term[4]]), 0x0A);
+        assert_eq!(term[5], OUTCOME_COMPLETE);
+    }
+
+    #[test]
+    fn timeout_terminal_names_the_slot() {
+        let mut r = rig();
+        r.server
+            .on_pipe(&submit_ping(4, 5), &mut r.bus, &mut r.sink);
+        r.bus.on_tx_complete();
+        r.clock.advance(100_000);
+        r.server.pump(&mut r.bus, &mut r.sink);
+        let term = r.sink.0.last().unwrap();
+        assert_eq!(term[5], OUTCOME_TIMEOUT);
+        assert_eq!(term[6], 0, "missing slot");
+    }
+}

--- a/firmware/lib/host/src/testutil.rs
+++ b/firmware/lib/host/src/testutil.rs
@@ -1,0 +1,171 @@
+//! Recording fake providers shared by the engine and link test suites
+//! (the drivers-crate mock spirit: cloneable `Rc` state companions, one
+//! clone moved into the engine).
+
+use std::cell::{Cell, RefCell, UnsafeCell};
+use std::rc::Rc;
+use std::vec::Vec;
+
+use osc_protocol::reply::FrameBuf;
+use osc_protocol::wire::{BaudRate, Id, Inst, ResultCode};
+
+use crate::traits;
+
+pub const RING_LEN: usize = 512;
+
+struct RingState {
+    buf: UnsafeCell<[u8; RING_LEN]>,
+    cursor: Cell<u16>,
+}
+
+/// Counted RX ring the test feeds like the wire would.
+#[derive(Clone)]
+pub struct FakeRing(Rc<RingState>);
+
+impl FakeRing {
+    pub fn new() -> Self {
+        FakeRing(Rc::new(RingState {
+            buf: UnsafeCell::new([0xFF; RING_LEN]),
+            cursor: Cell::new(0),
+        }))
+    }
+
+    /// Ring bytes in at the cursor, advancing it -- one wire arrival.
+    pub fn feed(&self, bytes: &[u8]) {
+        // SAFETY: test-only, single-threaded; never called while a
+        // `bytes()` slice is live.
+        let buf = unsafe { &mut *self.0.buf.get() };
+        let mut c = self.0.cursor.get() as usize;
+        for &b in bytes {
+            buf[c] = b;
+            c = (c + 1) % RING_LEN;
+        }
+        self.0.cursor.set(c as u16);
+    }
+}
+
+impl traits::RxRing for FakeRing {
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: test-only aliasing; the buffer is never fed while a
+        // returned slice is live (see `feed`).
+        let arr: &[u8; RING_LEN] = unsafe { &*self.0.buf.get() };
+        &arr[..]
+    }
+
+    fn cursor(&self) -> u16 {
+        self.0.cursor.get()
+    }
+}
+
+struct ClockState {
+    now: Cell<u32>,
+    armed: Cell<Option<u32>>,
+}
+
+/// Settable clock + a record of the armed compare.
+#[derive(Clone)]
+pub struct FakeDeadline(Rc<ClockState>);
+
+impl FakeDeadline {
+    pub fn new() -> Self {
+        FakeDeadline(Rc::new(ClockState {
+            now: Cell::new(0),
+            armed: Cell::new(None),
+        }))
+    }
+
+    pub fn advance(&self, ticks: u32) {
+        self.0.now.set(self.0.now.get().wrapping_add(ticks));
+    }
+
+    pub fn armed(&self) -> Option<u32> {
+        self.0.armed.get()
+    }
+}
+
+impl traits::Deadline for FakeDeadline {
+    const TICKS_PER_US: u32 = 1;
+
+    fn now(&self) -> u32 {
+        self.0.now.get()
+    }
+
+    fn set(&mut self, at: u32) {
+        self.0.armed.set(Some(at));
+    }
+
+    fn cancel(&mut self) {
+        self.0.armed.set(None);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WireOp {
+    Claim,
+    Break,
+    Send(Vec<u8>),
+    HoldLow,
+    Release,
+}
+
+#[derive(Clone, Default)]
+pub struct FakeWire(Rc<RefCell<Vec<WireOp>>>);
+
+impl FakeWire {
+    pub fn log(&self) -> Vec<WireOp> {
+        self.0.borrow().clone()
+    }
+
+    pub fn clear(&self) {
+        self.0.borrow_mut().clear();
+    }
+}
+
+impl traits::TxWire for FakeWire {
+    fn claim(&mut self) {
+        self.0.borrow_mut().push(WireOp::Claim);
+    }
+    fn send_break(&mut self) {
+        self.0.borrow_mut().push(WireOp::Break);
+    }
+    fn send(&mut self, span: &[u8]) {
+        self.0.borrow_mut().push(WireOp::Send(span.to_vec()));
+    }
+    fn hold_low(&mut self) {
+        self.0.borrow_mut().push(WireOp::HoldLow);
+    }
+    fn release(&mut self) {
+        self.0.borrow_mut().push(WireOp::Release);
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct FakeBaud(Rc<RefCell<Vec<BaudRate>>>);
+
+impl FakeBaud {
+    pub fn applied(&self) -> Vec<BaudRate> {
+        self.0.borrow().clone()
+    }
+}
+
+impl traits::UsartBaud for FakeBaud {
+    fn apply(&mut self, baud: BaudRate) {
+        self.0.borrow_mut().push(baud);
+    }
+}
+
+pub struct TestProviders;
+impl traits::Providers for TestProviders {
+    type Ring = FakeRing;
+    type Deadline = FakeDeadline;
+    type Tx = FakeWire;
+    type Baud = FakeBaud;
+}
+
+pub fn sealed_status(id: u8, result: ResultCode, payload: &[u8]) -> Vec<u8> {
+    let mut b = FrameBuf::<264>::new();
+    b.start(Id::new(id), Inst::status(result, false));
+    b.payload_mut()[..payload.len()].copy_from_slice(payload);
+    b.finish(payload.len() as u8);
+    b.seal().to_vec()
+}

--- a/firmware/lib/host/src/traits.rs
+++ b/firmware/lib/host/src/traits.rs
@@ -1,0 +1,70 @@
+//! Host transport interfaces, engine-owned (driver-pattern sec 5.1); chip
+//! providers implement them over real peripherals, tests over recording
+//! fakes. Deliberately absent (see the crate doc for the grid rationale):
+//! a break-event input (no LBD on the adapter target; all host RX is
+//! solicited, the framer walks the ring), a CRC engine (software CRC from
+//! osc-protocol -- the host has cycles to spare), and a separate monotonic
+//! (`Deadline::now` covers it).
+
+use osc_protocol::wire::BaudRate;
+
+/// Counted circular RX DMA ring, armed once. Contract: the ring never
+/// contains the host's own TX bytes (HDSEL no-echo or buffer mute -- the
+/// provider guarantees it, the framer assumes it). Ring length must be a
+/// power of two exceeding the largest legal frame (258) with polling margin.
+pub trait RxRing {
+    fn bytes(&self) -> &[u8];
+    /// Index where the next received byte lands.
+    fn cursor(&self) -> u16;
+}
+
+/// One-shot compare on the host tick domain. The host is crystal-clocked --
+/// it is the bus's syntonization root (protocol sec 9.3) -- so there is no
+/// trim-step constant here. `set` arms the compare; the chip ISR it fires
+/// calls back into the engine's `on_deadline`.
+pub trait Deadline {
+    const TICKS_PER_US: u32;
+    fn now(&self) -> u32;
+    fn set(&mut self, at: u32);
+    fn cancel(&mut self);
+}
+
+/// TX side of the wire: drive discipline + law break + byte streaming.
+/// Send completion surfaces as the chip calling the engine's
+/// `on_tx_complete`. The provider owns break/M-bit sequencing internally --
+/// a `send` queued behind a break is legal, and blocking a character time
+/// inside the provider is acceptable.
+pub trait TxWire {
+    /// Claim the wire: push-pull drive (protocol sec 2 discipline).
+    fn claim(&mut self);
+    /// One law break: a 10-bit `0x00` character (protocol sec 3). Wire
+    /// claimed. Never the off-law hardware SBK (~14 bits).
+    fn send_break(&mut self);
+    /// Stream one span (DMA arm or PIO -- provider's choice).
+    fn send(&mut self, span: &[u8]);
+    /// Drive the line dominant and hold it (rescue pulse, protocol sec 9.1);
+    /// ends at [`release`](Self::release). The engine times the pulse.
+    fn hold_low(&mut self);
+    /// Release the wire: open-drain idle, TX off.
+    fn release(&mut self);
+}
+
+/// Host-side UART rate: the four operational rates; `BaudRate::RESCUE` is
+/// the sec 9.1 floor the rescue verb drops to.
+pub trait UsartBaud {
+    fn apply(&mut self, baud: BaudRate);
+}
+
+/// Role bundle for the `HostBus` composite (driver-pattern sec 5.4).
+pub trait Providers {
+    type Ring: RxRing;
+    type Deadline: Deadline;
+    type Tx: TxWire;
+    type Baud: UsartBaud;
+}
+
+/// Wrap-aware "`a` is at or after `b`" on the u32 tick domain.
+#[inline]
+pub const fn tick_reached(a: u32, b: u32) -> bool {
+    a.wrapping_sub(b) < u32::MAX / 2
+}

--- a/firmware/lib/integration/Cargo.toml
+++ b/firmware/lib/integration/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 osc-servo-core     = { workspace = true, features = ["log"] }
 osc-servo-drivers  = { workspace = true, features = ["log"] }
+osc-host     = { workspace = true }
 osc-protocol = { workspace = true, features = ["software-crc"] }
 control-table.workspace = true
 log = "0.4"
@@ -32,3 +33,7 @@ path = "tests/resilience.rs"
 [[test]]
 name = "timing"
 path = "tests/timing.rs"
+
+[[test]]
+name = "host_loop"
+path = "tests/host_loop.rs"

--- a/firmware/lib/integration/src/sim/core.rs
+++ b/firmware/lib/integration/src/sim/core.rs
@@ -101,6 +101,11 @@ pub enum Event {
     TxArmDone { servo: usize },
     /// A servo's handler body ended (`super::cpu`): deliver one pended vector.
     CpuFree { servo: usize },
+    /// The attached host engine's tick-compare fired; same generation gate
+    /// as `Compare`.
+    HostCompare { generation: u64 },
+    /// The host engine's TX span drained -- drive its `on_tx_complete`.
+    HostTxDone,
 }
 
 struct Scheduled {

--- a/firmware/lib/integration/src/sim/host.rs
+++ b/firmware/lib/integration/src/sim/host.rs
@@ -1,0 +1,238 @@
+//! Host-in-the-loop: the production `osc_host` engine over sim providers,
+//! closing both columns of the grid inside the DES -- production host
+//! scheduling against the production servo stack on one modeled wire.
+//!
+//! The provider shapes mirror `providers.rs` (shared `Rc` state the `Sim`
+//! also holds): the host ring is fed by the same wire deliveries the servo
+//! rings get (minus the host's own TX -- the no-echo contract), the
+//! deadline schedules `HostCompare` events, and the TX wire schedules the
+//! same `WireBreak`/`WireData` events a scripted `host_send` would.
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+use osc_host::engine::{HostBus, Terminal};
+use osc_host::traits::{Deadline, Providers, RxRing, TxWire, UsartBaud};
+use osc_protocol::wire::BaudRate;
+use osc_servo_drivers::bus::RESCUE_LOW_US;
+
+use super::core::{Core, Event, TICKS_PER_US, Talker, break_ticks, byte_ticks};
+use super::providers::{BaudState, DeadlineState, RingState};
+
+/// One engine event, copied out of the ring for the harness.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HostEvent {
+    Status {
+        slot: u8,
+        id: u8,
+        inst: u8,
+        payload: Vec<u8>,
+    },
+    Done(Terminal),
+}
+
+pub struct HostRing(pub Rc<RingState>);
+
+impl RxRing for HostRing {
+    fn bytes(&self) -> &[u8] {
+        self.0.bytes()
+    }
+
+    fn cursor(&self) -> u16 {
+        self.0.cursor()
+    }
+}
+
+/// Crystal-clocked host deadline: the sim clock IS the host clock (no
+/// skew -- the host is the syntonization root).
+pub struct HostDeadline {
+    core: Rc<RefCell<Core>>,
+    state: Rc<DeadlineState>,
+}
+
+impl Deadline for HostDeadline {
+    const TICKS_PER_US: u32 = TICKS_PER_US as u32;
+
+    fn now(&self) -> u32 {
+        self.core.borrow().now() as u32
+    }
+
+    fn set(&mut self, at: u32) {
+        let generation = self.state.bump();
+        let sim_now = self.core.borrow().now();
+        let delta = at.wrapping_sub(sim_now as u32);
+        // A past `at` fires immediately (pend-on-past, the chip contract).
+        let delta = if delta > i32::MAX as u32 {
+            0
+        } else {
+            delta as u64
+        };
+        self.core
+            .borrow_mut()
+            .schedule(Event::HostCompare { generation }, sim_now + delta);
+    }
+
+    fn cancel(&mut self) {
+        self.state.bump();
+    }
+}
+
+/// The host's TX onto the shared wire. Break/byte events mirror the
+/// scripted `host_send` path; the frame record finalizes off scheduled
+/// `HostFrameEnd` events so bare CAL-train breaks and full frames both
+/// record like their scripted twins.
+pub struct HostWire {
+    core: Rc<RefCell<Core>>,
+    baud: Rc<BaudState>,
+    /// End tick of the last-scheduled unit; the next unit starts at
+    /// `max(cursor, now)`.
+    tx_cursor: Cell<u64>,
+    /// A sent break not yet claimed by a frame body: flushed as an empty
+    /// recorded frame by the next unit (CAL train marks).
+    bare_break: Cell<Option<u64>>,
+    /// Rescue pulse start while the line is held dominant.
+    low_since: Cell<Option<u64>>,
+}
+
+impl TxWire for HostWire {
+    fn claim(&mut self) {
+        let now = self.core.borrow().now();
+        self.tx_cursor.set(self.tx_cursor.get().max(now));
+    }
+
+    fn send_break(&mut self) {
+        let baud = self.baud.current();
+        let mut c = self.core.borrow_mut();
+        let now = c.now();
+        // Flush a preceding bare break's record before its successor begins.
+        if let Some(end) = self.bare_break.take() {
+            c.schedule(Event::HostFrameEnd, end.max(now));
+        }
+        let start = self.tx_cursor.get().max(now);
+        let end = start + break_ticks(baud);
+        c.claim(Talker::Host, start, end);
+        c.schedule(
+            Event::WireBreak {
+                talker: Talker::Host,
+                baud,
+                break_start: start,
+            },
+            end,
+        );
+        self.tx_cursor.set(end);
+        self.bare_break.set(Some(end));
+    }
+
+    fn send(&mut self, span: &[u8]) {
+        // The break heads this frame -- one record, no bare flush.
+        self.bare_break.take();
+        let baud = self.baud.current();
+        let bt = byte_ticks(baud);
+        let mut c = self.core.borrow_mut();
+        let start = self.tx_cursor.get().max(c.now());
+        for (k, &b) in span.iter().enumerate() {
+            c.schedule(
+                Event::WireData {
+                    talker: Talker::Host,
+                    byte: b,
+                    baud,
+                },
+                start + (k as u64 + 1) * bt,
+            );
+        }
+        let end = start + span.len() as u64 * bt;
+        c.claim(Talker::Host, start, end);
+        c.schedule(Event::HostFrameEnd, end);
+        c.schedule(Event::HostTxDone, end);
+        self.tx_cursor.set(end);
+    }
+
+    fn hold_low(&mut self) {
+        let baud = self.baud.current();
+        let mut c = self.core.borrow_mut();
+        let now = c.now();
+        self.low_since.set(Some(now));
+        // The engine holds well past the sampler threshold by contract; the
+        // fleet-wide declaration lands mid-pulse (sec 9.1).
+        c.schedule(
+            Event::RescueDeclare,
+            now + byte_ticks(baud) + RESCUE_LOW_US as u64 * TICKS_PER_US,
+        );
+    }
+
+    fn release(&mut self) {
+        let mut c = self.core.borrow_mut();
+        let now = c.now();
+        if let Some(end) = self.bare_break.take() {
+            // Last CAL-train break: its record closes after delivery.
+            c.schedule(Event::HostFrameEnd, end.max(now));
+        }
+        if let Some(start) = self.low_since.take() {
+            // Pulse end: the rising edge is where break detectors latch.
+            c.claim(Talker::Host, start, now);
+            let baud = self.baud.current();
+            c.schedule(Event::StrayBreak { baud }, now);
+        }
+    }
+}
+
+pub struct HostUsart(pub Rc<BaudState>);
+
+impl UsartBaud for HostUsart {
+    fn apply(&mut self, baud: BaudRate) {
+        self.0.apply(baud);
+    }
+}
+
+/// Provider bundle for the sim-hosted engine.
+pub struct SimHostProviders;
+
+impl Providers for SimHostProviders {
+    type Ring = HostRing;
+    type Deadline = HostDeadline;
+    type Tx = HostWire;
+    type Baud = HostUsart;
+}
+
+/// The attached host: the production engine plus the shared handles the
+/// `Sim` feeds during wire delivery.
+pub struct SimHost {
+    pub bus: HostBus<SimHostProviders>,
+    pub ring: Rc<RingState>,
+    pub deadline: Rc<DeadlineState>,
+    pub baud: Rc<BaudState>,
+    pub events: Vec<HostEvent>,
+}
+
+impl SimHost {
+    pub fn build(core: &Rc<RefCell<Core>>, rate: BaudRate) -> Self {
+        let ring = RingState::new();
+        let deadline = DeadlineState::new();
+        let baud = BaudState::new(rate);
+        let bus = HostBus::new(
+            HostRing(ring.clone()),
+            HostDeadline {
+                core: core.clone(),
+                state: deadline.clone(),
+            },
+            HostWire {
+                core: core.clone(),
+                baud: baud.clone(),
+                tx_cursor: Cell::new(0),
+                bare_break: Cell::new(None),
+                low_since: Cell::new(None),
+            },
+            HostUsart(baud.clone()),
+            rate,
+        );
+        Self {
+            bus,
+            ring,
+            deadline,
+            baud,
+            events: Vec::new(),
+        }
+    }
+}

--- a/firmware/lib/integration/src/sim/mod.rs
+++ b/firmware/lib/integration/src/sim/mod.rs
@@ -10,6 +10,7 @@
 
 mod core;
 mod cpu;
+mod host;
 mod providers;
 mod servo;
 mod store;
@@ -32,6 +33,7 @@ use self::providers::Handles;
 use self::servo::SimServo;
 
 pub use self::cpu::HandlerCost;
+pub use self::host::HostEvent;
 pub use self::store::RamStore;
 
 /// XOR mask applied to bytes ringed at a baud-mismatched receiver: arbitrary
@@ -74,6 +76,10 @@ pub struct Sim {
     rate: BaudRate,
     /// The scheduling host queues each frame after its own prior traffic.
     host_free_at: u64,
+    /// The production engine, when attached (host-in-the-loop scenarios);
+    /// scripted `host_send*` and the engine can coexist but must not overlap
+    /// on the wire -- the claim assert catches a scenario that mixes them.
+    host: Option<host::SimHost>,
 }
 
 impl Sim {
@@ -85,7 +91,31 @@ impl Sim {
             cpus: Vec::new(),
             rate,
             host_free_at: 0,
+            host: None,
         }
+    }
+
+    /// Attach the production host engine at the sim's wire rate. Submit
+    /// through [`Self::host_submit`], drain events after [`Self::run`]
+    /// through [`Self::host_events`].
+    pub fn attach_host(&mut self) {
+        assert!(self.host.is_none(), "host already attached");
+        self.host = Some(host::SimHost::build(&self.core, self.rate));
+    }
+
+    /// Submit one command to the attached engine (panics if none).
+    pub fn host_submit(
+        &mut self,
+        cmd: osc_host::engine::Command<'_>,
+    ) -> Result<(), osc_host::engine::SubmitError> {
+        let r = self.host.as_mut().expect("host attached").bus.submit(cmd);
+        self.host_pump();
+        r
+    }
+
+    /// Drain everything the engine yielded since the last call.
+    pub fn host_events(&mut self) -> Vec<HostEvent> {
+        std::mem::take(&mut self.host.as_mut().expect("host attached").events)
     }
 
     /// Add a servo with the default table seed at this id; returns its index.
@@ -404,6 +434,49 @@ impl Sim {
             Event::TxArmDone { servo } => self.deliver(servo, Vector::TxDone),
             Event::CpuFree { servo } => self.cpu_free(servo),
             Event::WakeRefire { servo } => self.deliver(servo, Vector::Break),
+            Event::HostCompare { generation } => {
+                if let Some(h) = self.host.as_mut()
+                    && h.deadline.generation() == generation
+                {
+                    h.bus.on_deadline();
+                }
+            }
+            Event::HostTxDone => {
+                if let Some(h) = self.host.as_mut() {
+                    h.bus.on_tx_complete();
+                }
+            }
+        }
+        // The adapter's main loop is a tight poll: drain the engine after
+        // every event so its clocks and framer track the wire promptly.
+        self.host_pump();
+    }
+
+    /// Poll the attached engine to exhaustion, copying events out of the
+    /// ring for the harness.
+    fn host_pump(&mut self) {
+        let Some(h) = self.host.as_mut() else { return };
+        loop {
+            match h.bus.poll() {
+                Some(osc_host::engine::Event::Status {
+                    slot,
+                    id,
+                    inst,
+                    payload,
+                }) => {
+                    let (a, b) = payload.segments();
+                    let mut bytes = a.to_vec();
+                    bytes.extend_from_slice(b);
+                    h.events.push(HostEvent::Status {
+                        slot,
+                        id: id.as_byte(),
+                        inst: inst.0,
+                        payload: bytes,
+                    });
+                }
+                Some(osc_host::engine::Event::Done(t)) => h.events.push(HostEvent::Done(t)),
+                None => return,
+            }
         }
     }
 
@@ -467,6 +540,17 @@ impl Sim {
             }
             self.deliver_break_to(j, baud);
         }
+        // The host hears every foreign break (its ring contract excludes
+        // only its own TX); no wake exists to qualify -- just the ring image.
+        if let Some(h) = &self.host
+            && talker != Talker::Host
+        {
+            if h.baud.current().as_hz() >= baud.as_hz() {
+                h.ring.push(0x00);
+            } else {
+                h.ring.push(MISMATCH_GARBLE);
+            }
+        }
     }
 
     /// Length-qualified break delivery (sec 3.4): the 10-bit span covers >=10 of
@@ -485,6 +569,15 @@ impl Sim {
     fn deliver_data(&mut self, talker: Talker, byte: u8, baud: BaudRate) {
         let now = self.core.borrow().now();
         self.core.borrow_mut().append_byte(byte, now);
+        if let Some(h) = &self.host
+            && talker != Talker::Host
+        {
+            if h.baud.current() == baud {
+                h.ring.push(byte);
+            } else {
+                h.ring.push(byte ^ MISMATCH_GARBLE);
+            }
+        }
         for j in 0..self.servos.len() {
             if talker == Talker::Servo(j) {
                 continue;
@@ -510,11 +603,21 @@ impl Sim {
         for j in 0..self.servos.len() {
             self.handles[j].ring.push(byte);
         }
+        if let Some(h) = &self.host {
+            h.ring.push(byte);
+        }
     }
 
     fn deliver_stray_break(&mut self, baud: BaudRate) {
         for j in 0..self.servos.len() {
             self.deliver_break_to(j, baud);
+        }
+        if let Some(h) = &self.host {
+            if h.baud.current().as_hz() >= baud.as_hz() {
+                h.ring.push(0x00);
+            } else {
+                h.ring.push(MISMATCH_GARBLE);
+            }
         }
     }
 

--- a/firmware/lib/integration/src/sim/providers.rs
+++ b/firmware/lib/integration/src/sim/providers.rs
@@ -45,6 +45,17 @@ impl RingState {
         unsafe { (*self.buf.get()).0[i] = b };
         self.cursor.set(((i + 1) % RING_LEN) as u16);
     }
+
+    pub fn bytes(&self) -> &[u8] {
+        // SAFETY: test-only aliasing (see `push`); the buffer is never
+        // mutated while a returned slice is live.
+        let arr: &[u8; RING_LEN] = unsafe { &(*self.buf.get()).0 };
+        &arr[..]
+    }
+
+    pub fn cursor(&self) -> u16 {
+        self.cursor.get()
+    }
 }
 
 pub struct DeadlineState {
@@ -73,6 +84,13 @@ impl DeadlineState {
 
     pub fn generation(&self) -> u64 {
         self.generation.get()
+    }
+
+    /// Supersede any armed compare; returns the new generation.
+    pub fn bump(&self) -> u64 {
+        let g = self.generation.get() + 1;
+        self.generation.set(g);
+        g
     }
 
     /// The servo's local clock at `sim_now`, unwrapped.
@@ -114,6 +132,11 @@ impl BaudState {
     #[allow(dead_code)]
     pub fn applied(&self) -> Vec<BaudRate> {
         self.applied.borrow().clone()
+    }
+
+    pub fn apply(&self, baud: BaudRate) {
+        self.applied.borrow_mut().push(baud);
+        self.current.set(baud);
     }
 }
 
@@ -346,8 +369,7 @@ impl SimBaud {
 
 impl UsartBaud for SimBaud {
     fn apply(&mut self, baud: BaudRate) {
-        self.state.applied.borrow_mut().push(baud);
-        self.state.current.set(baud);
+        self.state.apply(baud);
     }
 }
 

--- a/firmware/lib/integration/src/sim/servo.rs
+++ b/firmware/lib/integration/src/sim/servo.rs
@@ -67,13 +67,14 @@ impl SimServo {
 
         // The table is the comms authority (registry `Drivers::install` does
         // the same read on the chip).
-        let (id, rate, response_deadline_us) = shared.table.with(|t| {
+        let (id, rate_idx, response_deadline_us) = shared.table.with(|t| {
             (
                 t.config.comms.id,
                 t.config.comms.baud_rate_idx,
                 t.config.comms.response_deadline_us,
             )
         });
+        let rate = BaudRate::from_idx(rate_idx).expect("seeded baud idx");
         let baud = BaudState::new(rate);
 
         let bus = ServoBus::new(

--- a/firmware/lib/integration/tests/host_loop.rs
+++ b/firmware/lib/integration/tests/host_loop.rs
@@ -1,0 +1,296 @@
+//! Host-in-the-loop: the production `osc_host` engine scheduling the
+//! production servo stack over the sim wire -- both grid columns closed
+//! end-to-end with no scripted host bytes. Assertions read decoded events
+//! and table state (spec style), not raw hex.
+
+use osc_host::engine::{Command, Outcome};
+use osc_integration::sim::{HostEvent, Sim, Source, assert_valid};
+use osc_protocol::build;
+use osc_protocol::wire::{BaudRate, Id, Inst, Opcode, ResultCode, UID_LEN};
+use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
+
+const ID5: u8 = 5;
+
+fn ping(id: u8) -> Command<'static> {
+    Command::Exchange {
+        id: Id::new(id),
+        inst: Inst::instruction(Opcode::Ping, 0),
+        payload: &[],
+    }
+}
+
+fn status_result(inst: u8) -> Option<ResultCode> {
+    Inst(inst).result()
+}
+
+#[test]
+fn ping_round_trips_through_the_engine() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    sim.add_servo(ID5);
+
+    sim.host_submit(ping(ID5)).unwrap();
+    let frames = sim.run();
+
+    // Both wire frames are real and valid: the engine's instruction and the
+    // servo's status.
+    assert_eq!(frames.len(), 2, "{frames:#?}");
+    assert_eq!(frames[0].from, Source::Host);
+    assert_eq!(frames[1].from, Source::Servo(ID5));
+    assert_valid(&frames[0]);
+    assert_valid(&frames[1]);
+
+    let ev = sim.host_events();
+    assert_eq!(ev.len(), 2, "{ev:#?}");
+    match &ev[0] {
+        HostEvent::Status {
+            slot,
+            id,
+            inst,
+            payload,
+        } => {
+            assert_eq!((*slot, *id), (0, ID5));
+            assert_eq!(status_result(*inst), Some(ResultCode::Ok));
+            assert_eq!(payload.len(), 3, "model(2) + fw(1)");
+        }
+        other => panic!("expected Status, got {other:?}"),
+    }
+    match &ev[1] {
+        HostEvent::Done(t) => {
+            assert_eq!(t.outcome, Outcome::Complete);
+            assert_eq!(t.evidence.statuses, 1);
+            assert_eq!(t.evidence.garble, 0);
+        }
+        other => panic!("expected Done, got {other:?}"),
+    }
+}
+
+#[test]
+fn write_acks_and_reads_back() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    let s = sim.add_servo(ID5);
+
+    let mut p = [0u8; 16];
+    let val = 0x0B0B_0B0Bu32;
+    let n = build::write(&mut p, GOAL_VELOCITY, &val.to_le_bytes()).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::new(ID5),
+        inst: Inst::instruction(Opcode::Write, 0),
+        payload: &p[..n],
+    })
+    .unwrap();
+    sim.run();
+    let ev = sim.host_events();
+    assert!(
+        matches!(&ev[1], HostEvent::Done(t) if t.outcome == Outcome::Complete),
+        "{ev:#?}"
+    );
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        val as i32
+    );
+
+    let n = build::read(&mut p, GOAL_VELOCITY, 4).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::new(ID5),
+        inst: Inst::instruction(Opcode::Read, 0),
+        payload: &p[..n],
+    })
+    .unwrap();
+    sim.run();
+    let ev = sim.host_events();
+    match &ev[0] {
+        HostEvent::Status { payload, .. } => {
+            assert_eq!(payload.as_slice(), &val.to_le_bytes());
+        }
+        other => panic!("expected Status, got {other:?}"),
+    }
+}
+
+#[test]
+fn noreply_write_is_sent_and_applied() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    let s = sim.add_servo(ID5);
+
+    let mut p = [0u8; 16];
+    let n = build::write(&mut p, GOAL_VELOCITY, &0x11223344u32.to_le_bytes()).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::new(ID5),
+        inst: Inst::instruction(Opcode::Write, Inst::FLAG_NOREPLY),
+        payload: &p[..n],
+    })
+    .unwrap();
+    let frames = sim.run();
+
+    let ev = sim.host_events();
+    assert_eq!(ev.len(), 1, "no status for NOREPLY: {ev:#?}");
+    assert!(matches!(&ev[0], HostEvent::Done(t) if t.outcome == Outcome::Sent));
+    assert_eq!(
+        sim.servo_table(s, |t| t.control.lifecycle.goal_velocity),
+        0x11223344
+    );
+    assert_eq!(frames.len(), 1, "instruction only, no reply on the wire");
+}
+
+#[test]
+fn gread_chains_the_fleet_in_slot_order() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    for id in [1u8, 2, 3] {
+        sim.add_servo(id);
+    }
+
+    let mut p = [0u8; 16];
+    let ids = [Id::new(1), Id::new(2), Id::new(3)];
+    let n = build::gread_uniform(&mut p, GOAL_VELOCITY, 4, &ids).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::BROADCAST,
+        inst: Inst::instruction(Opcode::Gread, 0),
+        payload: &p[..n],
+    })
+    .unwrap();
+    sim.run();
+
+    let ev = sim.host_events();
+    assert_eq!(ev.len(), 4, "{ev:#?}");
+    for (k, want_id) in [1u8, 2, 3].iter().enumerate() {
+        match &ev[k] {
+            HostEvent::Status {
+                slot, id, payload, ..
+            } => {
+                assert_eq!((*slot, *id), (k as u8, *want_id));
+                assert_eq!(payload.len(), 4);
+            }
+            other => panic!("expected Status, got {other:?}"),
+        }
+    }
+    assert!(matches!(&ev[3], HostEvent::Done(t) if t.outcome == Outcome::Complete));
+}
+
+#[test]
+fn absent_servo_times_out() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    sim.add_servo(ID5);
+
+    sim.host_submit(ping(9)).unwrap();
+    sim.run();
+    let ev = sim.host_events();
+    assert_eq!(ev.len(), 1);
+    assert!(
+        matches!(&ev[0], HostEvent::Done(t) if t.outcome == Outcome::Timeout { slot: 0 }),
+        "{ev:#?}"
+    );
+}
+
+#[test]
+fn enum_exact_prefix_elects_the_sole_matcher() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    let a = sim.add_servo(1);
+    sim.add_servo(2);
+    sim.seed_servo_uid(a, [0xA1; UID_LEN]);
+    sim.seed_servo_uid(1, [0xB2; UID_LEN]);
+
+    let mut p = [0u8; 24];
+    let n = build::mgmt_enum(&mut p, 128, &[0xA1; UID_LEN]).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::BROADCAST,
+        inst: Inst::instruction(Opcode::Mgmt, 0),
+        payload: &p[..n],
+    })
+    .unwrap();
+    sim.run();
+
+    let ev = sim.host_events();
+    assert_eq!(ev.len(), 2, "{ev:#?}");
+    match &ev[0] {
+        HostEvent::Status { id, payload, .. } => {
+            assert_eq!(*id, 1);
+            assert_eq!(payload.as_slice(), &[0xA1; UID_LEN]);
+        }
+        other => panic!("expected Status, got {other:?}"),
+    }
+    // Collect completes at the quiet horizon; one matcher, no garble.
+    match &ev[1] {
+        HostEvent::Done(t) => {
+            assert_eq!(t.outcome, Outcome::Complete);
+            assert_eq!(t.evidence.statuses, 1);
+            assert!(!t.evidence.garble_after_last_frame);
+        }
+        other => panic!("expected Done, got {other:?}"),
+    }
+
+    // A prefix nobody carries: quiet completion with zero statuses -- the
+    // walk's empty-subtree verdict.
+    let n = build::mgmt_enum(&mut p, 128, &[0x77; UID_LEN]).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::BROADCAST,
+        inst: Inst::instruction(Opcode::Mgmt, 0),
+        payload: &p[..n],
+    })
+    .unwrap();
+    sim.run();
+    let ev = sim.host_events();
+    assert!(
+        matches!(&ev[0], HostEvent::Done(t) if t.outcome == Outcome::Complete && t.evidence.statuses == 0),
+        "{ev:#?}"
+    );
+}
+
+#[test]
+fn rescue_verb_reunites_host_and_fleet_at_the_rescue_rate() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    sim.add_servo(ID5);
+
+    sim.host_submit(Command::Rescue).unwrap();
+    sim.run();
+    let ev = sim.host_events();
+    assert!(
+        matches!(&ev[0], HostEvent::Done(t) if t.outcome == Outcome::Sent),
+        "{ev:#?}"
+    );
+
+    // Both ends dropped to 0.5M together: a ping now round-trips (the
+    // engine also spent its post-rescue pacing gap first).
+    sim.host_submit(ping(ID5)).unwrap();
+    sim.run();
+    let ev = sim.host_events();
+    assert_eq!(ev.len(), 2, "{ev:#?}");
+    assert!(matches!(&ev[1], HostEvent::Done(t) if t.outcome == Outcome::Complete));
+}
+
+#[test]
+fn cal_train_is_wire_invisible_to_the_fleet() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    sim.attach_host();
+    let s = sim.add_servo(ID5);
+
+    let mut p = [0u8; 8];
+    let n = build::mgmt_cal(&mut p, 400, 4).unwrap();
+    sim.host_submit(Command::Exchange {
+        id: Id::BROADCAST,
+        inst: Inst::instruction(Opcode::Mgmt, 0),
+        payload: &p[..n],
+    })
+    .unwrap();
+    let frames = sim.run();
+
+    let ev = sim.host_events();
+    assert!(
+        matches!(&ev[0], HostEvent::Done(t) if t.outcome == Outcome::Sent),
+        "{ev:#?}"
+    );
+    // The announce plus gaps + 1 = 5 bare ruler marks, all host-sourced.
+    let host_frames: Vec<_> = frames.iter().filter(|f| f.from == Source::Host).collect();
+    assert_eq!(host_frames.len(), 6, "{frames:#?}");
+    let bare = host_frames.iter().filter(|f| f.bytes == [0x00]).count();
+    assert_eq!(bare, 5, "ruler marks record as empty break frames");
+    // sec 9.3: the train is invisible to the link counters.
+    let d = sim.servo_diag(s);
+    assert_eq!(d.crc_fail_count, 0);
+    assert_eq!(d.framing_drop_count, 0);
+}

--- a/firmware/lib/integration/tests/resilience.rs
+++ b/firmware/lib/integration/tests/resilience.rs
@@ -405,7 +405,7 @@ fn rescue_pulse_drops_to_500k() {
     // Volatile: the config register still reads the operational baud.
     assert_eq!(
         sim.servo_table(s, |t| t.config.comms.baud_rate_idx),
-        BaudRate::B1000000
+        BaudRate::B1000000.as_idx()
     );
 
     // A ping at the operational 1M baud now mismatches the 0.5M servo -> no reply.
@@ -482,7 +482,7 @@ fn short_break_is_not_rescue(baud_idx: u8) {
     // No false rescue: the operational baud is unchanged.
     assert_eq!(
         sim.servo_table(s, |t| t.config.comms.baud_rate_idx),
-        BaudRate::from_idx(baud_idx).expect("valid baud idx")
+        baud_idx
     );
 }
 

--- a/firmware/lib/osc-protocol/src/build.rs
+++ b/firmware/lib/osc-protocol/src/build.rs
@@ -1,0 +1,404 @@
+//! Instruction payload builders -- the encode mirror of the `frame`/`group`
+//! parsers (`docs/osc-native-protocol.md` sec 5, sec 9). Hosts and tests
+//! write payloads through these into a caller buffer (typically
+//! [`FrameBuf::payload_mut`](crate::reply::FrameBuf::payload_mut)); the
+//! returned length feeds `finish`.
+//!
+//! The contract is parse-level validity, exactly: a built payload always
+//! round-trips through its parser, and anything the parser would reject
+//! (empty id list, zero CAL fields, ragged geometry, the sec 5.1 ceiling)
+//! refuses to build. Semantic validity -- id ranges, table addressing --
+//! stays the responder's verdict, reachable on the wire by construction.
+
+use crate::group::{GreadProfileTarget, GreadTarget};
+use crate::wire::{self, Id, MgmtOp};
+
+/// Bounds every builder: the destination window is the smaller of the buffer
+/// and the sec 5.1 payload ceiling.
+#[inline]
+fn cap(dst: &[u8]) -> usize {
+    dst.len().min(wire::MAX_PAYLOAD as usize)
+}
+
+/// READ / GREAD span head: `addr(2) count(2)` little-endian.
+#[inline]
+pub fn read(dst: &mut [u8], addr: u16, count: u16) -> Option<usize> {
+    if cap(dst) < 4 {
+        return None;
+    }
+    dst[..2].copy_from_slice(&addr.to_le_bytes());
+    dst[2..4].copy_from_slice(&count.to_le_bytes());
+    Some(4)
+}
+
+/// READ+PROFILE: `slot(1)` (sec 5.2).
+#[inline]
+pub fn read_profile(dst: &mut [u8], slot: u8) -> Option<usize> {
+    if cap(dst) < 1 {
+        return None;
+    }
+    dst[0] = slot;
+    Some(1)
+}
+
+/// WRITE: `addr(2)` little-endian, then the data bytes.
+#[inline]
+pub fn write(dst: &mut [u8], addr: u16, data: &[u8]) -> Option<usize> {
+    let total = 2 + data.len();
+    if cap(dst) < total {
+        return None;
+    }
+    dst[..2].copy_from_slice(&addr.to_le_bytes());
+    dst[2..total].copy_from_slice(data);
+    Some(total)
+}
+
+/// Uniform GREAD: `addr(2) count(2) id-list(1 each)`.
+pub fn gread_uniform(dst: &mut [u8], addr: u16, count: u16, ids: &[Id]) -> Option<usize> {
+    let total = 4 + ids.len();
+    if ids.is_empty() || cap(dst) < total {
+        return None;
+    }
+    read(dst, addr, count)?;
+    for (b, id) in dst[4..total].iter_mut().zip(ids) {
+        *b = id.as_byte();
+    }
+    Some(total)
+}
+
+/// PER_TARGET GREAD: `[id(1) addr(2) count(2)]x`.
+pub fn gread_per_target(dst: &mut [u8], targets: &[GreadTarget]) -> Option<usize> {
+    let total = 5 * targets.len();
+    if targets.is_empty() || cap(dst) < total {
+        return None;
+    }
+    for (chunk, t) in dst[..total].as_chunks_mut::<5>().0.iter_mut().zip(targets) {
+        chunk[0] = t.id.as_byte();
+        chunk[1..3].copy_from_slice(&t.addr.to_le_bytes());
+        chunk[3..5].copy_from_slice(&t.count.to_le_bytes());
+    }
+    Some(total)
+}
+
+/// Uniform GREAD+PROFILE: `slot(1) id-list(1 each)` (sec 5.2).
+pub fn gread_profile_uniform(dst: &mut [u8], slot: u8, ids: &[Id]) -> Option<usize> {
+    let total = 1 + ids.len();
+    if ids.is_empty() || cap(dst) < total {
+        return None;
+    }
+    dst[0] = slot;
+    for (b, id) in dst[1..total].iter_mut().zip(ids) {
+        *b = id.as_byte();
+    }
+    Some(total)
+}
+
+/// PER_TARGET GREAD+PROFILE: `[id(1) slot(1)]x`.
+pub fn gread_profile_per_target(dst: &mut [u8], targets: &[GreadProfileTarget]) -> Option<usize> {
+    let total = 2 * targets.len();
+    if targets.is_empty() || cap(dst) < total {
+        return None;
+    }
+    for (chunk, t) in dst[..total].as_chunks_mut::<2>().0.iter_mut().zip(targets) {
+        chunk[0] = t.id.as_byte();
+        chunk[1] = t.slot;
+    }
+    Some(total)
+}
+
+/// Uniform GWRITE: `addr(2) count(1)` head, then [`push`](Self::push) per
+/// `[id(1) data(count)]` entry. Entry data length is pinned to `count`.
+pub struct GwriteUniform<'a> {
+    dst: &'a mut [u8],
+    len: usize,
+    count: u8,
+}
+
+impl<'a> GwriteUniform<'a> {
+    pub fn new(dst: &'a mut [u8], addr: u16, count: u8) -> Option<Self> {
+        if count == 0 || cap(dst) < 3 {
+            return None;
+        }
+        dst[..2].copy_from_slice(&addr.to_le_bytes());
+        dst[2] = count;
+        Some(Self { dst, len: 3, count })
+    }
+
+    pub fn push(&mut self, id: Id, data: &[u8]) -> Option<()> {
+        if data.len() != self.count as usize {
+            return None;
+        }
+        let end = self.len + 1 + data.len();
+        if cap(self.dst) < end {
+            return None;
+        }
+        self.dst[self.len] = id.as_byte();
+        self.dst[self.len + 1..end].copy_from_slice(data);
+        self.len = end;
+        Some(())
+    }
+
+    /// The payload length; `None` when no entry was pushed (the parser
+    /// rejects a bare head).
+    pub fn finish(self) -> Option<usize> {
+        (self.len > 3).then_some(self.len)
+    }
+}
+
+/// PER_TARGET GWRITE: [`push`](Self::push) per `[id(1) addr(2) count(1)
+/// data(count)]` entry, each entry's data sizing itself.
+pub struct GwritePerTarget<'a> {
+    dst: &'a mut [u8],
+    len: usize,
+}
+
+impl<'a> GwritePerTarget<'a> {
+    pub fn new(dst: &'a mut [u8]) -> Self {
+        Self { dst, len: 0 }
+    }
+
+    pub fn push(&mut self, id: Id, addr: u16, data: &[u8]) -> Option<()> {
+        if data.len() > u8::MAX as usize {
+            return None;
+        }
+        let end = self.len + 4 + data.len();
+        if cap(self.dst) < end {
+            return None;
+        }
+        let e = &mut self.dst[self.len..end];
+        e[0] = id.as_byte();
+        e[1..3].copy_from_slice(&addr.to_le_bytes());
+        e[3] = data.len() as u8;
+        e[4..].copy_from_slice(data);
+        self.len = end;
+        Some(())
+    }
+
+    /// The payload length; `None` when no entry was pushed.
+    pub fn finish(self) -> Option<usize> {
+        (self.len > 0).then_some(self.len)
+    }
+}
+
+/// Bare MGMT payload: `sub-op(1)`, no args (SAVE / REBOOT / FACTORY, sec 9.4,
+/// sec 9.5).
+#[inline]
+pub fn mgmt(dst: &mut [u8], op: MgmtOp) -> Option<usize> {
+    if cap(dst) < 1 {
+        return None;
+    }
+    dst[0] = op as u8;
+    Some(1)
+}
+
+/// MGMT ENUM: `sub-op(1) prefix_len(1)` in bits (0..=128), then the
+/// `ceil(prefix_len/8)`-byte LSB-first prefix (sec 9.2).
+pub fn mgmt_enum(dst: &mut [u8], prefix_len: u8, prefix: &[u8; wire::UID_LEN]) -> Option<usize> {
+    if prefix_len > (wire::UID_LEN * 8) as u8 {
+        return None;
+    }
+    let n = prefix_len.div_ceil(8) as usize;
+    let total = 2 + n;
+    if cap(dst) < total {
+        return None;
+    }
+    dst[0] = MgmtOp::Enum as u8;
+    dst[1] = prefix_len;
+    dst[2..total].copy_from_slice(&prefix[..n]);
+    Some(total)
+}
+
+/// MGMT ASSIGN: `sub-op(1) uid(16) new_id(1)` (sec 9.2). `new_id` range is the
+/// matcher's verdict (a nackable `validation`), not a build gate.
+pub fn mgmt_assign(dst: &mut [u8], uid: &[u8; wire::UID_LEN], new_id: u8) -> Option<usize> {
+    let total = 2 + wire::UID_LEN;
+    if cap(dst) < total {
+        return None;
+    }
+    dst[0] = MgmtOp::Assign as u8;
+    dst[1..1 + wire::UID_LEN].copy_from_slice(uid);
+    dst[1 + wire::UID_LEN] = new_id;
+    Some(total)
+}
+
+/// MGMT CAL: `sub-op(1) gap_us(2 LE) gaps(1)` (sec 9.3). Zero in either field
+/// is no train -- rejected here as the parser rejects it.
+pub fn mgmt_cal(dst: &mut [u8], gap_us: u16, gaps: u8) -> Option<usize> {
+    if gap_us == 0 || gaps == 0 || cap(dst) < 4 {
+        return None;
+    }
+    dst[0] = MgmtOp::Cal as u8;
+    dst[1..3].copy_from_slice(&gap_us.to_le_bytes());
+    dst[3] = gaps;
+    Some(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bytes::FrameBytes;
+    use crate::frame::{AssignReq, CalReq, EnumReq, MgmtReq, ProfileReq, ReadReq, WriteReq};
+    use crate::group;
+
+    fn fb(b: &[u8]) -> FrameBytes<'_> {
+        FrameBytes::from(b)
+    }
+
+    #[test]
+    fn read_round_trips_and_matches_vector() {
+        let mut b = [0u8; 8];
+        let n = read(&mut b, 0x0200, 8).unwrap();
+        // The sec 3.2 READ test vector's payload bytes.
+        assert_eq!(&b[..n], &[0x00, 0x02, 0x08, 0x00]);
+        let r = ReadReq::parse(fb(&b[..n])).unwrap();
+        assert_eq!((r.addr, r.count), (0x0200, 8));
+    }
+
+    #[test]
+    fn read_profile_round_trips() {
+        let mut b = [0u8; 4];
+        let n = read_profile(&mut b, 2).unwrap();
+        assert_eq!(ProfileReq::parse(fb(&b[..n])).unwrap().slot, 2);
+    }
+
+    #[test]
+    fn write_round_trips_and_matches_vector() {
+        let mut b = [0u8; 16];
+        let n = write(&mut b, 0x0180, &[0x2C, 0x01]).unwrap();
+        // The sec 3.2 WRITE test vector's payload bytes.
+        assert_eq!(&b[..n], &[0x80, 0x01, 0x2C, 0x01]);
+        let w = WriteReq::parse(fb(&b[..n])).unwrap();
+        assert_eq!(w.addr, 0x0180);
+        assert_eq!(w.data, fb(&[0x2C, 0x01]));
+    }
+
+    #[test]
+    fn gread_uniform_round_trips() {
+        let mut b = [0u8; 16];
+        let ids = [Id::new(1), Id::new(2), Id::new(5)];
+        let n = gread_uniform(&mut b, 0x0084, 8, &ids).unwrap();
+        let g = group::GreadUniform::parse(fb(&b[..n])).unwrap();
+        assert_eq!((g.addr, g.count), (0x0084, 8));
+        assert!(g.ids().eq(ids));
+        assert_eq!(gread_uniform(&mut b, 0x0084, 8, &[]), None);
+    }
+
+    #[test]
+    fn gread_per_target_round_trips() {
+        let mut b = [0u8; 16];
+        let ts = [
+            GreadTarget {
+                id: Id::new(10),
+                addr: 0x0200,
+                count: 4,
+            },
+            GreadTarget {
+                id: Id::new(20),
+                addr: 0x0010,
+                count: 2,
+            },
+        ];
+        let n = gread_per_target(&mut b, &ts).unwrap();
+        let g = group::GreadPerTarget::parse(fb(&b[..n])).unwrap();
+        assert!(g.iter().eq(ts));
+        assert_eq!(gread_per_target(&mut b, &[]), None);
+    }
+
+    #[test]
+    fn gread_profile_forms_round_trip() {
+        let mut b = [0u8; 16];
+        let ids = [Id::new(1), Id::new(5)];
+        let n = gread_profile_uniform(&mut b, 2, &ids).unwrap();
+        let g = group::GreadProfileUniform::parse(fb(&b[..n])).unwrap();
+        assert_eq!(g.slot, 2);
+        assert!(g.ids().eq(ids));
+
+        let ts = [
+            GreadProfileTarget {
+                id: Id::new(10),
+                slot: 0,
+            },
+            GreadProfileTarget {
+                id: Id::new(20),
+                slot: 3,
+            },
+        ];
+        let n = gread_profile_per_target(&mut b, &ts).unwrap();
+        let g = group::GreadProfilePerTarget::parse(fb(&b[..n])).unwrap();
+        assert!(g.iter().eq(ts));
+    }
+
+    #[test]
+    fn gwrite_uniform_round_trips() {
+        let mut b = [0u8; 32];
+        let mut w = GwriteUniform::new(&mut b, 0x0180, 4).unwrap();
+        w.push(Id::new(1), &[1, 2, 3, 4]).unwrap();
+        w.push(Id::new(2), &[5, 6, 7, 8]).unwrap();
+        let n = w.finish().unwrap();
+        let g = group::GwriteUniform::parse(fb(&b[..n])).unwrap();
+        assert_eq!((g.addr, g.count), (0x0180, 4));
+        assert_eq!(g.find(Id::new(2)), Some(fb(&[5, 6, 7, 8])));
+    }
+
+    #[test]
+    fn gwrite_uniform_gates_mirror_the_parser() {
+        let mut b = [0u8; 32];
+        // count 0 has no stride; wrong-length data breaks it; a bare head
+        // would parse as ragged/empty.
+        assert!(GwriteUniform::new(&mut b, 0, 0).is_none());
+        let mut w = GwriteUniform::new(&mut b, 0, 4).unwrap();
+        assert!(w.push(Id::new(1), &[1, 2]).is_none());
+        assert!(w.finish().is_none());
+    }
+
+    #[test]
+    fn gwrite_per_target_round_trips() {
+        let mut b = [0u8; 32];
+        let mut w = GwritePerTarget::new(&mut b);
+        w.push(Id::new(3), 0x0000, &[0xAA, 0xBB]).unwrap();
+        w.push(Id::new(4), 0x0100, &[1, 2, 3, 4]).unwrap();
+        let n = w.finish().unwrap();
+        let g = group::GwritePerTarget::parse(fb(&b[..n])).unwrap();
+        assert_eq!(g.find(Id::new(4)).unwrap().data, fb(&[1, 2, 3, 4]));
+        assert!(GwritePerTarget::new(&mut b).finish().is_none());
+    }
+
+    #[test]
+    fn mgmt_forms_round_trip() {
+        let mut b = [0u8; 24];
+
+        let n = mgmt(&mut b, MgmtOp::Save).unwrap();
+        assert_eq!(MgmtReq::parse(fb(&b[..n])).unwrap().op, MgmtOp::Save);
+
+        let mut prefix = [0u8; wire::UID_LEN];
+        prefix[0] = 0b0000_0101;
+        let n = mgmt_enum(&mut b, 3, &prefix).unwrap();
+        let m = MgmtReq::parse(fb(&b[..n])).unwrap();
+        let e = EnumReq::parse(m.args).unwrap();
+        assert_eq!(e.prefix_len, 3);
+        assert_eq!(e.prefix, prefix);
+        assert_eq!(mgmt_enum(&mut b, 129, &prefix), None);
+
+        let uid = [7u8; wire::UID_LEN];
+        let n = mgmt_assign(&mut b, &uid, 9).unwrap();
+        let a = AssignReq::parse(MgmtReq::parse(fb(&b[..n])).unwrap().args).unwrap();
+        assert_eq!((a.uid, a.new_id), (uid, 9));
+
+        let n = mgmt_cal(&mut b, 400, 8).unwrap();
+        let c = CalReq::parse(MgmtReq::parse(fb(&b[..n])).unwrap().args).unwrap();
+        assert_eq!((c.gap_us, c.gaps), (400, 8));
+        assert_eq!(mgmt_cal(&mut b, 0, 8), None);
+        assert_eq!(mgmt_cal(&mut b, 400, 0), None);
+    }
+
+    #[test]
+    fn builders_hold_the_payload_ceiling() {
+        // 250 ids would build a 254 B payload -- past the sec 5.1 ceiling even
+        // in a roomier buffer.
+        let mut b = [0u8; 300];
+        let ids = [Id::new(1); 250];
+        assert_eq!(gread_uniform(&mut b, 0, 2, &ids), None);
+        // One shy of the full unicast space fits: 4 + 248 = 252.
+        assert_eq!(gread_uniform(&mut b, 0, 2, &ids[..248]), Some(252));
+    }
+}

--- a/firmware/lib/osc-protocol/src/lib.rs
+++ b/firmware/lib/osc-protocol/src/lib.rs
@@ -7,6 +7,7 @@
 //! osc-CRC-16 definition.
 #![no_std]
 
+pub mod build;
 pub mod bytes;
 pub mod crc;
 pub mod frame;

--- a/firmware/lib/osc-protocol/src/wire.rs
+++ b/firmware/lib/osc-protocol/src/wire.rs
@@ -274,6 +274,17 @@ impl Inst {
 /// Max payload bytes; sized so the largest frame fits whole in the ring (sec 3.1).
 pub const MAX_PAYLOAD: u8 = 252;
 
+/// sec 7 default: chain reclaim + host timeout, not a reply-time prescription.
+pub const DEFAULT_RESPONSE_DEADLINE_US: u16 = 60;
+
+/// sec 3.4: byte-times of ring silence that kill a parked partial frame -- the
+/// fallback death authority servo-side, and the host's post-garble pacing gap.
+pub const STARVE_HORIZON_BYTE_TIMES: u32 = 64;
+
+/// sec 9.1 rescue pulse: the servo sampler declares rescue at this much
+/// continuous dominant low; hosts send ~1 ms for sampler-jitter margin.
+pub const RESCUE_PULSE_MIN_US: u32 = 300;
+
 /// UID field width in bytes (sec 9.2): UUID-width, fixed. A chip fills it
 /// LSB-first from its silicon ID and zero-pads the tail (the V006's 96-bit
 /// ESIG leaves the top four bytes zero); no catalog MCU exceeds 128 bits.

--- a/firmware/lib/osc-protocol/src/wire.rs
+++ b/firmware/lib/osc-protocol/src/wire.rs
@@ -52,6 +52,48 @@ impl Id {
     }
 }
 
+/// Operational baud (sec 2): four rates, default 1M. Recovery is the rescue
+/// break's job (sec 9.1), so no crawl-speed fallback exists. The discriminant
+/// IS the `baud_rate_idx` config register value -- wire ABI, do not reorder.
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum BaudRate {
+    #[default]
+    B500000 = 0,
+    B1000000 = 1,
+    B2000000 = 2,
+    B3000000 = 3,
+}
+
+impl BaudRate {
+    /// The sec 9.1 rescue rate: the option floor, entered only via rescue
+    /// break -- volatile, config register untouched.
+    pub const RESCUE: Self = Self::B500000;
+
+    pub const fn as_idx(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn as_hz(self) -> u32 {
+        match self {
+            BaudRate::B500000 => 500_000,
+            BaudRate::B1000000 => 1_000_000,
+            BaudRate::B2000000 => 2_000_000,
+            BaudRate::B3000000 => 3_000_000,
+        }
+    }
+
+    pub const fn from_idx(idx: u8) -> Option<Self> {
+        match idx {
+            0 => Some(BaudRate::B500000),
+            1 => Some(BaudRate::B1000000),
+            2 => Some(BaudRate::B2000000),
+            3 => Some(BaudRate::B3000000),
+            _ => None,
+        }
+    }
+}
+
 /// Instruction opcode, `INST` bits [6:4] (sec 5). `0x0` is invalid.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/firmware/servo-ch32/src/runtime/registry.rs
+++ b/firmware/servo-ch32/src/runtime/registry.rs
@@ -13,7 +13,7 @@
 
 use core::cell::SyncUnsafeCell;
 
-use osc_servo_core::RegionStorage;
+use osc_servo_core::{BaudRate, RegionStorage};
 use osc_servo_drivers::Level;
 use osc_servo_drivers::bus::ServoBus;
 use osc_servo_drivers::led::Led;
@@ -100,13 +100,16 @@ impl Drivers {
 
         // The table is the comms authority here -- a saved image's id/baud
         // must be what the bus comes up as, not the board defaults.
-        let (id, baud, deadline_us) = crate::runtime::statics::SHARED.table.with(|t| {
+        let (id, baud_idx, deadline_us) = crate::runtime::statics::SHARED.table.with(|t| {
             (
                 t.config.comms.id,
                 t.config.comms.baud_rate_idx,
                 t.config.comms.response_deadline_us,
             )
         });
+        // Image parse gates enum UB only; a corrupt-but-CRC-valid idx falls
+        // back to the always-reachable rescue floor instead of panicking.
+        let baud = BaudRate::from_idx(baud_idx).unwrap_or(BaudRate::RESCUE);
 
         // SAFETY: see fn doc.
         let bus = unsafe { &mut *CELLS.bus.0.get() };

--- a/tools/bench/src/bin/tool-snoop.rs
+++ b/tools/bench/src/bin/tool-snoop.rs
@@ -1,0 +1,71 @@
+//! Passive wire snoop: park the pirate on a bus someone else is driving and
+//! print every captured byte with timing. Debug glass for third-party hosts
+//! (e.g. the wch-linke adapter spike) -- shows break boundaries, byte hex,
+//! and inter-byte gaps so a foreign host's TX shape can be read byte-exact.
+
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use bench::cli::Connect;
+use bench::pirate::BStamp;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(about = "Passively capture bus traffic through the pirate and dump it.")]
+struct Args {
+    #[command(flatten)]
+    conn: Connect,
+    /// Seconds to listen before draining.
+    #[arg(short, long, default_value_t = 3)]
+    seconds: u64,
+    /// Gap (us) that starts a new burst line.
+    #[arg(short, long, default_value_t = 300)]
+    gap_us: u32,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut client = args.conn.client()?;
+    let hz_per_us = client.hz_per_us()?;
+
+    client.reset()?;
+    println!(
+        "listening {} s at {} baud on {} ...",
+        args.seconds,
+        client.current_baud(),
+        client.port_path()
+    );
+    std::thread::sleep(Duration::from_secs(args.seconds));
+
+    let mut stamps: Vec<BStamp> = Vec::new();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline {
+        match client.drain_byte()? {
+            Some(s) => stamps.push(s),
+            None => break,
+        }
+    }
+
+    if stamps.is_empty() {
+        println!("no bytes captured");
+        return Ok(());
+    }
+
+    println!("{} bytes captured:", stamps.len());
+    let mut prev_tick: Option<u32> = None;
+    for s in &stamps {
+        let gap = prev_tick.map(|p| s.tick.wrapping_sub(p) / hz_per_us);
+        prev_tick = Some(s.tick);
+        if gap.is_none_or(|g| g > args.gap_us) {
+            println!();
+            print!("burst: ");
+        }
+        if s.flags & BStamp::BOUNDARY != 0 {
+            print!("|BRK|");
+        }
+        print!("{:02x} ", s.byte);
+    }
+    println!();
+    println!("(|BRK| = break-boundary capture on that byte's stamp)");
+    Ok(())
+}

--- a/tools/bench/tests/hardware/chain.rs
+++ b/tools/bench/tests/hardware/chain.rs
@@ -28,8 +28,8 @@ const BCAST: u8 = 0xFE;
 
 /// The DUT at chain slot 1 behind a silent phantom must reclaim the predecessor
 /// and reply `PredecessorSilent`, and only after waiting out the reclaim window.
-#[test]
 #[serial]
+#[test]
 fn gread_slot1_reclaims_silent_predecessor() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/hold_commit.rs
+++ b/tools/bench/tests/hardware/hold_commit.rs
@@ -10,8 +10,8 @@ const BROADCAST: u8 = 0xFE;
 /// WRITE+HOLD stages the value (the live field stays put); a broadcast COMMIT
 /// applies it. osc collapses DXL's RegWrite/Action into HOLD + COMMIT (protocol sec 5). The
 /// original is restored (state discipline).
-#[test]
 #[serial]
+#[test]
 fn hold_then_commit_applies() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/hot_loop.rs
+++ b/tools/bench/tests/hardware/hot_loop.rs
@@ -62,8 +62,8 @@ fn check(label: &str, baud: u32, report: &BurstReport, dirty: &mut Vec<String>) 
 
 /// The production hot loop `[GWRITE(HOLD), COMMIT, GREAD]` sent zero-gap at every
 /// wire baud: the GREAD must read back the just-committed value on every cycle.
-#[test]
 #[serial]
+#[test]
 fn hot_loop_zero_gap_survives() {
     let mut b = bench();
     let id = b.id();
@@ -87,8 +87,8 @@ fn hot_loop_zero_gap_survives() {
 /// A plain `[WRITE(NOREPLY) x 8, READ]` flood at every wire baud: no per-write
 /// reply paces the framer, so the READ read-back guards every silent write. The
 /// aggressive stress reproduces the low-baud glitch the most readily.
-#[test]
 #[serial]
+#[test]
 fn plain_write_flood_survives() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/mgmt.rs
+++ b/tools/bench/tests/hardware/mgmt.rs
@@ -15,8 +15,8 @@ use crate::support::bench;
 /// 16-byte field: the V006's 96-bit ESIG in the low 12 bytes (not the
 /// all-zero pattern a missed ESIG read would seed), zero pad above. An
 /// exact 128-bit prefix selects exactly the DUT; one flipped bit nobody.
-#[test]
 #[serial]
+#[test]
 fn enum_prefix_selects_exactly_the_dut() {
     let mut b = bench();
 
@@ -38,8 +38,8 @@ fn enum_prefix_selects_exactly_the_dut() {
 /// it (protocol sec 9.2) -- then back. PINGs prove the swap on the wire both ways.
 /// Fleet-safe: ASSIGN is UID-addressed (one matcher on any bus), and the
 /// away id sits outside every bench and fleet id map.
-#[test]
 #[serial]
+#[test]
 fn assign_moves_the_id_and_acks_from_it() {
     let mut b = bench();
     let home = b.id();
@@ -68,8 +68,8 @@ fn assign_moves_the_id_and_acks_from_it() {
 /// the identity -- the bus leaves exactly as found. Reads are collected
 /// first and asserted only after the restore, so a bad marker never
 /// strands a saved image on the bench.
-#[test]
 #[serial]
+#[test]
 fn save_persists_across_reboot_until_factory() {
     const MARKER: u16 = 123; // response_deadline_us; board default is 60
 

--- a/tools/bench/tests/hardware/ping.rs
+++ b/tools/bench/tests/hardware/ping.rs
@@ -4,8 +4,8 @@ use serial_test::serial;
 use crate::support::bench;
 
 /// PING -> status carries model(2) + fw(1), from the responder's id (protocol sec 5).
-#[test]
 #[serial]
+#[test]
 fn ping_returns_model_and_fw() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/profile.rs
+++ b/tools/bench/tests/hardware/profile.rs
@@ -21,8 +21,8 @@ const SCATTER: [(u16, u8); 3] = [
 
 /// A gathered reply is byte-identical to the concatenation of plain READs of
 /// the same spans (odd interior span included -- no parity constraint, protocol sec 5.2).
-#[test]
 #[serial]
+#[test]
 fn profile_read_matches_plain_reads() {
     let mut b = bench();
     let id = b.id();
@@ -39,8 +39,8 @@ fn profile_read_matches_plain_reads() {
 }
 
 /// Unconfigured and out-of-range slots reject `range` (protocol sec 5.3).
-#[test]
 #[serial]
+#[test]
 fn profile_read_bad_slot_rejects_range() {
     let mut b = bench();
     let id = b.id();
@@ -78,8 +78,8 @@ fn profile_turnaround_budget_us(baud: u32) -> f64 {
 /// matrix; the distribution at each baud is printed for the record. The 2M
 /// leg is the regression gate for the pirate's DATAR discipline (an
 /// IDLE-clear DATAR read ate the reply's final byte 1/128 exchanges).
-#[test]
 #[serial]
+#[test]
 fn profile_read_turnaround_within_budget() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/read.rs
+++ b/tools/bench/tests/hardware/read.rs
@@ -6,8 +6,8 @@ use crate::support::bench;
 
 /// READ the read-only model_number span and cross-check it against PING, which
 /// also reports the model -- the two must agree (no hardcoded model value).
-#[test]
 #[serial]
+#[test]
 fn read_model_number_matches_ping() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/rescue.rs
+++ b/tools/bench/tests/hardware/rescue.rs
@@ -24,8 +24,8 @@ use crate::support::bench;
 /// The pulse is baud-agnostic: servo moved to 3M (volatile) with the pirate
 /// back at the boot baud -- unreachable -- then one rescue pulse unifies the
 /// bus at 0.5M. Reboot restores the configured (boot-default) baud.
-#[test]
 #[serial]
+#[test]
 fn rescue_reaches_a_servo_at_any_baud_and_reboot_exits() {
     let mut b = bench();
     let id = b.id();
@@ -76,8 +76,8 @@ fn rescue_reaches_a_servo_at_any_baud_and_reboot_exits() {
 /// find a whole chain (only the entry at our configured id is the DUT),
 /// every mutation is UID-scoped, and a silent broadcast REBOOT releases
 /// the servos the bus-wide pulses parked at 0.5M.
-#[test]
 #[serial]
+#[test]
 fn rescue_walk_assign_save_survives_reboot_until_factory() {
     let mut b = bench();
     let home = b.id();

--- a/tools/bench/tests/hardware/silence.rs
+++ b/tools/bench/tests/hardware/silence.rs
@@ -9,8 +9,8 @@ const BROADCAST: u8 = 0xFE;
 
 /// A NOREPLY write draws no status frame (protocol sec 5 NOREPLY flag). We write the field's
 /// current value back -- inert, but the write still executes silently.
-#[test]
 #[serial]
+#[test]
 fn noreply_write_is_silent() {
     let mut b = bench();
     let id = b.id();
@@ -27,8 +27,8 @@ fn noreply_write_is_silent() {
 }
 
 /// A broadcast write is silent by addressing (protocol sec 5): no servo replies to 0xFE.
-#[test]
 #[serial]
+#[test]
 fn broadcast_write_is_silent() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/trim.rs
+++ b/tools/bench/tests/hardware/trim.rs
@@ -52,8 +52,8 @@ fn train(b: &mut Bench, announce_gap_us: u16) {
     sleep(Duration::from_millis(SETTLE_MS));
 }
 
-#[test]
 #[serial]
+#[test]
 fn lying_train_trims_and_truth_pulls_back() {
     let mut b = bench();
     let start = read_trim(&mut b);
@@ -104,8 +104,8 @@ fn feed(b: &mut Bench, burst: &[Vec<u8>], bursts: u32) {
     }
 }
 
-#[test]
 #[serial]
+#[test]
 fn tracker_follows_host_detune() {
     let mut b = bench();
     // The detune step is defined against the 1M BRR; pin the bus there.

--- a/tools/bench/tests/hardware/turnaround.rs
+++ b/tools/bench/tests/hardware/turnaround.rs
@@ -79,8 +79,8 @@ fn gate(b: &mut Bench, wire: &[u8], label: &str, budget_us: fn(u32) -> f64) {
 
 /// THE metric: instruction wire-end -> status break fall, swept across the
 /// baud matrix.
-#[test]
 #[serial]
+#[test]
 fn ping_turnaround_within_budget() {
     let mut b = bench();
     let id = b.id();
@@ -89,8 +89,8 @@ fn ping_turnaround_within_budget() {
 
 /// The copy-once read path at telemetry scale (16 B from the converted
 /// block).
-#[test]
 #[serial]
+#[test]
 fn read_turnaround_within_budget() {
     let mut b = bench();
     let id = b.id();
@@ -104,8 +104,8 @@ fn read_turnaround_within_budget() {
 
 /// The mutating path: validated goal_position write (board-default value,
 /// so the table state is untouched).
-#[test]
 #[serial]
+#[test]
 fn write_turnaround_within_budget() {
     let mut b = bench();
     let id = b.id();

--- a/tools/bench/tests/hardware/write.rs
+++ b/tools/bench/tests/hardware/write.rs
@@ -7,8 +7,8 @@ use crate::support::bench;
 /// WRITE -> empty OK ack, and the value lands. stream_field_mask is a plain u32
 /// bitmask (no range rule, no motion side-effect), so an arbitrary value is a
 /// clean round-trip probe. The original is restored (state discipline).
-#[test]
 #[serial]
+#[test]
 fn write_field_mask_round_trips() {
     let mut b = bench();
     let id = b.id();


### PR DESCRIPTION
## What

The host column's core-lib row: `osc-host` (engine + link, one no_std sans-io crate — alloc-free, no statics, multi-instance by construction), plus the osc-protocol groundwork the host column needed and a host-in-the-loop DES that closes both grid columns over the sim wire.

## osc-protocol groundwork

- **`BaudRate` hoisted from `osc-servo-core` into `osc-protocol::wire`** (grid law 2: the host column may not import servo crates, and wire vocabulary is never redefined). The control-table `Enum` derive impls a control-table trait, which orphan-rules the enum to whichever crate defines it — so the table field became a raw `baud_rate_idx: u8` under an `le = 3` rule (identical validation for the dense 0..=3 index). The chip registry decodes with a defensive fall-back to the rescue floor; the persist enum-UB gate test repoints at `stall_response`, a genuine enum field.
- **Instruction payload builders** (`build.rs`): the encode mirror of every parser — read/write, all four GREAD forms, both GWRITE forms, all six MGMT sub-ops. Contract: builders enforce exactly parse-level validity (a built payload always round-trips its parser; semantic verdicts stay the servo's nack). Tested by round-trip through the parsers plus the sec 3.2 wire vectors.
- **Shared timing consts hoisted**: `DEFAULT_RESPONSE_DEADLINE_US`, `STARVE_HORIZON_BYTE_TIMES`, `RESCUE_PULSE_MIN_US` (protocol-normative values both ends need).

## osc-host: engine

- **Provider traits** (`traits.rs`): `RxRing` / `Deadline` / `TxWire` / `UsartBaud` + a `Providers` bundle. They deliberately mirror the servo shapes without sharing code (consumer-owned interfaces + never-across-columns outrank DRY). Deliberately absent: a break-event input (no LBD on the adapter target; all host RX is solicited), a CRC engine trait (software CRC — the host has cycles to spare), a separate monotonic.
- **RX framer**: a pure ring walker — anchor on the break's 0x00 ring byte, LEN strides, geometry + CRC verdict as the only accept authority, hunt-to-next-0x00 resync. The fault contract (protocol sec 3.4) with the wake deleted: positions from ring data only, every clock stays in the engine.
- **`Shape::derive`**: per-opcode validation before anything touches the wire — this is where "clients cannot emit a malformed frame" lives — plus await-mode derivation (Single / Chain(n) / Collect-until-quiet / CAL-Train) and per-slot reply-footprint allowances.
- **`HostBus` FSM**: one outstanding command; `submit → poll` yields streamed statuses then exactly one terminal (Sent / Complete / Timeout + `WireEvidence`). Timeout windows are RESPONSE_DEADLINE + reply frame time + margin, extended by ring progress (never IDLE-derived). Sec 3.4 fault pacing (one starve horizon of enforced silence) after garble evidence, a baud change, or rescue. CAL trains ride a drift-free grid (`deadline_at += gap` — ISR entry jitter never accumulates down the train); `Rescue` is one atomic verb (pulse + host UART to 0.5M — no way to half-do it). The ENUM walk stays client-side by design: the engine ships evidence (statuses, garble, trailing energy), collision verdicts are client policy.

## osc-host: link

- Length-prefixed records (`len(2 LE) type(1) body`) over a reliable ordered byte pipe — carrier-portable, USB transfer boundaries carry no meaning.
- `LinkServer` (sans-io): reassembles records from arbitrary pipe chunking, drives the engine, tags statuses/terminals with the client's `seq`; exactly one REJECTED-or-TERMINAL per seq; HELLO/INFO advertises the tick rate once. Record families reserved from day one: `0x40..=0x4F` firmware update (enter-bootloader lands with the phase-3 flash service), `0x60..=0x6F` bench.

## Host-in-the-loop DES

`tests/host_loop.rs`: the production engine scheduling the production servo stack over the sim wire, zero scripted host bytes — ping round-trip, write + read-back, NOREPLY, a 3-servo GREAD chain in slot order, absent-servo timeout, ENUM sole-matcher election and empty-subtree quiet, rescue reuniting host and fleet at 0.5M, and CAL-train wire-invisibility to the link counters. The sim gained `attach_host()` (host ring fed by the same wire deliveries as servo rings, minus own-TX; `HostCompare`/`HostTxDone` events; the host TX schedules the same wire events a scripted `host_send` would).

Also here: `tool-snoop` (the passive pirate wire dump that cracked the LinkE clock bugs) lands in tools/bench.

## Verification

81 new tests (12 builders, 9 framer, 10 shape, 12 engine, 7 link, 8 DES, plus collateral updates); all CI gates run locally verbatim: fmt --check + clippy --workspace --tests -D warnings + full test suites on firmware/lib and firmware/servo-ch32, board release build + soft-arith gate, bench tools clippy + lib tests.
