### PR TITLE
protocol: common register block -- fixed fronts for model-agnostic tooling

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -24,3 +24,7 @@ osc-integration = { path = "../firmware/lib/integration", optional = true }
 [[example]]
 name = "fleet_smoke"
 required-features = ["nusb"]
+
+[[example]]
+name = "provision"
+required-features = ["nusb"]

--- a/client/examples/provision.rs
+++ b/client/examples/provision.rs
@@ -1,0 +1,178 @@
+//! Fleet provisioning over USB: the first-boot story (factory-fresh servos
+//! all share the board-default id) and the common-register-block health view.
+//!
+//!   provision factory 1 2 3 4 5      wipe saved config, reboot to defaults
+//!   provision discover               ENUM walk, print UIDs
+//!   provision assign 1               walk, then assign ids base.. by UID order
+//!   provision ping 1 2 3 4 5         liveness sweep
+//!   provision status 1 2 3 4 5       decode both common-block fronts
+//!   provision deadline 5 80          write response_deadline_us (marks dirty)
+//!   provision clear 1 2 3 4 5        zero the telemetry counters (rw-clear)
+//!   provision save 1 2 3 4 5         persist config, clears the dirty bit
+//!   provision reboot 1 2 3 4 5       MGMT REBOOT
+//!   provision cal 3 400 8            CAL trains; trim lands in `status`
+//!   provision migrate 3 1 2 3 4 5    servo-first baud migration + reunion sweep
+//!   provision chain 50 1 2 3 4 5     GREAD chain soak, reports non-clean runs
+
+use osc_client::blocking::Client;
+use osc_client::nusb::NusbPipe;
+use osc_client::{Error, Id};
+use osc_protocol::table;
+use osc_protocol::wire::BaudRate;
+
+fn ids(args: &[String]) -> Result<Vec<Id>, Box<dyn std::error::Error>> {
+    let out: Result<Vec<u8>, _> = args.iter().map(|a| a.parse::<u8>()).collect();
+    Ok(out?.into_iter().map(Id::new).collect())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let (cmd, rest) = args.split_first().ok_or("usage: provision <cmd> [args]")?;
+    let mut c = Client::connect(NusbPipe::open()?)?;
+
+    match cmd.as_str() {
+        "factory" => {
+            for id in ids(rest)? {
+                c.factory(id)?;
+                println!("id {}: factory ack (wiped, rebooting)", id.as_byte());
+            }
+        }
+        "discover" => {
+            for uid in c.discover()? {
+                println!("uid {uid:?}");
+            }
+        }
+        "assign" => {
+            let base: u8 = rest.first().ok_or("assign <base_id>")?.parse()?;
+            let mut uids = c.discover()?;
+            uids.sort_by_key(|u| u.0);
+            println!("{} servos found", uids.len());
+            for (i, uid) in uids.iter().enumerate() {
+                let id = Id::new(base + i as u8);
+                c.assign(uid, id)?;
+                println!("uid {uid:?} -> id {}", id.as_byte());
+            }
+            for (i, _) in uids.iter().enumerate() {
+                let id = Id::new(base + i as u8);
+                match c.ping(id) {
+                    Ok(p) => println!("ping {}: model {:#06x} fw {}", id.as_byte(), p.model, p.fw),
+                    Err(Error::Timeout { .. }) => println!("ping {}: ABSENT", id.as_byte()),
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+        "ping" => {
+            for id in ids(rest)? {
+                match c.ping(id) {
+                    Ok(_) => println!("ping {}: ok", id.as_byte()),
+                    Err(Error::Timeout { .. }) => println!("ping {}: ABSENT", id.as_byte()),
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+        "status" => {
+            for id in ids(rest)? {
+                let cfg = c.read(id, table::CONFIG_COMMON_START, 0x14)?;
+                let tel = c.read(id, table::TELEMETRY_COMMON_START, 0x0C)?;
+                println!(
+                    "id {}: model {:#06x} fw {} hw {} cap {:#010x} | id {} baud_idx {} deadline {}us",
+                    id.as_byte(),
+                    u16::from_le_bytes([cfg[0], cfg[1]]),
+                    cfg[2],
+                    cfg[3],
+                    u32::from_le_bytes([cfg[4], cfg[5], cfg[6], cfg[7]]),
+                    cfg[0x10],
+                    cfg[0x11],
+                    u16::from_le_bytes([cfg[0x12], cfg[0x13]]),
+                );
+                println!(
+                    "      fault {:#04x} status {:#04x} (dirty {}) trim {} | crc_fail {} framing_drop {}",
+                    tel[0],
+                    tel[1],
+                    (tel[1] & table::STATUS_FLAG_CONFIG_DIRTY) != 0,
+                    tel[2] as i8,
+                    u32::from_le_bytes([tel[4], tel[5], tel[6], tel[7]]),
+                    u32::from_le_bytes([tel[8], tel[9], tel[10], tel[11]]),
+                );
+            }
+        }
+        "deadline" => {
+            let id = Id::new(rest.first().ok_or("deadline <id> <us>")?.parse()?);
+            let us: u16 = rest.get(1).ok_or("deadline <id> <us>")?.parse()?;
+            c.write(id, table::RESPONSE_DEADLINE_US, &us.to_le_bytes())?;
+            println!("id {}: response_deadline_us = {us}", id.as_byte());
+        }
+        "clear" => {
+            for id in ids(rest)? {
+                c.write(id, table::CRC_FAIL_COUNT, &0u32.to_le_bytes())?;
+                c.write(id, table::FRAMING_DROP_COUNT, &0u32.to_le_bytes())?;
+                println!("id {}: counters cleared", id.as_byte());
+            }
+        }
+        "save" => {
+            for id in ids(rest)? {
+                c.save(id)?;
+                println!("id {}: save ack", id.as_byte());
+            }
+        }
+        "reboot" => {
+            for id in ids(rest)? {
+                c.reboot(id)?;
+                println!("id {}: reboot ack", id.as_byte());
+            }
+        }
+        "migrate" => {
+            let idx: u8 = rest.first().ok_or("migrate <baud_idx> <id...>")?.parse()?;
+            let rate = BaudRate::from_idx(idx).ok_or("bad baud idx")?;
+            let targets = ids(&rest[1..])?;
+            // Servo-first (they ack at the old rate, apply deferred), then
+            // the host follows and the sweep proves the reunion.
+            for &id in &targets {
+                c.write(id, table::BAUD_RATE_IDX, &[idx])?;
+            }
+            c.host_baud(rate)?;
+            for &id in &targets {
+                match c.ping(id) {
+                    Ok(_) => println!("ping {} at {}: ok", id.as_byte(), rate.as_hz()),
+                    Err(Error::Timeout { .. }) => println!("ping {}: ABSENT", id.as_byte()),
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+        "chain" => {
+            let n: u32 = rest.first().ok_or("chain <count> <id...>")?.parse()?;
+            let targets = ids(&rest[1..])?;
+            let mut bad = 0u32;
+            for i in 0..n {
+                let chain = c.gread(&targets, 392, 4)?; // GOAL_VELOCITY, V006 map
+                let clean = chain.timeout_slot.is_none()
+                    && chain.statuses.len() == targets.len()
+                    && chain
+                        .statuses
+                        .iter()
+                        .all(|s| s.result == Some(osc_protocol::wire::ResultCode::Ok));
+                if !clean {
+                    bad += 1;
+                    println!(
+                        "chain {i}: {} statuses, timeout_slot {:?}",
+                        chain.statuses.len(),
+                        chain.timeout_slot
+                    );
+                }
+            }
+            println!("chains: {}/{n} clean", n - bad);
+        }
+        "cal" => {
+            let trains: u8 = rest
+                .first()
+                .ok_or("cal <trains> <gap_us> <gaps>")?
+                .parse()?;
+            let gap_us: u16 = rest.get(1).ok_or("cal <trains> <gap_us> <gaps>")?.parse()?;
+            let gaps: u8 = rest.get(2).ok_or("cal <trains> <gap_us> <gaps>")?.parse()?;
+            c.cal(trains, gap_us, gaps)?;
+            println!("cal: {trains} trains of {gaps} x {gap_us}us sent");
+        }
+        other => return Err(format!("unknown command {other}").into()),
+    }
+    Ok(())
+}

--- a/docs/osc-native-protocol.md
+++ b/docs/osc-native-protocol.md
@@ -470,6 +470,54 @@ code shares the byte (bits [6:2], 32 values). Errors split by layer:
    the alarm register is nonzero, prompting the host to read it. The same
    alert-bit semantics as DXL, because they're right.
 
+### 5.4 Common register block
+
+The table map is per-model ABI — a servo and a sensor node share the
+protocol, not the register map (the DXL shape, and the right one: the
+map is where models differ). What **is** protocol is a small register
+set every node carries at fixed addresses, so model-agnostic tooling —
+rescue and baud migration, CAL verification, health polls, discovery
+triage — works on any node without knowing its model. Two 32-byte
+blocks, one at each region front:
+
+**CONFIG-COMMON** `0x000..0x020` — SAVE-persisted (§9.4); identity RO,
+comms RW:
+
+| addr  | name                   | width | access | notes                                  |
+| ----- | ---------------------- | ----- | ------ | -------------------------------------- |
+| 0x000 | `model_number`         | u16   | RO     | keys the per-model map                 |
+| 0x002 | `firmware_version`     | u8    | RO     |                                        |
+| 0x003 | `hardware_revision`    | u8    | RO     |                                        |
+| 0x004 | `capability_flags`     | u32   | RO     | no bits defined yet                    |
+| 0x008 | —                      | 8 B   | rsvd   |                                        |
+| 0x010 | `id`                   | u8    | RW     | unicast address `0x01..=0xF9` (§3.1)   |
+| 0x011 | `baud_rate_idx`        | u8    | RW     | §2 rate index                          |
+| 0x012 | `response_deadline_us` | u16   | RW     | §7                                     |
+| 0x014 | —                      | 12 B  | rsvd   |                                        |
+
+**TELEMETRY-COMMON** `0x200..0x220` — volatile:
+
+| addr  | name                 | width | access | notes                                       |
+| ----- | -------------------- | ----- | ------ | ------------------------------------------- |
+| 0x200 | `fault_flags`        | u8    | RO     | the §5.3 alarm register — ALERT's read target |
+| 0x201 | `status_flags`       | u8    | RO     | bit 0 = config-dirty (§9.4); bits 1–7 reserved |
+| 0x202 | `trim_steps`         | i8    | RO     | applied clock-trim total (§9.3)             |
+| 0x203 | —                    | 1 B   | rsvd   |                                             |
+| 0x204 | `crc_fail_count`     | u32   | RW     | §5.3 frame-level counters; hosts write 0 to clear |
+| 0x208 | `framing_drop_count` | u32   | RW     |                                             |
+| 0x20C | —                    | 20 B  | rsvd   |                                             |
+
+- Reserved bytes read zero; writes touching them reject with `access`.
+  Extension fills reserved slots, announced by `capability_flags` bits —
+  a host that doesn't know a bit ignores the bytes it covers.
+- Everything else is model-specific space (`0x020..0x200`,
+  `0x220..0x280`), except the profile region's own pin at
+  `0x280..0x2C0` (§5.2).
+- Deliberately absent: a torque switch (SAVE self-gates via `access`,
+  §9.4, and sensor nodes have no torque), the UID (MGMT ENUM is its only
+  reader, §9.2), boot mode (MGMT REBOOT's payload owns it), and every
+  motor semantic.
+
 ## 6. Coordinated reads (status chains)
 
 GREAD replies arrive as a chain of ordinary status frames, one per listed
@@ -727,7 +775,8 @@ so that is what gets gated:
   rules still apply to every write; anything genuinely unsafe to change
   mid-motion is the control kernel's job to sequence, not the table's to
   forbid.
-- A config-dirty bit in telemetry reports modified-since-save.
+- A config-dirty bit in telemetry reports modified-since-save
+  (`status_flags` bit 0, §5.4).
 
 Side effects: flash wear drops from program-per-write to
 program-per-session, and the ~10 ms write stall stops ambushing hosts on

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -4,7 +4,8 @@
 
 # Workspace lock files (not committed for lib workspaces)
 lib/Cargo.lock
-ch32/Cargo.lock
+servo-ch32/Cargo.lock
+host-ch32/Cargo.lock
 
 # Rust-analyzer
 /rust-project.json

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -18,11 +18,11 @@ pub use kernel::{Kernel, KernelState};
 pub use persist::{ConfigStore, StoreError};
 pub use regions::config::{BaudRate, ConfigDefaults};
 pub use regions::{
-    BemfCalibBlock, BootMode, CalibRegs, ConfigCalibration, ConfigComms, ConfigControlPosition,
-    ConfigIdentity, ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal, ControlLifecycle,
-    ControlRegs, ControlStreaming, ControlSystem, ControlTable, ControlTableCell, Mode,
-    PotLutBlock, StallResponse, TelemetryBusLink, TelemetryConverted, TelemetryFault,
-    TelemetryIntermediaries, TelemetryRaw, TelemetryRegs,
+    BemfCalibBlock, BootMode, CalibRegs, ConfigCalibration, ConfigCommon, ConfigControlPosition,
+    ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal, ControlLifecycle, ControlRegs,
+    ControlStreaming, ControlSystem, ControlTable, ControlTableCell, Mode, PotLutBlock,
+    StallResponse, TelemetryCommon, TelemetryConverted, TelemetryIntermediaries, TelemetryMode,
+    TelemetryRaw, TelemetryRegs,
 };
 pub use sample::{ConversionVariables, RawSamples, Sample};
 pub use services::bus::{Dispatcher, Session};

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -168,11 +168,12 @@ impl ControlTableCell {
     /// Overlay a validated image onto the live table -- raw byte copy,
     /// deliberately bypassing ro masks and field rules (`Image::parse`
     /// already gated the UB-critical bytes; everything else was rule-valid
-    /// when saved). The identity block is skipped: model/fw must reflect the
+    /// when saved). The identity front (everything before `id`) is skipped:
+    /// model/fw must reflect the
     /// flashed firmware, never a stale saved image. Bringup-only, pre-IRQ;
     /// sole writer (the `seed_config_defaults` contract).
     pub fn overlay_persistent(&self, config: &[u8; CONFIG_LEN], profile: &[u8; PROFILE_LEN]) {
-        let skip = config::addr::comms::ID as usize;
+        let skip = config::addr::common::ID as usize;
         let base = RegisterMap::base(self);
         // SAFETY: base points at the flat map (RegisterMap contract), both
         // regions lie inside it, and the fn doc pins the sole-writer window.
@@ -235,9 +236,9 @@ mod tests {
     /// (zero) bytes in every enum/bool field.
     fn body() -> ([u8; CONFIG_LEN], [u8; PROFILE_LEN]) {
         let mut config = [0u8; CONFIG_LEN];
-        config[addr::comms::ID as usize] = 7;
-        config[addr::comms::RESPONSE_DEADLINE_US as usize] = 99;
-        config[addr::identity::MODEL_NUMBER as usize] = 0xEE;
+        config[addr::common::ID as usize] = 7;
+        config[addr::common::RESPONSE_DEADLINE_US as usize] = 99;
+        config[addr::common::MODEL_NUMBER as usize] = 0xEE;
         let mut profile = [0u8; PROFILE_LEN];
         profile[0] = 0xAA;
         profile[PROFILE_LEN - 1] = 0x55;
@@ -303,7 +304,7 @@ mod tests {
         let table = seeded_table();
         let newer = {
             let (mut config, profile) = body();
-            config[addr::comms::ID as usize] = 8;
+            config[addr::common::ID as usize] = 8;
             let mut img = [0u8; IMAGE_LEN];
             assemble(&mut img, 6, &config, &profile);
             img
@@ -317,7 +318,7 @@ mod tests {
                 loaded: true
             }
         );
-        assert_eq!(table.with(|t| t.config.comms.id), 8);
+        assert_eq!(table.with(|t| t.config.common.id), 8);
         assert_eq!(table.with(|t| t.profile.slots.words[0]), 0x00AA);
     }
 
@@ -342,7 +343,7 @@ mod tests {
                 (pick.next_slot, pick.next_seq, pick.loaded),
                 (next, 4, true)
             );
-            assert_eq!(table.with(|t| t.config.comms.id), 7);
+            assert_eq!(table.with(|t| t.config.common.id), 7);
         }
     }
 
@@ -358,17 +359,17 @@ mod tests {
                 loaded: false
             }
         );
-        assert_eq!(table.with(|t| t.config.comms.id), 1);
+        assert_eq!(table.with(|t| t.config.common.id), 1);
     }
 
     #[test]
-    fn overlay_skips_the_identity_block() {
+    fn overlay_skips_the_identity_front() {
         let table = seeded_table();
-        table.with_mut(|t| t.config.identity.model_number = 0x1234);
+        table.with_mut(|t| t.config.common.model_number = 0x1234);
         boot_overlay(&table, &image_of(1), &[0xFF; IMAGE_LEN]);
         // The image carried 0x00EE at MODEL_NUMBER; the flashed firmware's
         // identity stands.
-        assert_eq!(table.with(|t| t.config.identity.model_number), 0x1234);
-        assert_eq!(table.with(|t| t.config.comms.id), 7, "comms overlaid");
+        assert_eq!(table.with(|t| t.config.common.model_number), 0x1234);
+        assert_eq!(table.with(|t| t.config.common.id), 7, "comms overlaid");
     }
 }

--- a/firmware/lib/core/src/regions/config.rs
+++ b/firmware/lib/core/src/regions/config.rs
@@ -16,25 +16,23 @@ pub enum StallResponse {
     Comply = 1,
 }
 
+/// protocol sec 5.4 CONFIG-COMMON block: identity RO at the region front,
+/// comms RW at 0x010, reserved bytes between and behind. Model-specific
+/// config starts at 0x020.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
-pub struct ConfigIdentity {
+#[ct_block(hooks = crate::regions::hooks::ControlTableHookEvents)]
+pub struct ConfigCommon {
     #[ct_field(access = ro)]
     pub model_number: u16,
     #[ct_field(access = ro)]
     pub firmware_version: u8,
-    #[ct_field(skip)]
-    pub _rsvd_align: u8,
     #[ct_field(access = ro)]
-    pub hardware_revision: u32,
+    pub hardware_revision: u8,
     #[ct_field(access = ro)]
     pub capability_flags: u32,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone, Block)]
-#[ct_block(hooks = crate::regions::hooks::ControlTableHookEvents)]
-pub struct ConfigComms {
+    #[ct_field(skip)]
+    pub _rsvd_identity: [u8; 8],
     #[ct_field(ge = 1u8, le = 249u8, hook = on_id_write)]
     pub id: u8,
     // `BaudRate` index; le gate = the enum ceiling. Zero (0.5M, the rescue
@@ -44,6 +42,8 @@ pub struct ConfigComms {
     pub baud_rate_idx: u8,
     #[ct_field(hook = on_response_deadline_us_write)]
     pub response_deadline_us: u16,
+    #[ct_field(skip)]
+    pub _rsvd_tail: [u8; 12],
 }
 
 #[repr(C)]
@@ -132,15 +132,14 @@ pub struct ConfigControlPosition {
     hooks = crate::regions::hooks::ControlTableHookEvents,
 )]
 pub struct ConfigRegs {
-    pub identity: ConfigIdentity,
-    pub comms: ConfigComms,
+    pub common: ConfigCommon,
     pub pos_limits: ConfigPosLimits,
     pub stall: ConfigStall,
     pub thermal: ConfigThermal,
     pub ctrl_pos: ConfigControlPosition,
     pub calibration: ConfigCalibration,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 44],
+    pub _rsvd_tail: [u8; 28],
 }
 
 /// Boot-time seed for `ControlTable.config`; stamped pre-IRQ, then host-owned.

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -23,13 +23,13 @@ pub mod telemetry;
 
 pub use calib::{BemfCalibBlock, CalibRegs, PotLutBlock};
 pub use config::{
-    BaudRate, ConfigCalibration, ConfigComms, ConfigControlPosition, ConfigIdentity,
-    ConfigPosLimits, ConfigRegs, ConfigStall, ConfigThermal, StallResponse,
+    BaudRate, ConfigCalibration, ConfigCommon, ConfigControlPosition, ConfigPosLimits, ConfigRegs,
+    ConfigStall, ConfigThermal, StallResponse,
 };
 pub use control::{BootMode, ControlLifecycle, ControlRegs, ControlStreaming, ControlSystem, Mode};
 pub use profile::{PROFILE_SLOTS, ProfileRegs, ProfileSlots, SPANS_PER_SLOT};
 pub use telemetry::{
-    TelemetryBusLink, TelemetryConverted, TelemetryFault, TelemetryIntermediaries, TelemetryRaw,
+    TelemetryCommon, TelemetryConverted, TelemetryIntermediaries, TelemetryMode, TelemetryRaw,
     TelemetryRegs,
 };
 
@@ -81,9 +81,63 @@ impl ControlTableCell {
             cfg.pos_limits.pos_min_soft_urad = defaults.pos_min_phys_urad;
             cfg.pos_limits.pos_max_soft_urad = defaults.pos_max_phys_urad;
             cfg.calibration.vdd_mv = defaults.vdd_mv;
-            cfg.comms.id = defaults.id;
-            cfg.comms.baud_rate_idx = defaults.baud.as_idx();
-            cfg.comms.response_deadline_us = defaults.response_deadline_us;
+            cfg.common.id = defaults.id;
+            cfg.common.baud_rate_idx = defaults.baud.as_idx();
+            cfg.common.response_deadline_us = defaults.response_deadline_us;
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use osc_protocol::table;
+
+    use super::config::addr as config_addr;
+    use super::telemetry::addr as telemetry_addr;
+
+    /// Pins the struct layout to the protocol sec 5.4 common register block:
+    /// every generated field address equals its protocol const, and the
+    /// model-specific space begins exactly at each block's end.
+    #[test]
+    fn common_register_block_offsets_match_the_protocol() {
+        assert_eq!(config_addr::common::MODEL_NUMBER, table::MODEL_NUMBER);
+        assert_eq!(
+            config_addr::common::FIRMWARE_VERSION,
+            table::FIRMWARE_VERSION
+        );
+        assert_eq!(
+            config_addr::common::HARDWARE_REVISION,
+            table::HARDWARE_REVISION
+        );
+        assert_eq!(
+            config_addr::common::CAPABILITY_FLAGS,
+            table::CAPABILITY_FLAGS
+        );
+        assert_eq!(config_addr::common::ID, table::ID);
+        assert_eq!(config_addr::common::BAUD_RATE_IDX, table::BAUD_RATE_IDX);
+        assert_eq!(
+            config_addr::common::RESPONSE_DEADLINE_US,
+            table::RESPONSE_DEADLINE_US
+        );
+        assert_eq!(
+            config_addr::pos_limits::POS_MIN_PHYS_URAD,
+            table::CONFIG_COMMON_END
+        );
+
+        assert_eq!(telemetry_addr::common::FAULT_FLAGS, table::FAULT_FLAGS);
+        assert_eq!(telemetry_addr::common::STATUS_FLAGS, table::STATUS_FLAGS);
+        assert_eq!(telemetry_addr::common::TRIM_STEPS, table::TRIM_STEPS);
+        assert_eq!(
+            telemetry_addr::common::CRC_FAIL_COUNT,
+            table::CRC_FAIL_COUNT
+        );
+        assert_eq!(
+            telemetry_addr::common::FRAMING_DROP_COUNT,
+            table::FRAMING_DROP_COUNT
+        );
+        assert_eq!(
+            telemetry_addr::mode::MODE_ACTIVE,
+            table::TELEMETRY_COMMON_END
+        );
     }
 }

--- a/firmware/lib/core/src/regions/telemetry.rs
+++ b/firmware/lib/core/src/regions/telemetry.rs
@@ -38,20 +38,47 @@ pub struct TelemetryIntermediaries {
     pub sample_tick: u32,
 }
 
-/// `fault_flags` writable-RO carve-out: host writing 0x00 clears non-latched bits.
+/// protocol sec 5.4 TELEMETRY-COMMON block, at the region front. Counters:
+/// host can Write zero to clear (bench instrumentation); the chip publishes
+/// deltas via raw pointer, bypassing the regmap, so a concurrent host clear +
+/// publish may drop one update -- acceptable for bench. `trim_steps`
+/// (sec 9.3) is the trim loop's applied total in signed chip trim steps from
+/// the factory default (positive = slowed), volatile by design -- every boot
+/// re-converges from live traffic.
 #[repr(C)]
 #[derive(Copy, Clone, Block)]
-pub struct TelemetryFault {
+pub struct TelemetryCommon {
+    /// The sec 5.3 alarm register -- ALERT's read target.
+    #[ct_field(access = ro)]
+    pub fault_flags: u8,
+    /// Bit 0 = config-dirty, modified-since-save (sec 9.4): set when a
+    /// committed write lands in CONFIG or PROFILE, cleared by a successful
+    /// SAVE; boot state is clean. Bits 1-7 reserved.
+    #[ct_field(access = ro)]
+    pub status_flags: u8,
+    #[ct_field(access = ro)]
+    pub trim_steps: i8,
+    #[ct_field(skip)]
+    pub _rsvd_align: u8,
+    #[ct_field(access = rw)]
+    pub crc_fail_count: u32,
+    #[ct_field(access = rw)]
+    pub framing_drop_count: u32,
+    #[ct_field(skip)]
+    pub _rsvd_tail: [u8; 20],
+}
+
+/// Model-specific mode + fault detail: sec 5.4 keeps only the alarm byte
+/// common; which faults exist and what the codes mean vary by node.
+#[repr(C)]
+#[derive(Copy, Clone, Block)]
+pub struct TelemetryMode {
     #[ct_field(access = ro)]
     pub mode_active: u8,
     #[ct_field(access = ro)]
-    pub fault_flags: u8,
-    #[ct_field(access = ro)]
     pub fault_code: u8,
-    /// Modified-since-save (sec 9.4): set when a committed write lands in
-    /// CONFIG or PROFILE, cleared by a successful SAVE; boot state is clean.
-    #[ct_field(access = ro)]
-    pub config_dirty: u8,
+    #[ct_field(skip)]
+    pub _rsvd_align: u16,
 }
 
 #[repr(C)]
@@ -75,40 +102,15 @@ pub struct TelemetryRaw {
     pub raw_enc_b: u16,
 }
 
-/// Host can Write zero to any field to clear it (bench instrumentation).
-/// Chip-side `report_fault` increments via raw pointer, bypassing the regmap.
-/// Concurrent host clear + ISR increment may drop one update -- acceptable for bench.
-#[repr(C)]
-#[derive(Copy, Clone, Block)]
-pub struct TelemetryBusLink {
-    #[ct_field(access = rw)]
-    pub crc_fail_count: u32,
-    #[ct_field(access = rw)]
-    pub framing_drop_count: u32,
-}
-
-/// Clock discipline (sec 9.3), read-only: the trim loop's applied total, in
-/// signed chip trim steps from the factory default (positive = slowed).
-/// Volatile by design -- every boot re-converges from live traffic.
-#[repr(C)]
-#[derive(Copy, Clone, Block)]
-pub struct TelemetryClock {
-    #[ct_field(access = ro)]
-    pub trim_steps: i8,
-    #[ct_field(skip)]
-    pub _rsvd_align: [u8; 3],
-}
-
 #[repr(C)]
 #[derive(Section)]
 #[ct_section(base = crate::regions::TELEMETRY_BASE_ADDR, size = crate::regions::TELEMETRY_REGION_SIZE)]
 pub struct TelemetryRegs {
+    pub common: TelemetryCommon,
+    pub mode: TelemetryMode,
     pub converted: TelemetryConverted,
     pub intermediaries: TelemetryIntermediaries,
-    pub fault: TelemetryFault,
     pub raw: TelemetryRaw,
-    pub link: TelemetryBusLink,
-    pub clock: TelemetryClock,
     #[ct_section(skip)]
-    pub _rsvd_tail: [u8; 56],
+    pub _rsvd_tail: [u8; 36],
 }

--- a/firmware/lib/core/src/services/bus/dispatch.rs
+++ b/firmware/lib/core/src/services/bus/dispatch.rs
@@ -2,6 +2,7 @@ use control_table::{RegisterFile, Snapshot};
 use heapless::Vec;
 use osc_protocol::FrameBytes;
 use osc_protocol::frame::uid_prefix_matches;
+use osc_protocol::table::STATUS_FLAG_CONFIG_DIRTY;
 use osc_protocol::wire::{Id, MAX_PAYLOAD, MgmtOp, ResultCode, UID_LEN};
 
 use crate::persist::{CONFIG_LEN, PROFILE_LEN, StoreError};
@@ -77,7 +78,7 @@ impl<'a> Dispatcher<'a> {
     fn alert(&self) -> bool {
         self.shared
             .table
-            .with(|t| t.telemetry.fault.fault_flags != 0)
+            .with(|t| t.telemetry.common.fault_flags != 0)
     }
 }
 
@@ -203,7 +204,7 @@ impl Dispatcher<'_> {
         if hits {
             self.shared
                 .table
-                .with_mut(|t| t.telemetry.fault.config_dirty = 1);
+                .with_mut(|t| t.telemetry.common.status_flags |= STATUS_FLAG_CONFIG_DIRTY);
         }
     }
 
@@ -225,12 +226,12 @@ impl Dispatcher<'_> {
         if !ctx.may_reply {
             return;
         }
-        // model_number + firmware_version are contiguous at the identity base:
+        // model_number + firmware_version are contiguous at the common-block front:
         // reply straight from the table so the TX engine streams in place (a
         // stack copy would force the slow copy-stage path).
         let data = RegisterFile::read(
             &self.shared.table,
-            crate::regions::config::addr::identity::MODEL_NUMBER,
+            crate::regions::config::addr::common::MODEL_NUMBER,
             3,
         )
         .unwrap_or(&[]);
@@ -460,8 +461,8 @@ impl Dispatcher<'_> {
             return Self::ack(alert, ctx, Err(e), reply);
         }
         self.shared.table.with_mut(|t| {
-            t.config.comms.id = new_id;
-            t.telemetry.fault.config_dirty = 1;
+            t.config.common.id = new_id;
+            t.telemetry.common.status_flags |= STATUS_FLAG_CONFIG_DIRTY;
         });
         reply.set_id(new_id);
         Self::ack(alert, ctx, Ok(()), reply);
@@ -501,7 +502,7 @@ impl Dispatcher<'_> {
             Ok(()) => {
                 self.shared
                     .table
-                    .with_mut(|t| t.telemetry.fault.config_dirty = 0);
+                    .with_mut(|t| t.telemetry.common.status_flags &= !STATUS_FLAG_CONFIG_DIRTY);
                 ResultCode::Ok
             }
             Err(StoreError) => ResultCode::Hardware,

--- a/firmware/lib/core/src/services/bus/tests/mod.rs
+++ b/firmware/lib/core/src/services/bus/tests/mod.rs
@@ -5,6 +5,7 @@
 use heapless::Vec;
 
 use osc_protocol::FrameBytes;
+use osc_protocol::table::STATUS_FLAG_CONFIG_DIRTY;
 use osc_protocol::wire::{MgmtOp, ResultCode};
 
 use crate::regions::CONTROL_BASE_ADDR;
@@ -146,8 +147,8 @@ fn enable_torque(shared: &Shared) {
 fn ping_replies_model_and_firmware() {
     let shared = Shared::new();
     shared.table.with_mut(|t| {
-        t.config.identity.model_number = 0x1234;
-        t.config.identity.firmware_version = 0x56;
+        t.config.common.model_number = 0x1234;
+        t.config.common.firmware_version = 0x56;
     });
     let mut staged = StagedWrites::new();
     let reply = go(&shared, &mut staged, Request::Ping, true);
@@ -171,7 +172,7 @@ fn read_returns_table_slice() {
     let shared = Shared::new();
     shared
         .table
-        .with_mut(|t| t.config.identity.model_number = 0xABCD);
+        .with_mut(|t| t.config.common.model_number = 0xABCD);
     let mut staged = StagedWrites::new();
     let reply = go(
         &shared,
@@ -264,10 +265,10 @@ use crate::regions::profile::span_word;
 
 /// Slot 0 -> two spans: model_number (2 B at 0x000) and comms id (1 B).
 fn seed_profile_slot0(shared: &Shared) {
-    use crate::regions::config::addr::comms::ID;
+    use crate::regions::config::addr::common::ID;
     shared.table.with_mut(|t| {
-        t.config.identity.model_number = 0xABCD;
-        t.config.comms.id = 7;
+        t.config.common.model_number = 0xABCD;
+        t.config.common.id = 7;
         t.profile.slots.words[0] = span_word(0, 2);
         t.profile.slots.words[1] = span_word(ID, 1);
     });
@@ -288,7 +289,7 @@ fn profile_read_gathers_spans_in_order() {
 fn profile_read_skips_disabled_words() {
     let shared = Shared::new();
     shared.table.with_mut(|t| {
-        t.config.identity.model_number = 0xABCD;
+        t.config.common.model_number = 0xABCD;
         // Hole at word 0 and word 2: disabled words are skipped, not
         // terminators (sec 5.2).
         t.profile.slots.words[1] = span_word(0, 1);
@@ -401,7 +402,7 @@ fn write_validation_reject_maps_to_validation() {
 /// torque-gated -- only MGMT SAVE is.
 #[test]
 fn write_config_allowed_with_torque_on() {
-    use crate::regions::config::addr::comms::ID;
+    use crate::regions::config::addr::common::ID;
     let shared = Shared::new();
     enable_torque(&shared);
     let mut staged = StagedWrites::new();
@@ -416,7 +417,7 @@ fn write_config_allowed_with_torque_on() {
         true,
     );
     assert_eq!(reply.last().result, ResultCode::Ok);
-    assert_eq!(shared.table.with(|t| t.config.comms.id), 5);
+    assert_eq!(shared.table.with(|t| t.config.common.id), 5);
     assert_eq!(reply.staged_id, Some(5));
 }
 
@@ -440,7 +441,7 @@ fn write_applies_even_when_may_reply_false() {
 
 #[test]
 fn write_id_stages_via_reply() {
-    use crate::regions::config::addr::comms::ID;
+    use crate::regions::config::addr::common::ID;
     let shared = Shared::new();
     let mut staged = StagedWrites::new();
     let reply = go(
@@ -459,7 +460,7 @@ fn write_id_stages_via_reply() {
 
 #[test]
 fn write_baud_stages_via_reply() {
-    use crate::regions::config::addr::comms::BAUD_RATE_IDX;
+    use crate::regions::config::addr::common::BAUD_RATE_IDX;
     let shared = Shared::new();
     let mut staged = StagedWrites::new();
     let reply = go(
@@ -478,7 +479,7 @@ fn write_baud_stages_via_reply() {
 
 #[test]
 fn write_response_deadline_sets_via_reply() {
-    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    use crate::regions::config::addr::common::RESPONSE_DEADLINE_US;
     let shared = Shared::new();
     let mut staged = StagedWrites::new();
     let reply = go(
@@ -653,7 +654,9 @@ fn mgmt_req(op: MgmtOp) -> Request<'static> {
 }
 
 fn dirty(shared: &Shared) -> u8 {
-    shared.table.with(|t| t.telemetry.fault.config_dirty)
+    shared
+        .table
+        .with(|t| t.telemetry.common.status_flags & STATUS_FLAG_CONFIG_DIRTY)
 }
 
 /// CRC fingerprint of the live persisted regions, mirroring FakeStore::save.
@@ -684,7 +687,7 @@ fn write_at(shared: &Shared, staged: &mut StagedWrites, addr: u16, data: &[u8]) 
 
 #[test]
 fn save_streams_the_table_and_acks_after() {
-    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    use crate::regions::config::addr::common::RESPONSE_DEADLINE_US;
     static STORE: FakeStore = FakeStore::new();
     let shared = Shared::new();
     shared.seed_store(&STORE);
@@ -723,7 +726,7 @@ fn save_with_torque_on_nacks_access() {
 
 #[test]
 fn save_store_failure_nacks_hardware_and_stays_dirty() {
-    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    use crate::regions::config::addr::common::RESPONSE_DEADLINE_US;
     static STORE: FakeStore = FakeStore::new();
     STORE.fail.store(true, Ordering::Relaxed);
     let shared = Shared::new();
@@ -799,7 +802,7 @@ fn factory_wipe_failure_nacks_hardware_without_reboot() {
 #[test]
 fn dirty_bit_tracks_persistent_regions_only() {
     use crate::regions::PROFILE_BASE_ADDR;
-    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    use crate::regions::config::addr::common::RESPONSE_DEADLINE_US;
     static STORE: FakeStore = FakeStore::new();
     let shared = Shared::new();
     shared.seed_store(&STORE);
@@ -828,7 +831,7 @@ fn dirty_bit_tracks_persistent_regions_only() {
 
 #[test]
 fn held_write_marks_dirty_at_commit_not_before() {
-    use crate::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+    use crate::regions::config::addr::common::RESPONSE_DEADLINE_US;
     let shared = Shared::new();
     let mut staged = StagedWrites::new();
     let reply = go(
@@ -928,7 +931,7 @@ fn assign_matching_uid_sets_id_before_ack() {
     assert_eq!(reply.staged_id, None, "immediate, not deferred");
     // Mirrored into the config table so a later SAVE persists it -- which
     // also marks modified-since-save (sec 9.4).
-    assert_eq!(shared.table.with(|t| t.config.comms.id), 42);
+    assert_eq!(shared.table.with(|t| t.config.common.id), 42);
     assert_eq!(dirty(&shared), 1);
 }
 
@@ -936,7 +939,7 @@ fn assign_matching_uid_sets_id_before_ack() {
 fn assign_foreign_uid_is_silent_and_inert() {
     let shared = shared_with_uid();
     let mut staged = StagedWrites::new();
-    let before = shared.table.with(|t| t.config.comms.id);
+    let before = shared.table.with(|t| t.config.common.id);
     let mut uid = UID;
     uid[15] ^= 0x80;
     let reply = go(
@@ -947,7 +950,7 @@ fn assign_foreign_uid_is_silent_and_inert() {
     );
     assert_eq!(reply.count(), 0);
     assert_eq!(reply.set_id, None);
-    assert_eq!(shared.table.with(|t| t.config.comms.id), before);
+    assert_eq!(shared.table.with(|t| t.config.common.id), before);
 }
 
 #[test]
@@ -984,7 +987,7 @@ fn assign_noreply_still_applies() {
     );
     assert_eq!(reply.count(), 0);
     assert_eq!(reply.set_id, Some((9, 0)));
-    assert_eq!(shared.table.with(|t| t.config.comms.id), 9);
+    assert_eq!(shared.table.with(|t| t.config.common.id), 9);
 }
 
 // --- Unsupported ----------------------------------------------------------
@@ -1012,7 +1015,7 @@ fn alert_bit_set_when_fault_flags_nonzero() {
     let shared = Shared::new();
     shared
         .table
-        .with_mut(|t| t.telemetry.fault.fault_flags = 0x04);
+        .with_mut(|t| t.telemetry.common.fault_flags = 0x04);
     let mut staged = StagedWrites::new();
     let reply = go(&shared, &mut staged, Request::Ping, true);
     assert!(reply.last().alert);
@@ -1237,7 +1240,7 @@ fn held_write_keeps_entries_through_its_verdict() {
 
 #[test]
 fn hooks_fire_on_write_commit() {
-    use crate::regions::config::addr::comms::ID;
+    use crate::regions::config::addr::common::ID;
     let shared = Shared::new();
     let mut staged = StagedWrites::new();
     let mut pending = None;
@@ -1258,7 +1261,7 @@ fn hooks_fire_on_write_commit() {
 #[test]
 fn hooks_fire_on_real_commit() {
     // A real COMMIT of a held hooked field fires its hook.
-    use crate::regions::config::addr::comms::ID;
+    use crate::regions::config::addr::common::ID;
     let shared = Shared::new();
     let mut staged = StagedWrites::new();
     let mut pending = None;

--- a/firmware/lib/core/src/traits/control.rs
+++ b/firmware/lib/core/src/traits/control.rs
@@ -47,7 +47,7 @@ pub enum DecayMode {
 }
 
 bitflags::bitflags! {
-    /// Mirrors `capability_flags` in `ConfigIdentity`. Protocol-relevant only.
+    /// Mirrors `capability_flags` in `ConfigCommon`. Protocol-relevant only.
     #[derive(Copy, Clone, Debug, Default)]
     pub struct Capabilities: u32 {
         const HAS_MOTOR_ENCODER = 1 << 0;

--- a/firmware/lib/drivers/src/bus/servo_bus/tests.rs
+++ b/firmware/lib/drivers/src/bus/servo_bus/tests.rs
@@ -6,7 +6,7 @@
 use osc_protocol::reply::FrameBuf;
 use osc_protocol::wire::{self, Id, Inst, MgmtOp, Opcode, ResultCode};
 use osc_servo_core::regions::CONTROL_BASE_ADDR;
-use osc_servo_core::regions::config::addr::comms::ID as ID_ADDR;
+use osc_servo_core::regions::config::addr::common::ID as ID_ADDR;
 use osc_servo_core::{BaudRate, Dispatch, RegionStorage, Session, Shared};
 
 use crate::mocks::bus::{FakeWire, Harness, RING_LEN, WireEvent};
@@ -20,8 +20,8 @@ const REPLY_GAP: u32 = 12;
 fn shared_seeded() -> Shared {
     let shared = Shared::new();
     shared.table.with_mut(|t| {
-        t.config.identity.model_number = 0x1234;
-        t.config.identity.firmware_version = 0x56;
+        t.config.common.model_number = 0x1234;
+        t.config.common.firmware_version = 0x56;
     });
     shared
 }

--- a/firmware/lib/integration/src/sim/servo.rs
+++ b/firmware/lib/integration/src/sim/servo.rs
@@ -61,17 +61,17 @@ impl SimServo {
         // model/fw are read-only identity fields, seeded directly (not part of
         // ConfigDefaults) so PING has something to answer with.
         shared.table.with_mut(|t| {
-            t.config.identity.model_number = DEFAULT_MODEL;
-            t.config.identity.firmware_version = DEFAULT_FIRMWARE;
+            t.config.common.model_number = DEFAULT_MODEL;
+            t.config.common.firmware_version = DEFAULT_FIRMWARE;
         });
 
         // The table is the comms authority (registry `Drivers::install` does
         // the same read on the chip).
         let (id, rate_idx, response_deadline_us) = shared.table.with(|t| {
             (
-                t.config.comms.id,
-                t.config.comms.baud_rate_idx,
-                t.config.comms.response_deadline_us,
+                t.config.common.id,
+                t.config.common.baud_rate_idx,
+                t.config.common.response_deadline_us,
             )
         });
         let rate = BaudRate::from_idx(rate_idx).expect("seeded baud idx");

--- a/firmware/lib/integration/tests/chains.rs
+++ b/firmware/lib/integration/tests/chains.rs
@@ -6,7 +6,7 @@
 
 use osc_integration::sim::{Source, WireFrame, assert_valid, instruction, status};
 use osc_protocol::wire::{Inst, Opcode, ResultCode};
-use osc_servo_core::regions::config::addr::identity::{FIRMWARE_VERSION, MODEL_NUMBER};
+use osc_servo_core::regions::config::addr::common::{FIRMWARE_VERSION, MODEL_NUMBER};
 use osc_servo_core::regions::control::addr::lifecycle::GOAL_VELOCITY;
 use osc_servo_core::regions::control::addr::streaming::{STREAM_DECIMATION, STREAM_FIELD_MASK};
 use osc_servo_core::regions::profile::span_word;
@@ -103,7 +103,7 @@ fn gread_uniform_chains_in_list_order(baud_idx: u8) {
     // Distinct model per servo so each reply's data is traceable to its owner.
     let models = [0xAA01u16, 0xBB02, 0xCC03];
     for (i, m) in models.iter().enumerate() {
-        sim.servo_table_mut(i, |t| t.config.identity.model_number = *m);
+        sim.servo_table_mut(i, |t| t.config.common.model_number = *m);
     }
 
     sim.host_send(&instruction(
@@ -165,8 +165,8 @@ fn gread_profile_uniform_chains_gathered_replies(baud_idx: u8) {
     let models = [0x1122u16, 0x3344];
     for (i, m) in models.iter().enumerate() {
         sim.servo_table_mut(i, |t| {
-            t.config.identity.model_number = *m;
-            t.config.identity.firmware_version = 0x50 + i as u8;
+            t.config.common.model_number = *m;
+            t.config.common.firmware_version = 0x50 + i as u8;
             t.profile.slots.words[0] = span_word(MODEL_NUMBER, 2);
             t.profile.slots.words[1] = span_word(FIRMWARE_VERSION, 1);
         });
@@ -202,11 +202,11 @@ fn gread_profile_per_target_selects_distinct_slots(baud_idx: u8) {
         sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
     }
     sim.servo_table_mut(0, |t| {
-        t.config.identity.model_number = 0x1122;
+        t.config.common.model_number = 0x1122;
         t.profile.slots.words[0] = span_word(MODEL_NUMBER, 2);
     });
     sim.servo_table_mut(1, |t| {
-        t.config.identity.firmware_version = 0x77;
+        t.config.common.firmware_version = 0x77;
         // Servo 2 answers from slot 3 -- per-target slot selection.
         t.profile.slots.words[3 * 8] = span_word(FIRMWARE_VERSION, 1);
     });
@@ -234,9 +234,9 @@ fn gread_per_target_reads_distinct_spans(baud_idx: u8) {
     for id in [1u8, 2, 3] {
         sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
     }
-    sim.servo_table_mut(0, |t| t.config.identity.model_number = 0x1122);
-    sim.servo_table_mut(1, |t| t.config.identity.firmware_version = 0x5A);
-    sim.servo_table_mut(2, |t| t.config.identity.model_number = 0x3344);
+    sim.servo_table_mut(0, |t| t.config.common.model_number = 0x1122);
+    sim.servo_table_mut(1, |t| t.config.common.firmware_version = 0x5A);
+    sim.servo_table_mut(2, |t| t.config.common.model_number = 0x3344);
 
     // Each servo reads its own addr/count.
     let payload = gread_per_target(&[
@@ -269,8 +269,8 @@ fn missing_servo_reclaims_with_flag(baud_idx: u8) {
     // Only 1 and 3 present; 2 is absent from the bus.
     let s1 = sim.add_servo_with(1, 0, CHAIN_DEADLINE_US);
     let s3 = sim.add_servo_with(3, 0, CHAIN_DEADLINE_US);
-    sim.servo_table_mut(s1, |t| t.config.identity.model_number = 0x0101);
-    sim.servo_table_mut(s3, |t| t.config.identity.model_number = 0x0303);
+    sim.servo_table_mut(s1, |t| t.config.common.model_number = 0x0101);
+    sim.servo_table_mut(s3, |t| t.config.common.model_number = 0x0303);
 
     sim.host_send(&instruction(
         BCAST,
@@ -321,7 +321,7 @@ fn error_status_keeps_chain_alive(baud_idx: u8) {
     for id in [1u8, 2, 3] {
         sim.add_servo_with(id, 0, CHAIN_DEADLINE_US);
     }
-    sim.servo_table_mut(2, |t| t.config.identity.model_number = 0x9999);
+    sim.servo_table_mut(2, |t| t.config.common.model_number = 0x9999);
 
     // Per-target: servo 2's span is out of bounds -> Range error, empty payload.
     let payload = gread_per_target(&[(1, MODEL_NUMBER, 2), (2, 0xFFFE, 4), (3, MODEL_NUMBER, 2)]);

--- a/firmware/lib/integration/tests/persistence.rs
+++ b/firmware/lib/integration/tests/persistence.rs
@@ -4,11 +4,12 @@
 //! store across two `Sim`s models a reboot with flash intact.
 
 use osc_integration::sim::{RamStore, Sim, Source, WireFrame, assert_valid, instruction, status};
+use osc_protocol::table::STATUS_FLAG_CONFIG_DIRTY;
 use osc_protocol::wire::{Id, MgmtOp, Opcode, ResultCode};
 use osc_servo_core::persist::{Image, Slot};
-use osc_servo_core::regions::config::addr::comms::RESPONSE_DEADLINE_US;
+use osc_servo_core::regions::config::addr::common::RESPONSE_DEADLINE_US;
 use osc_servo_core::regions::control::addr::lifecycle::TORQUE_ENABLE;
-use osc_servo_core::regions::telemetry::addr::fault::CONFIG_DIRTY;
+use osc_servo_core::regions::telemetry::addr::common::STATUS_FLAGS;
 use rstest::rstest;
 use rstest_reuse::apply;
 
@@ -67,14 +68,20 @@ fn save_persists_the_live_regions_and_clears_dirty(baud_idx: u8) {
     sim.add_servo_with_store(ID5, store);
 
     write_ok(&mut sim, ID5, RESPONSE_DEADLINE_US, &200u16.to_le_bytes());
-    assert_eq!(read_byte(&mut sim, ID5, CONFIG_DIRTY), 1);
+    assert_eq!(
+        read_byte(&mut sim, ID5, STATUS_FLAGS) & STATUS_FLAG_CONFIG_DIRTY,
+        1
+    );
 
     let frames = mgmt(&mut sim, ID5, MgmtOp::Save);
     let (inst, payload) = status(sole_reply(&frames));
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     assert!(payload.is_empty());
     assert_eq!(store.saves(), 1);
-    assert_eq!(read_byte(&mut sim, ID5, CONFIG_DIRTY), 0);
+    assert_eq!(
+        read_byte(&mut sim, ID5, STATUS_FLAGS) & STATUS_FLAG_CONFIG_DIRTY,
+        0
+    );
 
     // The stored image is codec-valid and carries the written value.
     let img = store.slot(Slot::A).expect("first save lands in slot A");
@@ -107,7 +114,10 @@ fn save_failure_nacks_hardware_and_stays_dirty(baud_idx: u8) {
     let frames = mgmt(&mut sim, ID5, MgmtOp::Save);
     let (inst, _) = status(sole_reply(&frames));
     assert_eq!(inst.result(), Some(ResultCode::Hardware));
-    assert_eq!(read_byte(&mut sim, ID5, CONFIG_DIRTY), 1);
+    assert_eq!(
+        read_byte(&mut sim, ID5, STATUS_FLAGS) & STATUS_FLAG_CONFIG_DIRTY,
+        1
+    );
 }
 
 #[apply(matrix)]

--- a/firmware/lib/integration/tests/protocol.rs
+++ b/firmware/lib/integration/tests/protocol.rs
@@ -8,7 +8,7 @@ use osc_integration::sim::{
 };
 use osc_protocol::wire::{Id, Inst, MgmtOp, Opcode, ResultCode};
 use osc_servo_core::BaudRate;
-use osc_servo_core::regions::config::addr::comms::{BAUD_RATE_IDX, ID};
+use osc_servo_core::regions::config::addr::common::{BAUD_RATE_IDX, ID};
 use osc_servo_core::regions::control::addr::lifecycle::TORQUE_ENABLE;
 use osc_servo_core::regions::profile::span_word;
 use osc_servo_core::regions::{CALIB_BASE_ADDR, PROFILE_BASE_ADDR};
@@ -49,8 +49,8 @@ fn ping_reports_model_and_fw(baud_idx: u8) {
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     let (model, fw) = sim.servo_table(s, |t| {
         (
-            t.config.identity.model_number,
-            t.config.identity.firmware_version,
+            t.config.common.model_number,
+            t.config.common.firmware_version,
         )
     });
     let m = model.to_le_bytes();
@@ -70,8 +70,8 @@ fn read_returns_table_bytes(baud_idx: u8) {
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     let (model, fw) = sim.servo_table(s, |t| {
         (
-            t.config.identity.model_number,
-            t.config.identity.firmware_version,
+            t.config.common.model_number,
+            t.config.common.firmware_version,
         )
     });
     let m = model.to_le_bytes();
@@ -85,7 +85,7 @@ fn read_front_loaded_reply_matches_and_leaves_table(baud_idx: u8) {
     // never touches the table.
     let mut sim = sim(baud_idx);
     let s = sim.add_servo(ID5);
-    let before = sim.servo_table(s, |t| t.config.identity.model_number);
+    let before = sim.servo_table(s, |t| t.config.common.model_number);
 
     sim.host_send(&instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]));
     let frames = sim.run();
@@ -96,7 +96,7 @@ fn read_front_loaded_reply_matches_and_leaves_table(baud_idx: u8) {
     assert_eq!(payload, &[m[0], m[1], 0x56, 0]);
     assert_eq!(sim.servo_diag(s).crc_fail_count, 0);
     assert_eq!(
-        sim.servo_table(s, |t| t.config.identity.model_number),
+        sim.servo_table(s, |t| t.config.common.model_number),
         before,
         "a read leaves the table untouched"
     );
@@ -459,7 +459,7 @@ fn mgmt_assign_takes_the_id_and_acks_from_it(baud_idx: u8) {
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     assert!(payload.is_empty());
     assert_eq!(
-        sim.servo_table(s, |t| t.config.comms.id),
+        sim.servo_table(s, |t| t.config.common.id),
         42,
         "mirrored into the config ID register for a later SAVE"
     );
@@ -486,7 +486,7 @@ fn mgmt_assign_foreign_uid_is_silent_and_inert(baud_idx: u8) {
     let frames = sim.run();
 
     assert!(servo_frames(&frames).is_empty());
-    assert_eq!(sim.servo_table(s, |t| t.config.comms.id), ID5);
+    assert_eq!(sim.servo_table(s, |t| t.config.common.id), ID5);
     sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
     let (inst, _) = status(sole_reply(&sim.run()));
     assert_eq!(inst.result(), Some(ResultCode::Ok), "old id still answers");
@@ -511,7 +511,7 @@ fn mgmt_assign_invalid_id_nacks_validation(baud_idx: u8) {
     assert_eq!(reply.bytes[1], ID5, "the nack leaves from the unchanged id");
     let (inst, _) = status(reply);
     assert_eq!(inst.result(), Some(ResultCode::Validation));
-    assert_eq!(sim.servo_table(s, |t| t.config.comms.id), ID5);
+    assert_eq!(sim.servo_table(s, |t| t.config.common.id), ID5);
 }
 
 #[apply(matrix)]
@@ -539,8 +539,8 @@ fn profile_read_gathers_configured_spans(baud_idx: u8) {
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     let (model, fw) = sim.servo_table(s, |t| {
         (
-            t.config.identity.model_number,
-            t.config.identity.firmware_version,
+            t.config.common.model_number,
+            t.config.common.firmware_version,
         )
     });
     let m = model.to_le_bytes();
@@ -622,7 +622,7 @@ fn alert_bit_mirrors_fault_flags(baud_idx: u8) {
     let mut sim = sim(baud_idx);
     let s = sim.add_servo(ID5);
 
-    sim.servo_table_mut(s, |t| t.telemetry.fault.fault_flags = 1);
+    sim.servo_table_mut(s, |t| t.telemetry.common.fault_flags = 1);
     sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
     let frames = sim.run();
     let (inst, _) = status(sole_reply(&frames));
@@ -631,7 +631,7 @@ fn alert_bit_mirrors_fault_flags(baud_idx: u8) {
         "ALERT set while fault_flags nonzero (sec 5.3)"
     );
 
-    sim.servo_table_mut(s, |t| t.telemetry.fault.fault_flags = 0);
+    sim.servo_table_mut(s, |t| t.telemetry.common.fault_flags = 0);
     sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
     let frames = sim.run();
     let (inst, _) = status(sole_reply(&frames));

--- a/firmware/lib/integration/tests/resilience.rs
+++ b/firmware/lib/integration/tests/resilience.rs
@@ -404,7 +404,7 @@ fn rescue_pulse_drops_to_500k() {
 
     // Volatile: the config register still reads the operational baud.
     assert_eq!(
-        sim.servo_table(s, |t| t.config.comms.baud_rate_idx),
+        sim.servo_table(s, |t| t.config.common.baud_rate_idx),
         BaudRate::B1000000.as_idx()
     );
 
@@ -481,7 +481,7 @@ fn short_break_is_not_rescue(baud_idx: u8) {
     assert_eq!(d.framing_drop_count, 0);
     // No false rescue: the operational baud is unchanged.
     assert_eq!(
-        sim.servo_table(s, |t| t.config.comms.baud_rate_idx),
+        sim.servo_table(s, |t| t.config.common.baud_rate_idx),
         baud_idx
     );
 }

--- a/firmware/lib/integration/tests/timing.rs
+++ b/firmware/lib/integration/tests/timing.rs
@@ -10,7 +10,7 @@ use osc_integration::sim::{Sim, Source, WireFrame, assert_valid, instruction, st
 use osc_protocol::wire::{Opcode, ResultCode};
 use osc_servo_core::BaudRate;
 use osc_servo_core::regions::calib::addr::pot_lut::LUT;
-use osc_servo_core::regions::config::addr::identity::MODEL_NUMBER;
+use osc_servo_core::regions::config::addr::common::MODEL_NUMBER;
 use rstest::rstest;
 use rstest_reuse::apply;
 

--- a/firmware/lib/osc-protocol/src/lib.rs
+++ b/firmware/lib/osc-protocol/src/lib.rs
@@ -13,6 +13,7 @@ pub mod crc;
 pub mod frame;
 pub mod group;
 pub mod reply;
+pub mod table;
 pub mod wire;
 
 pub use bytes::FrameBytes;

--- a/firmware/lib/osc-protocol/src/table.rs
+++ b/firmware/lib/osc-protocol/src/table.rs
@@ -1,0 +1,42 @@
+//! Common register block (sec 5.4): the model-agnostic register set every
+//! node carries at fixed addresses. Everything outside these two blocks is
+//! per-model ABI and never named here.
+
+/// CONFIG-COMMON span (sec 5.4): SAVE-persisted; identity RO, comms RW.
+pub const CONFIG_COMMON_START: u16 = 0x000;
+/// Exclusive end; `CONFIG_COMMON_END..` is model-specific config space.
+pub const CONFIG_COMMON_END: u16 = 0x020;
+
+/// u16 RO -- keys the per-model register map.
+pub const MODEL_NUMBER: u16 = 0x000;
+/// u8 RO.
+pub const FIRMWARE_VERSION: u16 = 0x002;
+/// u8 RO.
+pub const HARDWARE_REVISION: u16 = 0x003;
+/// u32 RO -- reserved-slot extension signal; no bits defined yet.
+pub const CAPABILITY_FLAGS: u16 = 0x004;
+/// u8 RW -- unicast address, 0x01..=0xF9 (sec 3.1).
+pub const ID: u16 = 0x010;
+/// u8 RW -- sec 2 rate index (`BaudRate` discriminant).
+pub const BAUD_RATE_IDX: u16 = 0x011;
+/// u16 RW -- sec 7 reclaim window.
+pub const RESPONSE_DEADLINE_US: u16 = 0x012;
+
+/// TELEMETRY-COMMON span (sec 5.4): volatile.
+pub const TELEMETRY_COMMON_START: u16 = 0x200;
+/// Exclusive end; `TELEMETRY_COMMON_END..` is model-specific telemetry space.
+pub const TELEMETRY_COMMON_END: u16 = 0x220;
+
+/// u8 RO -- the sec 5.3 alarm register, ALERT's read target.
+pub const FAULT_FLAGS: u16 = 0x200;
+/// u8 RO -- common node state bits; see `STATUS_FLAG_CONFIG_DIRTY`.
+pub const STATUS_FLAGS: u16 = 0x201;
+/// i8 RO -- applied clock-trim total in chip trim steps (sec 9.3).
+pub const TRIM_STEPS: u16 = 0x202;
+/// u32 RW -- sec 5.3 frame-level counter; hosts write 0 to clear.
+pub const CRC_FAIL_COUNT: u16 = 0x204;
+/// u32 RW -- sec 5.3 frame-level counter; hosts write 0 to clear.
+pub const FRAMING_DROP_COUNT: u16 = 0x208;
+
+/// `STATUS_FLAGS` bit 0: modified-since-save (sec 9.4).
+pub const STATUS_FLAG_CONFIG_DIRTY: u8 = 1 << 0;

--- a/firmware/servo-ch32/src/runtime/registry.rs
+++ b/firmware/servo-ch32/src/runtime/registry.rs
@@ -102,9 +102,9 @@ impl Drivers {
         // must be what the bus comes up as, not the board defaults.
         let (id, baud_idx, deadline_us) = crate::runtime::statics::SHARED.table.with(|t| {
             (
-                t.config.comms.id,
-                t.config.comms.baud_rate_idx,
-                t.config.comms.response_deadline_us,
+                t.config.common.id,
+                t.config.common.baud_rate_idx,
+                t.config.common.response_deadline_us,
             )
         });
         // Image parse gates enum UB only; a corrupt-but-CRC-valid idx falls

--- a/firmware/servo-ch32/src/runtime/run.rs
+++ b/firmware/servo-ch32/src/runtime/run.rs
@@ -41,7 +41,7 @@ pub fn __run(cfg: BoardConfig, pre: Precomputed) -> ! {
     crate::runtime::statics::install(io);
     crate::runtime::isr::install_irqs();
     // Last-published transport counters: the table gets DELTAS, so a host
-    // zero-write (the rw clear contract, `TelemetryBusLink`) sticks instead
+    // zero-write (the rw clear contract, `TelemetryCommon`) sticks instead
     // of being clobbered by the next publish of a monotonic total.
     let mut published = osc_servo_drivers::bus::LinkDiag {
         crc_fail_count: 0,
@@ -86,15 +86,15 @@ pub fn __run(cfg: BoardConfig, pre: Precomputed) -> ! {
             // SAFETY: table storage is 'static; field access is volatile and
             // ISR-masked, mirroring the sample_tick idiom in `isr.rs`.
             unsafe {
-                let link = &raw mut (*crate::runtime::statics::SHARED.table.region_ptr())
+                let common = &raw mut (*crate::runtime::statics::SHARED.table.region_ptr())
                     .telemetry
-                    .link;
-                let crc = &raw mut (*link).crc_fail_count;
+                    .common;
+                let crc = &raw mut (*common).crc_fail_count;
                 crc.write_volatile(
                     crc.read_volatile()
                         .wrapping_add(diag.crc_fail_count.wrapping_sub(published.crc_fail_count)),
                 );
-                let drops = &raw mut (*link).framing_drop_count;
+                let drops = &raw mut (*common).framing_drop_count;
                 drops.write_volatile(
                     drops.read_volatile().wrapping_add(
                         diag.framing_drop_count
@@ -123,7 +123,7 @@ pub fn __run(cfg: BoardConfig, pre: Precomputed) -> ! {
             unsafe {
                 (&raw mut (*crate::runtime::statics::SHARED.table.region_ptr())
                     .telemetry
-                    .clock
+                    .common
                     .trim_steps)
                     .write_volatile(total);
             }

--- a/tools/bench/src/bin/osc.rs
+++ b/tools/bench/src/bin/osc.rs
@@ -18,17 +18,8 @@ use bench::pirate::Client;
 use bench::run::xfer;
 use bench::{RESCUE_BAUD, SUPPORTED_BAUDS, baud_index};
 use clap::{Parser, Subcommand};
+use osc_protocol::table::{BAUD_RATE_IDX, TRIM_STEPS};
 use osc_protocol::wire::{ResultCode, UID_LEN};
-
-/// Control-table address of `baud_rate_idx` (osc-servo-core
-/// `regions::config::addr::comms::BAUD_RATE_IDX`; value pinned here to keep
-/// the heavy core crate out of the bench build).
-const BAUD_RATE_IDX_ADDR: u16 = 0x000D;
-
-/// Control-table address of `telemetry.clock.trim_steps` (osc-servo-core
-/// `regions::telemetry`; pinned like `BAUD_RATE_IDX_ADDR`). Signed chip trim
-/// steps the trim loop has applied, read-only, volatile (protocol sec 9.3).
-const TRIM_STEPS_ADDR: u16 = 0x0244;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -228,12 +219,8 @@ fn switch_baud(client: &mut Client, ids: &[u8], to: u32) -> Result<()> {
     let idx = baud_index(to)
         .ok_or_else(|| anyhow::anyhow!("unsupported baud {to} (use {SUPPORTED_BAUDS:?})"))?;
     for &id in ids {
-        xfer_ok(
-            client,
-            &build_write(id, BAUD_RATE_IDX_ADDR, &[idx]),
-            SETTLE_MS,
-        )
-        .with_context(|| format!("baud write to id {id}"))?;
+        xfer_ok(client, &build_write(id, BAUD_RATE_IDX, &[idx]), SETTLE_MS)
+            .with_context(|| format!("baud write to id {id}"))?;
     }
     client.set_baud(to)?;
     client.reset()?;
@@ -297,7 +284,7 @@ fn rescue(cli: &Cli, set_baud: Option<u32>, do_save: bool) -> Result<()> {
 }
 
 fn read_trim(client: &mut Client, id: u8) -> Result<i8> {
-    let status = xfer_ok(client, &build_read(id, TRIM_STEPS_ADDR, 1), SETTLE_MS)?;
+    let status = xfer_ok(client, &build_read(id, TRIM_STEPS, 1), SETTLE_MS)?;
     match status.payload.as_slice() {
         [steps] => Ok(*steps as i8),
         p => bail!("trim_steps read returned {} bytes", p.len()),

--- a/tools/bench/src/bin/tool-baud.rs
+++ b/tools/bench/src/bin/tool-baud.rs
@@ -8,12 +8,8 @@ use bench::cli::{Connect, SETTLE_MS, Target};
 use bench::osc::{build_ping, build_write};
 use bench::run::measure;
 use clap::Parser;
+use osc_protocol::table::BAUD_RATE_IDX;
 use osc_protocol::wire::ResultCode;
-
-/// Control-table address of `baud_rate_idx` (osc-servo-core
-/// `regions::config::addr::comms::BAUD_RATE_IDX`; value pinned here to keep
-/// the heavy core crate out of the bench build).
-const BAUD_RATE_IDX_ADDR: u16 = 0x000D;
 
 #[derive(Parser, Debug)]
 #[command(about = "Switch a servo's baud and follow it (--baud = the current rate).")]
@@ -32,7 +28,7 @@ fn main() -> Result<()> {
     let mut client = args.conn.client()?;
     let idx = baud_index(args.to).ok_or_else(|| anyhow!("unsupported baud {}", args.to))?;
 
-    let write = build_write(args.target.id, BAUD_RATE_IDX_ADDR, &[idx]);
+    let write = build_write(args.target.id, BAUD_RATE_IDX, &[idx]);
     let report = measure(&mut client, &write, 1, SETTLE_MS, false, |ex| {
         if ex.status.result != Some(ResultCode::Ok) {
             bail!("write nacked: {:?}", ex.status.result);

--- a/tools/bench/tests/hardware/chain.rs
+++ b/tools/bench/tests/hardware/chain.rs
@@ -19,7 +19,7 @@ use bench::osc::{build_instruction, gread_uniform_payload};
 use bench::run::Stats;
 use osc_protocol::wire::{Opcode, ResultCode};
 use osc_servo_core::regions::config::DEFAULT_RESPONSE_DEADLINE_US;
-use osc_servo_core::regions::config::addr::identity::MODEL_NUMBER;
+use osc_servo_core::regions::config::addr::common::MODEL_NUMBER;
 use serial_test::serial;
 
 use crate::support::bench;

--- a/tools/bench/tests/hardware/mgmt.rs
+++ b/tools/bench/tests/hardware/mgmt.rs
@@ -2,9 +2,10 @@ use bench::osc::{
     REBOOT_SETTLE_MS, SAVE_SETTLE_MS, build_assign, build_enum, build_factory, build_ping,
     build_read, build_reboot, build_save, build_write,
 };
+use osc_protocol::table::STATUS_FLAG_CONFIG_DIRTY;
 use osc_protocol::wire::UID_LEN;
-use osc_servo_core::regions::config::addr::comms::RESPONSE_DEADLINE_US;
-use osc_servo_core::regions::telemetry::addr::fault::CONFIG_DIRTY;
+use osc_servo_core::regions::config::addr::common::RESPONSE_DEADLINE_US;
+use osc_servo_core::regions::telemetry::addr::common::STATUS_FLAGS;
 use serial_test::serial;
 
 use crate::support::bench;
@@ -82,10 +83,12 @@ fn save_persists_across_reboot_until_factory() {
         RESPONSE_DEADLINE_US,
         &MARKER.to_le_bytes(),
     ));
-    let dirty_before = b.status_ok(&build_read(id, CONFIG_DIRTY, 1)).payload[0];
+    let dirty_before =
+        b.status_ok(&build_read(id, STATUS_FLAGS, 1)).payload[0] & STATUS_FLAG_CONFIG_DIRTY;
 
     b.status_ok_within(&build_save(id), SAVE_SETTLE_MS);
-    let dirty_after = b.status_ok(&build_read(id, CONFIG_DIRTY, 1)).payload[0];
+    let dirty_after =
+        b.status_ok(&build_read(id, STATUS_FLAGS, 1)).payload[0] & STATUS_FLAG_CONFIG_DIRTY;
 
     // REBOOT acks first, then resets; the marker must come back from flash.
     b.status_ok(&build_reboot(id));

--- a/tools/bench/tests/hardware/profile.rs
+++ b/tools/bench/tests/hardware/profile.rs
@@ -2,8 +2,8 @@ use bench::SUPPORTED_BAUDS;
 use bench::osc::{build_profile_config, build_read, build_read_profile};
 use bench::run::Stats;
 use osc_protocol::wire::ResultCode;
-use osc_servo_core::regions::config::addr::comms::ID;
-use osc_servo_core::regions::config::addr::identity::MODEL_NUMBER;
+use osc_servo_core::regions::config::addr::common::ID;
+use osc_servo_core::regions::config::addr::common::MODEL_NUMBER;
 use osc_servo_core::regions::telemetry::addr::converted::{
     PRESENT_CURRENT, PRESENT_POSITION, PRESENT_VBUS_MV,
 };

--- a/tools/bench/tests/hardware/read.rs
+++ b/tools/bench/tests/hardware/read.rs
@@ -1,5 +1,5 @@
 use bench::osc::{build_ping, build_read};
-use osc_servo_core::regions::config::addr::identity::MODEL_NUMBER;
+use osc_servo_core::regions::config::addr::common::MODEL_NUMBER;
 use serial_test::serial;
 
 use crate::support::bench;

--- a/tools/bench/tests/hardware/rescue.rs
+++ b/tools/bench/tests/hardware/rescue.rs
@@ -16,7 +16,7 @@ use bench::osc::{
 };
 use bench::{BOOT_BAUD, baud_index};
 use osc_protocol::wire::{Id, ResultCode};
-use osc_servo_core::regions::config::addr::comms::BAUD_RATE_IDX;
+use osc_servo_core::regions::config::addr::common::BAUD_RATE_IDX;
 use serial_test::serial;
 
 use crate::support::bench;

--- a/tools/bench/tests/hardware/support.rs
+++ b/tools/bench/tests/hardware/support.rs
@@ -21,7 +21,7 @@ use bench::pirate::{Client, auto_detect_pirate};
 use bench::run::{BurstCycle, BurstReport, Report, burst_measure, capture, drain, measure, xfer};
 use bench::{BOOT_BAUD, RESCUE_BAUD};
 use osc_protocol::wire::ResultCode;
-use osc_servo_core::regions::config::addr::comms::BAUD_RATE_IDX;
+use osc_servo_core::regions::config::addr::common::BAUD_RATE_IDX;
 
 pub struct Bench {
     client: Client,

--- a/tools/bench/tests/hardware/trim.rs
+++ b/tools/bench/tests/hardware/trim.rs
@@ -21,7 +21,7 @@ use bench::BOOT_BAUD;
 use bench::osc::{build_cal, build_instruction, build_read};
 use osc_protocol::wire::{Inst, Opcode};
 use osc_servo_core::regions::control::addr::lifecycle::GOAL_POSITION;
-use osc_servo_core::regions::telemetry::addr::clock::TRIM_STEPS;
+use osc_servo_core::regions::telemetry::addr::common::TRIM_STEPS;
 use serial_test::serial;
 
 use super::support::{Bench, SETTLE_MS, bench};


### PR DESCRIPTION
Landing 2 of the osc-client band (sketch sec 7): a protocol-normative register set every node carries at fixed addresses, so model-agnostic tooling (rescue, baud migration, CAL verify, health polls, provisioning) works without knowing the model. Everything else in the table stays per-model ABI.

## What

- **Protocol doc sec 5.4**: two 32-byte blocks — CONFIG-COMMON `0x000..0x020` (identity RO, comms RW at 0x010) and TELEMETRY-COMMON `0x200..0x220` (alarm/status/trim + rw-clear counters). Reserved bytes read zero and reject writes with `access`; `capability_flags` is the expansion signal. Deliberate exclusions: torque switch, UID, boot mode.
- **osc-protocol `table` module**: the address consts + block bounds + `STATUS_FLAG_CONFIG_DIRTY`.
- **V006 rearrange**: one struct per protocol block (`ConfigCommon`, `TelemetryCommon`); `hardware_revision` u32→u8; `config_dirty` byte becomes `status_flags` bit 0; `mode_active`/`fault_code` move to model-specific `TelemetryMode` at 0x220. A pin test asserts every generated `addr::` const equals its `table::` const and that model-specific space starts exactly at each block's end.
- **bench**: the pinned `0x000D`/`0x0244` address consts retire onto `osc_protocol::table`.
- **client**: `provision` example — the first-boot fleet story (factory → discover → assign → save) plus status/migrate/chain, all on the `table` consts.
- Note: the old `TelemetryFault` comment claimed a fault_flags clear-write carve-out that was never implemented; the field is plain RO and the doc now says so.

## Silicon validation (5-servo fleet)

FACTORY-wiped on the old build, reflashed, then the full factory story on factory-fresh id-1 same-die clones: ENUM walk 5/5 UIDs, assign by UID, SAVE round-trip across reboot in the new layout, per-servo dirty isolation, rw-clear counters, CAL trim readback at 0x202, 50/50 chains clean at both 1M and 3M with zero CRC fails. Fleet left provisioned and saved at 1M.

All workspace gates green locally (lib 566 tests incl. DES suites, client 15 full-stack, boards + soft-arith + IAP header gates).