### PR TITLE
client: typed helpers, choreography halves, cyclic layer

### DIFF
--- a/client/examples/provision.rs
+++ b/client/examples/provision.rs
@@ -10,7 +10,7 @@
 //!   provision clear 1 2 3 4 5        zero the telemetry counters (rw-clear)
 //!   provision save 1 2 3 4 5         persist config, clears the dirty bit
 //!   provision reboot 1 2 3 4 5       MGMT REBOOT
-//!   provision cal 3 400 8            CAL trains; trim lands in `status`
+//!   provision cal 3 400 8 1 2 3 4 5  CAL trains + per-servo convergence trace
 //!   provision migrate 3 1 2 3 4 5    servo-first baud migration + reunion sweep
 //!   provision chain 50 1 2 3 4 5     GREAD chain soak, reports non-clean runs
 
@@ -72,27 +72,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         "status" => {
             for id in ids(rest)? {
-                let cfg = c.read(id, table::CONFIG_COMMON_START, 0x14)?;
-                let tel = c.read(id, table::TELEMETRY_COMMON_START, 0x0C)?;
+                let i = c.identity(id)?;
+                let h = c.health(id)?;
                 println!(
-                    "id {}: model {:#06x} fw {} hw {} cap {:#010x} | id {} baud_idx {} deadline {}us",
+                    "id {}: model {:#06x} fw {} hw {} cap {:#010x}",
                     id.as_byte(),
-                    u16::from_le_bytes([cfg[0], cfg[1]]),
-                    cfg[2],
-                    cfg[3],
-                    u32::from_le_bytes([cfg[4], cfg[5], cfg[6], cfg[7]]),
-                    cfg[0x10],
-                    cfg[0x11],
-                    u16::from_le_bytes([cfg[0x12], cfg[0x13]]),
+                    i.model,
+                    i.fw,
+                    i.hw,
+                    i.capabilities,
                 );
                 println!(
-                    "      fault {:#04x} status {:#04x} (dirty {}) trim {} | crc_fail {} framing_drop {}",
-                    tel[0],
-                    tel[1],
-                    (tel[1] & table::STATUS_FLAG_CONFIG_DIRTY) != 0,
-                    tel[2] as i8,
-                    u32::from_le_bytes([tel[4], tel[5], tel[6], tel[7]]),
-                    u32::from_le_bytes([tel[8], tel[9], tel[10], tel[11]]),
+                    "      fault {:#04x} dirty {} trim {} | crc_fail {} framing_drop {}",
+                    h.fault_flags,
+                    h.config_dirty,
+                    h.trim_steps,
+                    h.crc_fail_count,
+                    h.framing_drop_count,
                 );
             }
         }
@@ -104,8 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         "clear" => {
             for id in ids(rest)? {
-                c.write(id, table::CRC_FAIL_COUNT, &0u32.to_le_bytes())?;
-                c.write(id, table::FRAMING_DROP_COUNT, &0u32.to_le_bytes())?;
+                c.clear_counters(id)?;
                 println!("id {}: counters cleared", id.as_byte());
             }
         }
@@ -125,18 +120,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let idx: u8 = rest.first().ok_or("migrate <baud_idx> <id...>")?.parse()?;
             let rate = BaudRate::from_idx(idx).ok_or("bad baud idx")?;
             let targets = ids(&rest[1..])?;
-            // Servo-first (they ack at the old rate, apply deferred), then
-            // the host follows and the sweep proves the reunion.
-            for &id in &targets {
-                c.write(id, table::BAUD_RATE_IDX, &[idx])?;
-            }
-            c.host_baud(rate)?;
-            for &id in &targets {
-                match c.ping(id) {
-                    Ok(_) => println!("ping {} at {}: ok", id.as_byte(), rate.as_hz()),
-                    Err(Error::Timeout { .. }) => println!("ping {}: ABSENT", id.as_byte()),
-                    Err(e) => return Err(e.into()),
-                }
+            for (id, alive) in c.set_baud(&targets, rate)? {
+                let verdict = if alive { "ok" } else { "ABSENT" };
+                println!("ping {} at {}: {verdict}", id.as_byte(), rate.as_hz());
             }
         }
         "chain" => {
@@ -163,14 +149,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("chains: {}/{n} clean", n - bad);
         }
         "cal" => {
-            let trains: u8 = rest
-                .first()
-                .ok_or("cal <trains> <gap_us> <gaps>")?
-                .parse()?;
-            let gap_us: u16 = rest.get(1).ok_or("cal <trains> <gap_us> <gaps>")?.parse()?;
-            let gaps: u8 = rest.get(2).ok_or("cal <trains> <gap_us> <gaps>")?.parse()?;
-            c.cal(trains, gap_us, gaps)?;
-            println!("cal: {trains} trains of {gaps} x {gap_us}us sent");
+            let usage = "cal <trains> <gap_us> <gaps> <id...>";
+            let trains: u8 = rest.first().ok_or(usage)?.parse()?;
+            let gap_us: u16 = rest.get(1).ok_or(usage)?.parse()?;
+            let gaps: u8 = rest.get(2).ok_or(usage)?.parse()?;
+            let targets = ids(&rest[3..])?;
+            for t in c.cal_verify(&targets, trains, gap_us, gaps)? {
+                let verdict = if t.converged() { "converged" } else { "MOVING" };
+                println!("id {}: trims {:?} {verdict}", t.id.as_byte(), t.trims);
+            }
         }
         other => return Err(format!("unknown command {other}").into()),
     }

--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -7,8 +7,10 @@ use futures_lite::future::block_on;
 use osc_protocol::wire::{BaudRate, Id, Inst};
 
 use crate::client::{Chain, Ping, Reply};
+use crate::common::{self, Health, Identity};
+use crate::cyclic::Cycle;
 use crate::error::Error;
-use crate::mgmt::{self, Uid};
+use crate::mgmt::{self, CalTrace, Uid};
 use crate::pipe::Pipe;
 use crate::session::LinkInfo;
 
@@ -127,5 +129,41 @@ impl<P: Pipe> Client<P> {
 
     pub fn rescue_sweep(&mut self, ids: &[Id]) -> Result<Vec<(Id, bool)>, Error> {
         block_on(mgmt::rescue_sweep(&mut self.0, ids))
+    }
+
+    pub fn set_baud(&mut self, ids: &[Id], rate: BaudRate) -> Result<Vec<(Id, bool)>, Error> {
+        block_on(mgmt::set_baud(&mut self.0, ids, rate))
+    }
+
+    pub fn cal_verify(
+        &mut self,
+        ids: &[Id],
+        trains: u8,
+        gap_us: u16,
+        gaps: u8,
+    ) -> Result<Vec<CalTrace>, Error> {
+        block_on(mgmt::cal_verify(&mut self.0, ids, trains, gap_us, gaps))
+    }
+
+    pub fn identity(&mut self, id: Id) -> Result<Identity, Error> {
+        block_on(common::identity(&mut self.0, id))
+    }
+
+    pub fn health(&mut self, id: Id) -> Result<Health, Error> {
+        block_on(common::health(&mut self.0, id))
+    }
+
+    pub fn clear_counters(&mut self, id: Id) -> Result<(), Error> {
+        block_on(common::clear_counters(&mut self.0, id))
+    }
+
+    pub fn gread_profile(&mut self, ids: &[Id], slot: u8) -> Result<Chain, Error> {
+        block_on(self.0.gread_profile(ids, slot))
+    }
+
+    /// One [`Cycle`] exchange (see `cyclic`): held group writes, COMMIT,
+    /// telemetry chain.
+    pub fn step(&mut self, cycle: &Cycle, payloads: &[&[u8]]) -> Result<Chain, Error> {
+        block_on(cycle.step(&mut self.0, payloads))
     }
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -259,13 +259,18 @@ impl<P: Pipe> Client<P> {
             .ok_or(Error::Servo(ResultCode::Limit))?;
         let inst = Inst::instruction(Opcode::Gread, 0);
         let reply = self.exchange(Id::BROADCAST, inst, &p[..n]).await?;
-        Ok(Chain {
-            statuses: reply.statuses,
-            timeout_slot: match reply.outcome {
-                Outcome::Timeout { slot } => Some(slot),
-                _ => None,
-            },
-        })
+        Ok(chain_digest(reply))
+    }
+
+    /// Uniform profile-slot GREAD (sec 5.2): each target streams the span
+    /// list it pre-configured for `slot`.
+    pub async fn gread_profile(&mut self, ids: &[Id], slot: u8) -> Result<Chain, Error> {
+        let mut p = vec![0u8; ids.len() + 4];
+        let n = build::gread_profile_uniform(&mut p, slot, ids)
+            .ok_or(Error::Servo(ResultCode::Limit))?;
+        let inst = Inst::instruction(Opcode::Gread, Inst::FLAG_PROFILE);
+        let reply = self.exchange(Id::BROADCAST, inst, &p[..n]).await?;
+        Ok(chain_digest(reply))
     }
 
     /// Uniform GWRITE (silent unless a slice is missing -- completes at TX
@@ -355,6 +360,16 @@ impl<P: Pipe> Client<P> {
             Record::BootloaderAck => Ok(()),
             other => Err(desync("BOOTLOADER ack", &other)),
         }
+    }
+}
+
+fn chain_digest(reply: Reply) -> Chain {
+    Chain {
+        statuses: reply.statuses,
+        timeout_slot: match reply.outcome {
+            Outcome::Timeout { slot } => Some(slot),
+            _ => None,
+        },
     }
 }
 

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -1,0 +1,69 @@
+//! Typed views over the common register block (protocol sec 5.4) -- the
+//! only registers a model-agnostic client may name. One READ per view;
+//! layout comes from the `osc_protocol::table` consts, which the servo's
+//! pin test holds to the wire.
+
+use osc_protocol::table;
+use osc_protocol::wire::Id;
+
+use crate::client::Client;
+use crate::error::{Error, LinkError};
+use crate::pipe::Pipe;
+
+/// CONFIG-COMMON identity front (RO).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Identity {
+    pub model: u16,
+    pub fw: u8,
+    pub hw: u8,
+    pub capabilities: u32,
+}
+
+/// TELEMETRY-COMMON front: alarm, dirty, applied trim, transport counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Health {
+    /// The sec 5.3 alarm register -- nonzero is what sets ALERT.
+    pub fault_flags: u8,
+    /// Modified-since-save (sec 9.4).
+    pub config_dirty: bool,
+    pub trim_steps: i8,
+    pub crc_fail_count: u32,
+    pub framing_drop_count: u32,
+}
+
+pub async fn identity<P: Pipe>(c: &mut Client<P>, id: Id) -> Result<Identity, Error> {
+    let b = c.read(id, table::MODEL_NUMBER, 8).await?;
+    if b.len() < 8 {
+        return Err(short("identity"));
+    }
+    Ok(Identity {
+        model: u16::from_le_bytes([b[0], b[1]]),
+        fw: b[2],
+        hw: b[3],
+        capabilities: u32::from_le_bytes([b[4], b[5], b[6], b[7]]),
+    })
+}
+
+pub async fn health<P: Pipe>(c: &mut Client<P>, id: Id) -> Result<Health, Error> {
+    let b = c.read(id, table::FAULT_FLAGS, 12).await?;
+    if b.len() < 12 {
+        return Err(short("health"));
+    }
+    Ok(Health {
+        fault_flags: b[0],
+        config_dirty: b[1] & table::STATUS_FLAG_CONFIG_DIRTY != 0,
+        trim_steps: b[2] as i8,
+        crc_fail_count: u32::from_le_bytes([b[4], b[5], b[6], b[7]]),
+        framing_drop_count: u32::from_le_bytes([b[8], b[9], b[10], b[11]]),
+    })
+}
+
+/// Zero both transport counters -- contiguous by the sec 5.4 layout, so a
+/// single 8-byte write clears them atomically.
+pub async fn clear_counters<P: Pipe>(c: &mut Client<P>, id: Id) -> Result<(), Error> {
+    c.write(id, table::CRC_FAIL_COUNT, &[0u8; 8]).await
+}
+
+fn short(what: &str) -> Error {
+    Error::Link(LinkError::Desync(format!("short {what} payload")))
+}

--- a/client/src/cyclic.rs
+++ b/client/src/cyclic.rs
@@ -1,0 +1,74 @@
+//! The protocol sec 7 hot loop as a mechanism: configure a [`Cycle`] once,
+//! then [`Cycle::step`] forever -- GWRITE(HOLD) per group, one COMMIT so the
+//! fleet applies in the same instant, then the telemetry GREAD. The chain is
+//! the implicit ack: a rejected write surfaces as ALERT on that servo's
+//! status. Pacing is the caller's; there is no timer here.
+
+use osc_protocol::wire::{Id, ResultCode};
+
+use crate::client::{Chain, Client};
+use crate::error::Error;
+use crate::pipe::Pipe;
+
+/// One uniform GWRITE group: `count` bytes at `addr` for each listed target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Group {
+    pub addr: u16,
+    pub count: u8,
+    pub ids: Vec<Id>,
+}
+
+/// The read half of a step: a raw span, or a pre-configured profile slot
+/// (sec 5.2) when the interesting registers don't sit contiguously.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Telemetry {
+    Span { ids: Vec<Id>, addr: u16, count: u16 },
+    Profile { ids: Vec<Id>, slot: u8 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cycle {
+    groups: Vec<Group>,
+    telemetry: Telemetry,
+}
+
+impl Cycle {
+    pub fn new(groups: Vec<Group>, telemetry: Telemetry) -> Self {
+        Self { groups, telemetry }
+    }
+
+    /// Payload slots of one step, group-major: `payloads[k]` feeds the k-th
+    /// (group, id) pair in declaration order and must be `count` bytes wide.
+    pub fn payload_slots(&self) -> usize {
+        self.groups.iter().map(|g| g.ids.len()).sum()
+    }
+
+    /// One hot-loop exchange. `payloads` is group-major (see
+    /// [`Self::payload_slots`]); a wrong slot count or slice width is a
+    /// caller bug and answers `range` without touching the wire.
+    pub async fn step<P: Pipe>(
+        &self,
+        c: &mut Client<P>,
+        payloads: &[&[u8]],
+    ) -> Result<Chain, Error> {
+        if payloads.len() != self.payload_slots() {
+            return Err(Error::Servo(ResultCode::Range));
+        }
+        let mut next = payloads;
+        for g in &self.groups {
+            let (batch, rest) = next.split_at(g.ids.len());
+            next = rest;
+            if batch.iter().any(|d| d.len() != g.count as usize) {
+                return Err(Error::Servo(ResultCode::Range));
+            }
+            let pairs: Vec<(Id, &[u8])> =
+                g.ids.iter().copied().zip(batch.iter().copied()).collect();
+            c.gwrite_hold(g.addr, g.count, &pairs).await?;
+        }
+        c.commit().await?;
+        match &self.telemetry {
+            Telemetry::Span { ids, addr, count } => c.gread(ids, *addr, *count).await,
+            Telemetry::Profile { ids, slot } => c.gread_profile(ids, *slot).await,
+        }
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod blocking;
 mod client;
+pub mod common;
 mod error;
 pub mod mgmt;
 pub mod pipe;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod blocking;
 mod client;
 pub mod common;
+pub mod cyclic;
 mod error;
 pub mod mgmt;
 pub mod pipe;

--- a/client/src/mgmt.rs
+++ b/client/src/mgmt.rs
@@ -1,10 +1,12 @@
 //! MGMT choreographies: client policy over engine evidence (the walk and
 //! its verdicts live here by phase-2 ruling -- the engine only ships
-//! WireEvidence). Everything address-free; the register-touching halves
-//! (set_baud, CAL verify, SAVE guard) arrive with the common-block consts.
+//! WireEvidence). Register-touching halves (set_baud, cal_verify) name only
+//! the sec 5.4 common block; SAVE has no client-side guard by design (the
+//! servo self-gates and answers `access`).
 
 use osc_protocol::build;
-use osc_protocol::wire::{Id, Inst, MgmtOp, Opcode, ResultCode, UID_LEN};
+use osc_protocol::table;
+use osc_protocol::wire::{BaudRate, Id, Inst, MgmtOp, Opcode, ResultCode, UID_LEN};
 
 use crate::client::{Client, Reply};
 use crate::error::Error;
@@ -197,8 +199,8 @@ pub async fn assign<P: Pipe>(c: &mut Client<P>, uid: &Uid, new_id: Id) -> Result
 }
 
 /// Broadcast CAL trains (>= 2 per protocol sec 9.3 boot guidance: the
-/// second train finishes weak-step chips). Convergence readback arrives
-/// with the common-block consts.
+/// second train finishes weak-step chips), blind: no readback. See
+/// [`cal_verify`] for the per-servo convergence trace.
 pub async fn cal<P: Pipe>(
     c: &mut Client<P>,
     trains: u8,
@@ -242,6 +244,67 @@ pub async fn rescue_sweep<P: Pipe>(
     ids: &[Id],
 ) -> Result<Vec<(Id, bool)>, Error> {
     c.rescue().await?;
+    ping_sweep(c, ids).await
+}
+
+/// Fleet baud migration, servo-first (protocol sec 8): every target acks
+/// the register write at the old rate and applies it deferred, then the
+/// host follows, then the ping sweep reports the reunion.
+pub async fn set_baud<P: Pipe>(
+    c: &mut Client<P>,
+    ids: &[Id],
+    rate: BaudRate,
+) -> Result<Vec<(Id, bool)>, Error> {
+    for &id in ids {
+        c.write(id, table::BAUD_RATE_IDX, &[rate.as_idx()]).await?;
+    }
+    c.host_baud(rate).await?;
+    ping_sweep(c, ids).await
+}
+
+/// Per-servo trim trace from a CAL run: `trims[k]` is the applied total
+/// after train k+1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalTrace {
+    pub id: Id,
+    pub trims: Vec<i8>,
+}
+
+impl CalTrace {
+    /// Converged = the last two trains agreed (protocol sec 9.3: a train
+    /// that moves nothing has nothing left to move).
+    pub fn converged(&self) -> bool {
+        matches!(self.trims.as_slice(), [.., a, b] if a == b)
+    }
+}
+
+/// CAL with convergence readback: one broadcast train at a time, each
+/// listed servo's `trim_steps` sampled after every train.
+pub async fn cal_verify<P: Pipe>(
+    c: &mut Client<P>,
+    ids: &[Id],
+    trains: u8,
+    gap_us: u16,
+    gaps: u8,
+) -> Result<Vec<CalTrace>, Error> {
+    let mut traces: Vec<CalTrace> = ids
+        .iter()
+        .map(|&id| CalTrace {
+            id,
+            trims: Vec::with_capacity(trains as usize),
+        })
+        .collect();
+    for _ in 0..trains {
+        cal(c, 1, gap_us, gaps).await?;
+        for trace in &mut traces {
+            let b = c.read(trace.id, table::TRIM_STEPS, 1).await?;
+            trace.trims.push(*b.first().unwrap_or(&0) as i8);
+        }
+    }
+    Ok(traces)
+}
+
+async fn ping_sweep<P: Pipe>(c: &mut Client<P>, ids: &[Id]) -> Result<Vec<(Id, bool)>, Error> {
     let mut roster = Vec::with_capacity(ids.len());
     for &id in ids {
         let alive = match c.ping(id).await {

--- a/client/tests/full_stack.rs
+++ b/client/tests/full_stack.rs
@@ -5,15 +5,24 @@
 #![cfg(feature = "fake-adapter")]
 
 use osc_client::blocking::Client;
+use osc_client::common::{Health, Identity};
+use osc_client::cyclic::{Cycle, Group, Telemetry};
 use osc_client::fake::FakePipe;
 use osc_client::mgmt::Uid;
 use osc_client::{BaudRate, Error, Id, LinkError, RejectReason};
+use osc_protocol::table;
 use osc_protocol::wire::UID_LEN;
 
 /// V006 map fact used by read/write round trips (control.lifecycle
-/// goal_velocity); replaced by common-block consts where applicable in
-/// landing 3.
+/// goal_velocity); the common block is the only protocol-fixed address space.
 const GOAL_VELOCITY: u16 = 392;
+/// Slot 0 of the profile region (protocol sec 5.2 pin).
+const PROFILE_SLOT0: u16 = 0x280;
+
+/// Span word encoding, protocol sec 5.2: `[addr:10][count:6]`.
+const fn span_word(addr: u16, count: u16) -> u16 {
+    (addr << 6) | count
+}
 
 fn fleet(ids: &[u8]) -> Client<FakePipe> {
     Client::connect(FakePipe::new(BaudRate::B1000000, ids)).expect("connect")
@@ -172,4 +181,172 @@ fn rails_and_bootloader_ack() {
     let mut c = fleet(&[1]);
     c.set_rails(true, false).expect("rails");
     c.enter_bootloader().expect("bootloader");
+}
+
+#[test]
+fn identity_decodes_the_config_front() {
+    let mut c = fleet(&[5]);
+    c.pipe_mut().sim_mut().servo_table_mut(0, |t| {
+        t.config.common.hardware_revision = 3;
+        t.config.common.capability_flags = 0x8000_0001;
+    });
+    let got = c.identity(Id::new(5)).expect("identity");
+    assert_eq!(
+        got,
+        Identity {
+            model: 0x1234, // the sim's seeded default
+            fw: 0x56,
+            hw: 3,
+            capabilities: 0x8000_0001,
+        }
+    );
+}
+
+#[test]
+fn health_reads_the_telemetry_front_and_tracks_dirty() {
+    let mut c = fleet(&[5]);
+    c.pipe_mut().sim_mut().servo_table_mut(0, |t| {
+        t.telemetry.common.fault_flags = 0x04;
+        t.telemetry.common.trim_steps = -3;
+        t.telemetry.common.crc_fail_count = 7;
+        t.telemetry.common.framing_drop_count = 9;
+    });
+    // fault_flags nonzero sets ALERT on the reply; the digest must not
+    // mistake that for an error.
+    let got = c.health(Id::new(5)).expect("health");
+    assert_eq!(
+        got,
+        Health {
+            fault_flags: 0x04,
+            config_dirty: false,
+            trim_steps: -3,
+            crc_fail_count: 7,
+            framing_drop_count: 9,
+        }
+    );
+    c.write(
+        Id::new(5),
+        table::RESPONSE_DEADLINE_US,
+        &60u16.to_le_bytes(),
+    )
+    .expect("config write");
+    assert!(c.health(Id::new(5)).expect("health").config_dirty);
+}
+
+#[test]
+fn clear_counters_zeroes_both_in_one_write() {
+    let mut c = fleet(&[5]);
+    c.pipe_mut().sim_mut().servo_table_mut(0, |t| {
+        t.telemetry.common.crc_fail_count = 41;
+        t.telemetry.common.framing_drop_count = 8;
+    });
+    c.clear_counters(Id::new(5)).expect("clear");
+    let h = c.health(Id::new(5)).expect("health");
+    assert_eq!((h.crc_fail_count, h.framing_drop_count), (0, 0));
+}
+
+#[test]
+fn set_baud_migrates_servo_first_and_reunites() {
+    let mut c = fleet(&[1, 2]);
+    let ids = [Id::new(1), Id::new(2)];
+    let roster = c.set_baud(&ids, BaudRate::B3000000).expect("set_baud");
+    assert_eq!(roster, vec![(Id::new(1), true), (Id::new(2), true)]);
+    let chain = c.gread(&ids, GOAL_VELOCITY, 4).expect("gread at 3M");
+    assert_eq!(chain.timeout_slot, None);
+    assert_eq!(chain.statuses.len(), 2);
+}
+
+#[test]
+fn cal_verify_traces_every_train() {
+    let mut c = fleet(&[5]);
+    let traces = c.cal_verify(&[Id::new(5)], 3, 400, 4).expect("cal_verify");
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0].id, Id::new(5));
+    assert_eq!(traces[0].trims.len(), 3);
+    // Sim clocks don't drift, so the applied total never moves -- the
+    // convergence verdict is what silicon exercises.
+    assert!(traces[0].converged());
+}
+
+#[test]
+fn cycle_step_commits_the_writes_the_chain_echoes() {
+    let mut c = fleet(&[1, 2]);
+    let ids = vec![Id::new(1), Id::new(2)];
+    let cycle = Cycle::new(
+        vec![Group {
+            addr: GOAL_VELOCITY,
+            count: 4,
+            ids: ids.clone(),
+        }],
+        Telemetry::Span {
+            ids: ids.clone(),
+            addr: GOAL_VELOCITY,
+            count: 4,
+        },
+    );
+    let a = 0x0000_00AAu32.to_le_bytes();
+    let b = 0x0000_00BBu32.to_le_bytes();
+    let chain = c.step(&cycle, &[&a, &b]).expect("step");
+    assert_eq!(chain.timeout_slot, None);
+    let echoed: Vec<&[u8]> = chain.statuses.iter().map(|s| &s.payload[..]).collect();
+    assert_eq!(echoed, vec![&a[..], &b[..]]);
+}
+
+#[test]
+fn cycle_step_rejects_a_malformed_payload_batch() {
+    let mut c = fleet(&[1]);
+    let cycle = Cycle::new(
+        vec![Group {
+            addr: GOAL_VELOCITY,
+            count: 4,
+            ids: vec![Id::new(1)],
+        }],
+        Telemetry::Span {
+            ids: vec![Id::new(1)],
+            addr: GOAL_VELOCITY,
+            count: 4,
+        },
+    );
+    match c.step(&cycle, &[]) {
+        Err(Error::Servo(osc_client::ResultCode::Range)) => {}
+        other => panic!("expected Range on a missing slot, got {other:?}"),
+    }
+    match c.step(&cycle, &[&[0u8; 2][..]]) {
+        Err(Error::Servo(osc_client::ResultCode::Range)) => {}
+        other => panic!("expected Range on a narrow slice, got {other:?}"),
+    }
+}
+
+#[test]
+fn cycle_profile_telemetry_streams_the_slot() {
+    let mut c = fleet(&[5]);
+    let ids = vec![Id::new(5)];
+    // Slot 0: the 4-byte goal echo plus the alarm/status pair -- scattered
+    // registers one slot byte fetches per step.
+    let words = [
+        span_word(GOAL_VELOCITY, 4),
+        span_word(table::FAULT_FLAGS, 2),
+    ];
+    let mut spans = Vec::new();
+    for w in words {
+        spans.extend_from_slice(&w.to_le_bytes());
+    }
+    c.write(Id::new(5), PROFILE_SLOT0, &spans)
+        .expect("configure slot");
+    let cycle = Cycle::new(
+        vec![Group {
+            addr: GOAL_VELOCITY,
+            count: 4,
+            ids: ids.clone(),
+        }],
+        Telemetry::Profile { ids, slot: 0 },
+    );
+    let goal = 0x0000_0C0Cu32.to_le_bytes();
+    let chain = c.step(&cycle, &[&goal]).expect("step");
+    assert_eq!(chain.timeout_slot, None);
+    let [status] = chain.statuses.as_slice() else {
+        panic!("one status, got {}", chain.statuses.len());
+    };
+    assert_eq!(status.payload.len(), 6);
+    assert_eq!(&status.payload[..4], &goal);
 }

--- a/firmware/lib/integration/src/sim/mod.rs
+++ b/firmware/lib/integration/src/sim/mod.rs
@@ -158,6 +158,10 @@ impl Sim {
         let h = self.host.as_mut().expect("host attached");
         let rig = self.link.as_mut().expect("link attached");
         rig.server.on_pipe(bytes, &mut h.bus, &mut rig.out);
+        // Wire-silent commands (HostBaud, SetResponseDeadline) terminal
+        // inside on_pipe and schedule no wire event, so [`Self::run`] never
+        // reaches a pump -- drain the engine here or their records strand.
+        rig.server.pump(&mut h.bus, &mut rig.out);
     }
 
     /// Drain the outbound record byte stream (panics if no link).


### PR DESCRIPTION
Landing 3 of the osc-client band (sketch sec 5/6/8): the model-agnostic typed surface over the common register block, the register-touching mgmt halves, and the protocol sec 7 hot loop as a mechanism.

## What

- **common.rs**: `Identity` / `Health` views (one READ each against the `osc_protocol::table` consts; `config_dirty` decoded from the status_flags bit) and `clear_counters` (the counters are contiguous by the sec 5.4 layout, so one 8-byte write clears both).
- **mgmt.rs**: `set_baud(ids, rate)` — servo-first writes, `HostBaud`, reunion ping sweep; `cal_verify` — one broadcast train at a time with per-servo `trim_steps` sampled after each, `CalTrace::converged()` = the last two trains agreed. SAVE keeps no client-side guard by design (the servo self-gates and answers `access`); the stale header note saying a guard would arrive is gone.
- **cyclic.rs**: `Cycle` configured once (uniform GWRITE groups + telemetry as a raw span or a sec 5.2 profile slot), `step()` = GWRITE(HOLD) per group, one COMMIT, telemetry GREAD. The chain is the implicit ack (ALERT surfaces rejected writes); pacing is the caller's — no timer in the mechanism.
- **client.rs**: `gread_profile(ids, slot)` (the engine already shapes profile GREADs); blocking facade wraps everything including `step`.
- **provision example**: status/clear/migrate/cal collapse onto the helpers; `cal` now prints per-servo convergence traces.
- **sim fix (osc-integration)**: wire-silent commands (`HostBaud`, `SetResponseDeadline`) terminal inside `on_pipe` and schedule no wire event, so `Sim::run` never reached a pump and their records stranded — `link_send` now pumps once after `on_pipe`. Found by the first full-stack test to exercise a wire-silent command.

## Tests

8 new full-stack DES tests (23 total): identity/health decode against seeded tables (health also pins that ALERT is not an error), dirty-bit tracking across a config write, one-write counter clear, fleet baud migration to 3M + chain, cal_verify trace shape, cycle step with the chain echoing the committed values, malformed payload-batch rejection, and a profile-slot cycle round-trip.

All client and firmware/lib gates green locally (566 + 23 tests, clippy -D warnings both feature sets).