### PR TITLE
transport: fleet-mute RCA - cross-baud model, sec 8 pacing in set_baud

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -32,3 +32,7 @@ required-features = ["nusb"]
 [[example]]
 name = "cycle_soak"
 required-features = ["nusb"]
+
+[[example]]
+name = "mute_probe"
+required-features = ["nusb"]

--- a/client/examples/mute_probe.rs
+++ b/client/examples/mute_probe.rs
@@ -1,0 +1,167 @@
+//! Fleet-mute characterization driver (transport open item): migrate toward
+//! a target rate, then round-robin ping with timestamps until every servo
+//! answers -- per-servo dead time, over N migration cycles.
+//!
+//!   mute_probe cycles <n> <id...>       1M -> 3M -> 1M cycles, dead times
+//!   mute_probe order <n> <id...>        reversed write order each odd cycle
+//!   mute_probe solo <n> <id>            single-servo migrate (no cross-baud)
+//!   mute_probe rescue <id...>           mute the fleet, then rescue mid-mute
+
+use std::time::{Duration, Instant};
+
+use osc_client::blocking::Client;
+use osc_client::nusb::NusbPipe;
+use osc_client::{BaudRate, Error, Id};
+use osc_protocol::table;
+
+/// Round-robin ping until every id answers; per-id dead time from `t0`.
+fn wait_reunion(
+    c: &mut Client<NusbPipe>,
+    ids: &[Id],
+    t0: Instant,
+    cap: Duration,
+) -> Result<Vec<(Id, Option<Duration>)>, Error> {
+    let mut dead: Vec<(Id, Option<Duration>)> = ids.iter().map(|&id| (id, None)).collect();
+    while dead.iter().any(|(_, d)| d.is_none()) && t0.elapsed() < cap {
+        for slot in dead.iter_mut().filter(|(_, d)| d.is_none()) {
+            match c.ping(slot.0) {
+                Ok(_) => slot.1 = Some(t0.elapsed()),
+                Err(Error::Timeout { .. }) => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(dead)
+}
+
+fn report(tag: &str, dead: &[(Id, Option<Duration>)]) {
+    for (id, d) in dead {
+        match d {
+            Some(d) => println!("  {tag} id {}: back after {:>9.3?}", id.as_byte(), d),
+            None => println!("  {tag} id {}: NEVER (cap hit)", id.as_byte()),
+        }
+    }
+}
+
+/// Write baud registers in the given order, switch the host, stamp t0.
+/// A timed-out baud write is INDETERMINATE (the servo may have applied it
+/// with the ack lost -- silicon-observed); never retry, let the reunion
+/// sweep at the new rate decide.
+fn migrate(c: &mut Client<NusbPipe>, order: &[Id], rate: BaudRate) -> Result<Instant, Error> {
+    for &id in order {
+        match c.write(id, table::BAUD_RATE_IDX, &[rate.as_idx()]) {
+            Ok(()) => {}
+            Err(Error::Timeout { .. }) => {
+                println!(
+                    "  (baud ack LOST from id {} -- indeterminate)",
+                    id.as_byte()
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    c.host_baud(rate)?;
+    Ok(Instant::now())
+}
+
+/// Post-reunion stability tail: sweep everyone for `span`, report relapses.
+fn stability_tail(
+    c: &mut Client<NusbPipe>,
+    ids: &[Id],
+    t0: Instant,
+    span: Duration,
+) -> Result<(), Error> {
+    let start = Instant::now();
+    while start.elapsed() < span {
+        for &id in ids {
+            match c.ping(id) {
+                Ok(_) => {}
+                Err(Error::Timeout { .. }) => {
+                    println!("  RELAPSE id {} at +{:.3?}", id.as_byte(), t0.elapsed());
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(())
+}
+
+const CAP: Duration = Duration::from_secs(10);
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let usage = "mute_probe <cycles|order|solo|rescue> [n] <id...>";
+    let mode = args.first().ok_or(usage)?.clone();
+    let mut c = Client::connect(NusbPipe::open()?)?;
+
+    let parse_ids = |from: usize| -> Result<Vec<Id>, Box<dyn std::error::Error>> {
+        let out: Result<Vec<u8>, _> = args[from..].iter().map(|a| a.parse::<u8>()).collect();
+        Ok(out?.into_iter().map(Id::new).collect())
+    };
+
+    match mode.as_str() {
+        "cycles" | "order" => {
+            let n: u32 = args.get(1).ok_or(usage)?.parse()?;
+            let ids = parse_ids(2)?;
+            for i in 0..n {
+                let mut order = ids.clone();
+                if mode == "order" && i % 2 == 1 {
+                    order.reverse();
+                }
+                let t0 = migrate(&mut c, &order, BaudRate::B3000000)?;
+                println!(
+                    "cycle {i} -> 3M (write order {:?}):",
+                    order.iter().map(|d| d.as_byte()).collect::<Vec<_>>()
+                );
+                report("3M", &wait_reunion(&mut c, &ids, t0, CAP)?);
+                stability_tail(&mut c, &ids, t0, Duration::from_millis(200))?;
+                let t0 = migrate(&mut c, &ids, BaudRate::B1000000)?;
+                println!("cycle {i} -> 1M:");
+                report("1M", &wait_reunion(&mut c, &ids, t0, CAP)?);
+                stability_tail(&mut c, &ids, t0, Duration::from_millis(200))?;
+            }
+        }
+        "solo" => {
+            let n: u32 = args.get(1).ok_or(usage)?.parse()?;
+            let ids = parse_ids(2)?;
+            let [id] = ids.as_slice() else {
+                return Err("solo takes exactly one id".into());
+            };
+            for i in 0..n {
+                let t0 = migrate(&mut c, &[*id], BaudRate::B3000000)?;
+                println!("solo {i} -> 3M:");
+                report("3M", &wait_reunion(&mut c, &[*id], t0, CAP)?);
+                let t0 = migrate(&mut c, &[*id], BaudRate::B1000000)?;
+                println!("solo {i} -> 1M:");
+                report("1M", &wait_reunion(&mut c, &[*id], t0, CAP)?);
+            }
+        }
+        "rescue" => {
+            let ids = parse_ids(1)?;
+            let t0 = migrate(&mut c, &ids, BaudRate::B3000000)?;
+            // One quick sweep to confirm the mute is on, then rescue into it.
+            let mut muted = Vec::new();
+            for &id in &ids {
+                match c.ping(id) {
+                    Ok(_) => {}
+                    Err(Error::Timeout { .. }) => muted.push(id.as_byte()),
+                    Err(e) => return Err(e.into()),
+                }
+            }
+            println!("muted at +{:.3?}: {muted:?}", t0.elapsed());
+            let t1 = Instant::now();
+            let roster = c.rescue_sweep(&ids)?;
+            println!("rescue at +{:.3?} -> roster {:?}", t0.elapsed(), roster);
+            println!("rescue sweep took {:.3?}", t1.elapsed());
+            // Leave the bench at 1M.
+            for &id in &ids {
+                c.write(id, table::BAUD_RATE_IDX, &[BaudRate::B1000000.as_idx()])?;
+            }
+            c.host_baud(BaudRate::B1000000)?;
+            let t0 = Instant::now();
+            report("1M", &wait_reunion(&mut c, &ids, t0, CAP)?);
+        }
+        _ => return Err(usage.into()),
+    }
+    Ok(())
+}

--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -42,6 +42,12 @@ impl<P: Pipe> Client<P> {
         block_on(self.0.exchange(id, inst, payload))
     }
 
+    /// Quiet bus time (sec 8 pacing): wall time on hardware, sim time on
+    /// the fake adapter.
+    pub fn pause(&mut self, d: Duration) {
+        block_on(self.0.pause(d));
+    }
+
     pub fn ping(&mut self, id: Id) -> Result<Ping, Error> {
         block_on(self.0.ping(id))
     }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -186,6 +186,12 @@ impl<P: Pipe> Client<P> {
         self.submit(Command::Exchange { id, inst, payload }).await
     }
 
+    /// Quiet bus time (the sec 8 pacing primitive): wall time on hardware,
+    /// sim time on the fake adapter.
+    pub async fn pause(&mut self, d: Duration) {
+        self.pipe.pause(d).await;
+    }
+
     /// Digest a single-status reply: exactly one OK status or an error.
     fn sole_ok(reply: Reply) -> Result<Status, Error> {
         if let Outcome::Timeout { slot } = reply.outcome {

--- a/client/src/fake.rs
+++ b/client/src/fake.rs
@@ -47,4 +47,8 @@ impl Pipe for FakePipe {
         }
         Ok(out)
     }
+
+    async fn pause(&mut self, d: std::time::Duration) {
+        self.sim.idle(d.as_micros() as u64);
+    }
 }

--- a/client/src/mgmt.rs
+++ b/client/src/mgmt.rs
@@ -43,8 +43,8 @@ fn matches_prefix(uid: &[u8; UID_LEN], prefix: &[u8; UID_LEN], len: u8) -> bool 
 /// fleet-measured (2 ms still lost occasional subtrees mid-walk).
 const PROBE_SETTLE: std::time::Duration = std::time::Duration::from_millis(5);
 
-async fn settle() {
-    futures_timer::Delay::new(PROBE_SETTLE).await;
+async fn settle<P: Pipe>(c: &mut Client<P>) {
+    c.pause(PROBE_SETTLE).await;
 }
 
 fn with_bit(prefix: &[u8; UID_LEN], k: u8, v: bool) -> [u8; UID_LEN] {
@@ -90,7 +90,7 @@ async fn probe<P: Pipe>(
         _ => Verdict::Collision,
     };
     if matches!(verdict, Verdict::Collision) {
-        settle().await;
+        settle(c).await;
     }
     Ok(verdict)
 }
@@ -108,7 +108,7 @@ async fn probe_settled<P: Pipe>(
         if !matches!(verdict, Verdict::Empty) {
             return Ok(verdict);
         }
-        settle().await;
+        settle(c).await;
         verdict = probe(c, len, prefix).await?;
     }
     Ok(verdict)
@@ -129,7 +129,7 @@ pub async fn discover<P: Pipe>(c: &mut Client<P>) -> Result<Vec<Uid>, Error> {
     const WALKS_CAP: usize = 5;
     let mut prev = walk(c).await?;
     for _ in 1..WALKS_CAP {
-        futures_timer::Delay::new(4 * PROBE_SETTLE).await;
+        c.pause(4 * PROBE_SETTLE).await;
         let next = walk(c).await?;
         if next == prev {
             return Ok(next);
@@ -256,9 +256,20 @@ pub async fn set_baud<P: Pipe>(
     rate: BaudRate,
 ) -> Result<Vec<(Id, bool)>, Error> {
     for &id in ids {
-        c.write(id, table::BAUD_RATE_IDX, &[rate.as_idx()]).await?;
+        match c.write(id, table::BAUD_RATE_IDX, &[rate.as_idx()]).await {
+            Ok(()) => {}
+            // Indeterminate: the servo may have applied with the ack lost
+            // (silicon-observed), and a retry at the old rate can only
+            // garble an applied switch -- the reunion sweep is the verdict.
+            Err(Error::Timeout { .. }) => {}
+            Err(e) => return Err(e),
+        }
     }
     c.host_baud(rate).await?;
+    // sec 8 pacing: the write burst was cross-rate garble to every servo
+    // that already applied -- one settle of quiet lets parked resolvers
+    // starve out before the sweep asks for proof of life.
+    settle(c).await;
     ping_sweep(c, ids).await
 }
 

--- a/client/src/pipe.rs
+++ b/client/src/pipe.rs
@@ -3,12 +3,19 @@
 //! meaning -- records reassemble in the session.
 
 use std::fmt;
+use std::time::Duration;
 
 pub trait Pipe {
     /// Deliver bytes in order, whole.
     fn send(&mut self, bytes: &[u8]) -> impl Future<Output = Result<(), PipeError>>;
     /// The next delivered chunk (never empty). Pends until bytes arrive.
     fn recv(&mut self) -> impl Future<Output = Result<Vec<u8>, PipeError>>;
+    /// Let `d` of BUS time pass with the wire quiet -- the sec 8 pacing
+    /// primitive (post-garble settles). Wall time by default; the fake
+    /// adapter overrides with sim time so servo-side horizons really elapse.
+    fn pause(&mut self, d: Duration) -> impl Future<Output = ()> {
+        futures_timer::Delay::new(d)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/client/tests/full_stack.rs
+++ b/client/tests/full_stack.rs
@@ -245,6 +245,10 @@ fn clear_counters_zeroes_both_in_one_write() {
     assert_eq!((h.crc_fail_count, h.framing_drop_count), (0, 0));
 }
 
+/// The park mechanism itself is pinned in osc-integration's `cross_baud`
+/// suite -- the link-mode rig cannot hold a parked resolver across
+/// commands (every exchange drains the sim queue = unbounded quiet), so
+/// this level pins the paced choreography only.
 #[test]
 fn set_baud_migrates_servo_first_and_reunites() {
     let mut c = fleet(&[1, 2]);

--- a/firmware/lib/integration/src/sim/core.rs
+++ b/firmware/lib/integration/src/sim/core.rs
@@ -86,6 +86,9 @@ pub enum Event {
     RescueDeclare,
     /// The host's frame drained -- finalize the recorded frame.
     HostFrameEnd,
+    /// Scheduled quiet: nothing happens, sim time passes (the paced-client
+    /// settle in link mode -- servo starve horizons need real quiet).
+    Idle,
     /// A servo's tick-compare fired; `generation` guards against a cancelled/re-armed
     /// deadline (stale generations are dropped on delivery).
     Compare { servo: usize, generation: u64 },

--- a/firmware/lib/integration/src/sim/mod.rs
+++ b/firmware/lib/integration/src/sim/mod.rs
@@ -12,6 +12,7 @@ mod core;
 mod cpu;
 mod host;
 mod providers;
+mod resample;
 mod servo;
 mod store;
 mod support;
@@ -30,15 +31,12 @@ use osc_servo_drivers::bus::RESCUE_LOW_US;
 use self::core::{Core, Event, TICKS_PER_US, Talker, break_ticks, byte_ticks};
 use self::cpu::{Cpu, Vector};
 use self::providers::Handles;
+use self::resample::{CrossRx, RxOut};
 use self::servo::SimServo;
 
 pub use self::cpu::HandlerCost;
 pub use self::host::HostEvent;
 pub use self::store::RamStore;
-
-/// XOR mask applied to bytes ringed at a baud-mismatched receiver: arbitrary
-/// but nonzero, so mismatched data never survives as valid content.
-const MISMATCH_GARBLE: u8 = 0xA5;
 
 pub use self::support::{assert_valid, instruction, status};
 
@@ -73,6 +71,10 @@ pub struct Sim {
     servos: Vec<Box<SimServo>>,
     handles: Vec<Handles>,
     cpus: Vec<Cpu>,
+    /// Per-servo cross-baud reception machines (see `resample`): fed
+    /// whenever a wire event's rate differs from the receiver's.
+    cross: Vec<CrossRx>,
+    host_cross: Option<CrossRx>,
     rate: BaudRate,
     /// The scheduling host queues each frame after its own prior traffic.
     host_free_at: u64,
@@ -109,6 +111,8 @@ impl Sim {
             servos: Vec::new(),
             handles: Vec::new(),
             cpus: Vec::new(),
+            cross: Vec::new(),
+            host_cross: None,
             rate,
             host_free_at: 0,
             host: None,
@@ -122,6 +126,7 @@ impl Sim {
     pub fn attach_host(&mut self) {
         assert!(self.host.is_none(), "host already attached");
         self.host = Some(host::SimHost::build(&self.core, self.rate));
+        self.host_cross = Some(CrossRx::new(self.rate));
     }
 
     /// Submit one command to the attached engine (panics if none).
@@ -162,6 +167,15 @@ impl Sim {
         // inside on_pipe and schedule no wire event, so [`Self::run`] never
         // reaches a pump -- drain the engine here or their records strand.
         rig.server.pump(&mut h.bus, &mut rig.out);
+    }
+
+    /// Let `us` of quiet sim time pass (link mode's pipe pause): schedules
+    /// a no-op that far out and runs to it, so servo-side horizons that need
+    /// wire silence (starve resync, sec 3.4) actually elapse.
+    pub fn idle(&mut self, us: u64) {
+        let t = self.core.borrow().now() + us * TICKS_PER_US;
+        self.core.borrow_mut().schedule(Event::Idle, t);
+        self.run();
     }
 
     /// Drain the outbound record byte stream (panics if no link).
@@ -206,6 +220,7 @@ impl Sim {
         self.servos.push(servo);
         self.handles.push(handles);
         self.cpus.push(Cpu::default());
+        self.cross.push(CrossRx::new(self.rate));
         idx
     }
 
@@ -472,7 +487,11 @@ impl Sim {
                 let now = self.core.borrow().now();
                 self.handles[servo].deadline.set_skew(now, ppm);
             }
-            Event::HostFrameEnd => self.core.borrow_mut().finalize_frame(),
+            Event::HostFrameEnd => {
+                self.core.borrow_mut().finalize_frame();
+                self.flush_cross();
+            }
+            Event::Idle => {}
             Event::Compare { servo, generation } => {
                 // The generation gate is checked at the match instant only: a
                 // deadline re-aimed before its match never fires, but once
@@ -594,64 +613,119 @@ impl Sim {
             if talker == Talker::Servo(j) {
                 continue; // no own-TX echo (F9)
             }
-            self.deliver_break_to(j, baud);
+            self.deliver_break_to(j, baud, break_start);
         }
         // The host hears every foreign break (its ring contract excludes
         // only its own TX); no wake exists to qualify -- just the ring image.
-        if let Some(h) = &self.host
-            && talker != Talker::Host
-        {
-            if h.baud.current().as_hz() >= baud.as_hz() {
-                h.ring.push(0x00);
-            } else {
-                h.ring.push(MISMATCH_GARBLE);
+        if talker != Talker::Host {
+            let rx = self.host.as_ref().map(|h| h.baud.current());
+            if let Some(rx) = rx {
+                if rx == baud {
+                    self.host.as_ref().expect("host attached").ring.push(0x00);
+                } else {
+                    let mut out = Vec::new();
+                    let hc = self.host_cross.as_mut().expect("host attached");
+                    hc.retune(rx);
+                    hc.on_break(break_start, break_ticks(baud), &mut out);
+                    self.cross_deliver_host(out);
+                }
             }
         }
     }
 
-    /// Length-qualified break delivery (sec 3.4): the 10-bit span covers >=10 of
-    /// the receiver's bit-times only at receivers at or above the talker's
-    /// rate -- those decode the all-zeros character and wake. A slower
-    /// receiver hears a sub-character low: compressed junk, no wake.
-    fn deliver_break_to(&mut self, j: usize, baud: BaudRate) {
-        if self.handles[j].baud.current().as_hz() >= baud.as_hz() {
+    /// Break delivery: a matched receiver decodes the all-zeros character
+    /// and wakes; a mismatched one hears the span through its cross-baud
+    /// machine (sec 3.4 length qualification falls out of the resample --
+    /// faster receivers see a qualified break, slower ones sub-bar junk).
+    fn deliver_break_to(&mut self, j: usize, baud: BaudRate, break_start: u64) {
+        let rx = self.handles[j].baud.current();
+        if rx == baud {
             self.handles[j].ring.push(0x00);
             self.deliver(j, Vector::Break);
         } else {
-            self.handles[j].ring.push(MISMATCH_GARBLE);
+            let mut out = Vec::new();
+            self.cross[j].retune(rx);
+            self.cross[j].on_break(break_start, break_ticks(baud), &mut out);
+            self.cross_deliver(j, out);
         }
     }
 
     fn deliver_data(&mut self, talker: Talker, byte: u8, baud: BaudRate) {
         let now = self.core.borrow().now();
         self.core.borrow_mut().append_byte(byte, now);
-        if let Some(h) = &self.host
-            && talker != Talker::Host
-        {
-            if h.baud.current() == baud {
-                h.ring.push(byte);
-            } else {
-                h.ring.push(byte ^ MISMATCH_GARBLE);
+        if talker != Talker::Host {
+            let rx = self.host.as_ref().map(|h| h.baud.current());
+            if let Some(rx) = rx {
+                if rx == baud {
+                    self.host.as_ref().expect("host attached").ring.push(byte);
+                } else {
+                    let mut out = Vec::new();
+                    let hc = self.host_cross.as_mut().expect("host attached");
+                    hc.retune(rx);
+                    hc.on_byte(now, byte, baud, &mut out);
+                    self.cross_deliver_host(out);
+                }
             }
         }
         for j in 0..self.servos.len() {
             if talker == Talker::Servo(j) {
                 continue;
             }
-            let matched = self.handles[j].baud.current() == baud;
-            if matched {
+            let rx = self.handles[j].baud.current();
+            if rx == baud {
                 self.handles[j].ring.push(byte);
             } else {
-                // A baud mismatch garbles both value and framing (sec 2
-                // approximation): the sampled bits are wrong-rate noise, so
-                // the ringed byte must not survive as valid data at either a
-                // faster or slower receiver. No wake (sec 3.4): a data byte's
-                // dominant runs stay under the detector's 10-bit bar in this
-                // model (silicon: rare slower-baud bytes do qualify -- leg D
-                // of the lbd_wake spike -- but the wake-into-junk exposure is
-                // already carried by the slower talker's breaks).
-                self.handles[j].ring.push(byte ^ MISMATCH_GARBLE);
+                // Wrong-rate reception goes through the waveform model: a
+                // slower talker's characters multiply and its low runs can
+                // wake as spurious breaks (the baud-migration garble the
+                // fleet measures); a faster talker's spans mostly vanish.
+                let mut out = Vec::new();
+                self.cross[j].retune(rx);
+                self.cross[j].on_byte(now, byte, baud, &mut out);
+                self.cross_deliver(j, out);
             }
+        }
+    }
+
+    /// Ring cross-baud artifacts at servo `j`: characters ring as data, a
+    /// qualified break rings one 0x00 and wakes (F2/F3).
+    fn cross_deliver(&mut self, j: usize, out: Vec<RxOut>) {
+        for o in out {
+            match o {
+                RxOut::Byte(b) => self.handles[j].ring.push(b),
+                RxOut::Break => {
+                    self.handles[j].ring.push(0x00);
+                    self.deliver(j, Vector::Break);
+                }
+            }
+        }
+    }
+
+    fn cross_deliver_host(&mut self, out: Vec<RxOut>) {
+        if let Some(h) = &self.host {
+            for o in out {
+                match o {
+                    RxOut::Byte(b) => h.ring.push(b),
+                    RxOut::Break => h.ring.push(0x00),
+                }
+            }
+        }
+    }
+
+    /// A frame ended and the line is idle: complete every mismatched
+    /// receiver's in-flight sampling against the high line.
+    fn flush_cross(&mut self) {
+        for j in 0..self.cross.len() {
+            let mut out = Vec::new();
+            self.cross[j].flush(&mut out);
+            if !out.is_empty() {
+                self.cross_deliver(j, out);
+            }
+        }
+        if self.host_cross.is_some() {
+            let mut out = Vec::new();
+            self.host_cross.as_mut().expect("checked").flush(&mut out);
+            self.cross_deliver_host(out);
         }
     }
 
@@ -665,14 +739,18 @@ impl Sim {
     }
 
     fn deliver_stray_break(&mut self, baud: BaudRate) {
+        let start = {
+            let now = self.core.borrow().now();
+            now.saturating_sub(break_ticks(baud))
+        };
         for j in 0..self.servos.len() {
-            self.deliver_break_to(j, baud);
+            self.deliver_break_to(j, baud, start);
         }
         if let Some(h) = &self.host {
             if h.baud.current().as_hz() >= baud.as_hz() {
                 h.ring.push(0x00);
             } else {
-                h.ring.push(MISMATCH_GARBLE);
+                h.ring.push(0xA5); // injected junk, value arbitrary
             }
         }
     }

--- a/firmware/lib/integration/src/sim/resample.rs
+++ b/firmware/lib/integration/src/sim/resample.rs
@@ -1,0 +1,277 @@
+//! Cross-baud reception model: traffic sent at one rate, sampled by a
+//! receiver UART at another. This is the physics behind baud-migration
+//! garble (protocol sec 2 / sec 8): a slower talker's low runs stretch past
+//! the faster receiver's 10-bit break bar (spurious breaks + multiplied
+//! characters), while a faster talker's spans compress below the slower
+//! receiver's framing (most bytes vanish or merge).
+//!
+//! One streaming machine per receiver: wire events feed bit spans in wall
+//! order, gaps between events are idle-high by construction (one talker at
+//! a time), and outputs are ring artifacts -- characters ring regardless of
+//! framing violations (FE is only a wake, protocol sec 3.4), a qualified
+//! break rings one 0x00 and wakes (F2/F3).
+//!
+//! Approximations, all conservative: the break bar is 10 receiver bits (LIN
+//! LBD); a character completing inside a longer low run rings in addition
+//! to the run's break byte; a character left sampling at a frame's end
+//! completes against idle-high at the next feed or flush.
+
+use osc_protocol::wire::BaudRate;
+
+use super::core::bit_ticks;
+
+/// One received ring artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RxOut {
+    /// A sampled character (framing violations still ring).
+    Byte(u8),
+    /// A qualified break span: one 0x00 rings, the wake fires.
+    Break,
+}
+
+/// In-flight character: falling edge anchored, 9 samples (8 data + stop) at
+/// `edge + rx_bit*(3 + 2k)/2`.
+struct Sampler {
+    edge: u64,
+    taken: u8,
+    acc: u8,
+}
+
+pub struct CrossRx {
+    rate: BaudRate,
+    rx_bit: u64,
+    /// Waveform continuity cursor: `[last_end, next feed)` is idle-high.
+    last_end: u64,
+    /// Start of the running low span, when the line is low.
+    low_since: Option<u64>,
+    sampler: Option<Sampler>,
+    /// All-zero character completed inside its own still-running low span:
+    /// the run decides at close (break swallows it, a short run rings it).
+    held_zero: bool,
+}
+
+impl CrossRx {
+    pub fn new(rate: BaudRate) -> Self {
+        Self {
+            rate,
+            rx_bit: bit_ticks(rate),
+            last_end: 0,
+            low_since: None,
+            sampler: None,
+            held_zero: false,
+        }
+    }
+
+    /// The receiver retuned (deferred baud apply): all sampling state dies
+    /// with the old clock.
+    pub fn retune(&mut self, rate: BaudRate) {
+        if rate != self.rate {
+            *self = Self::new(rate);
+        }
+    }
+
+    /// A data character sent at `tx`, event-stamped at its wire END (the
+    /// sim's byte events carry end times).
+    pub fn on_byte(&mut self, end: u64, byte: u8, tx: BaudRate, out: &mut Vec<RxOut>) {
+        let tx_bit = bit_ticks(tx);
+        let start = end.saturating_sub(10 * tx_bit);
+        self.idle_gap(start, out);
+        self.feed(true, start, tx_bit, out);
+        for k in 0..8 {
+            let low = byte >> k & 1 == 0;
+            self.feed(low, start + (1 + k as u64) * tx_bit, tx_bit, out);
+        }
+        self.feed(false, start + 9 * tx_bit, tx_bit, out);
+    }
+
+    /// A break span `[start, start+dur)` of dominant low.
+    pub fn on_break(&mut self, start: u64, dur: u64, out: &mut Vec<RxOut>) {
+        self.idle_gap(start, out);
+        self.feed(true, start, dur, out);
+    }
+
+    /// The line is idle-high from here on: complete or drop what's pending.
+    pub fn flush(&mut self, out: &mut Vec<RxOut>) {
+        let now = self.last_end;
+        if let Some(t0) = self.low_since.take() {
+            self.close_run(t0, now, out);
+        }
+        if let Some(s) = self.sampler.take()
+            && s.taken > 0
+        {
+            let mut acc = s.acc;
+            for k in s.taken..8 {
+                acc |= 1 << k;
+            }
+            out.push(RxOut::Byte(acc));
+        }
+    }
+
+    fn idle_gap(&mut self, start: u64, out: &mut Vec<RxOut>) {
+        if start > self.last_end {
+            let gap = start - self.last_end;
+            self.feed(false, self.last_end, gap, out);
+        }
+    }
+
+    fn feed(&mut self, low: bool, start: u64, dur: u64, out: &mut Vec<RxOut>) {
+        let end = start + dur;
+        if low {
+            if self.low_since.is_none() {
+                self.low_since = Some(start);
+                if self.sampler.is_none() {
+                    self.sampler = Some(Sampler {
+                        edge: start,
+                        taken: 0,
+                        acc: 0,
+                    });
+                }
+            }
+        } else if let Some(t0) = self.low_since.take() {
+            self.close_run(t0, start, out);
+        }
+        self.pump(low, end, out);
+        self.last_end = end;
+    }
+
+    /// Consume sample instants that fall before `end` at the current level.
+    fn pump(&mut self, low: bool, end: u64, out: &mut Vec<RxOut>) {
+        while let Some(s) = self.sampler.as_mut() {
+            let t = s.edge + self.rx_bit * (3 + 2 * s.taken as u64) / 2;
+            if t >= end {
+                return;
+            }
+            if s.taken < 8 && !low {
+                s.acc |= 1 << s.taken;
+            }
+            s.taken += 1;
+            if s.taken == 9 {
+                let byte = s.acc;
+                let edge = s.edge;
+                self.sampler = None;
+                if low && byte == 0 && self.low_since == Some(edge) {
+                    // Still inside its own low run: break-or-zero at close.
+                    self.held_zero = true;
+                } else {
+                    out.push(RxOut::Byte(byte));
+                }
+            }
+        }
+    }
+
+    /// A low run `[t0, t1)` ended: break-qualify it (10 receiver bits).
+    fn close_run(&mut self, t0: u64, t1: u64, out: &mut Vec<RxOut>) {
+        let held = std::mem::take(&mut self.held_zero);
+        if t1 - t0 >= 10 * self.rx_bit {
+            // The run's own in-flight sampler dies with it; a sampler from
+            // an earlier edge cannot exist here (it either completed inside
+            // the run or was this run's own).
+            if self.sampler.as_ref().is_some_and(|s| s.edge == t0) {
+                self.sampler = None;
+            }
+            out.push(RxOut::Break);
+        } else if held {
+            out.push(RxOut::Byte(0));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resample(bytes: &[u8], tx: BaudRate, rx: BaudRate) -> Vec<RxOut> {
+        let mut m = CrossRx::new(rx);
+        let bt = bit_ticks(tx) * 10;
+        let mut out = Vec::new();
+        for (k, &b) in bytes.iter().enumerate() {
+            m.on_byte((k as u64 + 1) * bt, b, tx, &mut out);
+        }
+        m.flush(&mut out);
+        out
+    }
+
+    #[test]
+    fn slow_zero_byte_reads_as_break_at_the_faster_rate() {
+        // 1M 0x00: start + 8 zero bits = 9 us low = 27 bits at 3M >= 10.
+        let out = resample(&[0x00], BaudRate::B1000000, BaudRate::B3000000);
+        assert_eq!(out, vec![RxOut::Break]);
+    }
+
+    #[test]
+    fn slow_ff_reads_as_one_char() {
+        // 1M 0xFF at 3M: start low = 3 bits -> samples 0,0 then highs = 0xFC.
+        let out = resample(&[0xFF], BaudRate::B1000000, BaudRate::B3000000);
+        assert_eq!(out, vec![RxOut::Byte(0xFC)]);
+    }
+
+    #[test]
+    fn slow_alternating_byte_multiplies() {
+        // 1M 0x55 at 3M: three characters (hand-derived sampling).
+        let out = resample(&[0x55], BaudRate::B1000000, BaudRate::B3000000);
+        assert_eq!(
+            out,
+            vec![RxOut::Byte(0x1C), RxOut::Byte(0x1C), RxOut::Byte(0xFC)]
+        );
+    }
+
+    #[test]
+    fn matched_rate_round_trips() {
+        for b in [0x00u8, 0x5A, 0xFF, 0x01] {
+            let out = resample(&[b], BaudRate::B1000000, BaudRate::B1000000);
+            if b == 0 {
+                // A matched-rate 0x00 is 9 low bits -- under the break bar.
+                assert_eq!(out, vec![RxOut::Byte(0)], "byte {b:#04x}");
+            } else {
+                assert_eq!(out, vec![RxOut::Byte(b)], "byte {b:#04x}");
+            }
+        }
+    }
+
+    #[test]
+    fn fast_traffic_mostly_vanishes_at_the_slower_rate() {
+        // A 3M frame at 1M: spans compress to fractions of the receiver's
+        // bit -- far fewer characters than sent, and no breaks.
+        let sent = [0x00u8, 0x05, 0x30, 0x80, 0xA5, 0x11, 0x22, 0x33];
+        let out = resample(&sent, BaudRate::B3000000, BaudRate::B1000000);
+        assert!(out.len() < sent.len() / 2, "got {out:?}");
+        assert!(!out.contains(&RxOut::Break), "got {out:?}");
+    }
+
+    #[test]
+    fn slow_break_span_qualifies_at_the_faster_rate() {
+        let mut m = CrossRx::new(BaudRate::B3000000);
+        let mut out = Vec::new();
+        // A 1M break: 14 bit-times dominant low.
+        m.on_break(0, 14 * bit_ticks(BaudRate::B1000000), &mut out);
+        m.flush(&mut out);
+        assert_eq!(out, vec![RxOut::Break]);
+    }
+
+    #[test]
+    fn fast_break_span_is_invisible_at_the_slower_rate() {
+        let mut m = CrossRx::new(BaudRate::B1000000);
+        let mut out = Vec::new();
+        // A 3M break: 14 * 16 ticks = 4.7 receiver bits -- under the bar.
+        m.on_break(0, 14 * bit_ticks(BaudRate::B3000000), &mut out);
+        m.flush(&mut out);
+        assert!(!out.contains(&RxOut::Break), "got {out:?}");
+    }
+
+    #[test]
+    fn retune_resets_the_machine() {
+        let mut m = CrossRx::new(BaudRate::B3000000);
+        let mut out = Vec::new();
+        m.on_byte(
+            10 * bit_ticks(BaudRate::B1000000),
+            0x55,
+            BaudRate::B1000000,
+            &mut out,
+        );
+        m.retune(BaudRate::B1000000);
+        m.flush(&mut out);
+        let n = out.len();
+        m.flush(&mut out);
+        assert_eq!(out.len(), n, "reset machine must hold no residue");
+    }
+}

--- a/firmware/lib/integration/tests/cross_baud.rs
+++ b/firmware/lib/integration/tests/cross_baud.rs
@@ -1,0 +1,108 @@
+//! Cross-baud garble and the parked resolver (the fleet-mute RCA,
+//! `docs/osc-native-protocol.md` sec 3.4 / sec 8): garble that spells a
+//! plausible frame prefix parks the resolver on a phantom footprint, frames
+//! that follow FEED the phantom instead of dispatching, and recovery is the
+//! starve giveup -- which needs one horizon of NO ring progress, exactly
+//! what back-to-back traffic denies. Silicon-measured as 8-19 ms of fleet
+//! mute during unpaced toward-faster baud migrations (survivor = the
+//! last-written servo); here the mechanism is pinned exactly.
+//!
+//! These scenarios run on the SCRIPTED host with overlapping schedules: the
+//! link-mode client rig cannot hold a park across commands (every exchange
+//! runs the queue dry, which is unbounded quiet), so client-level suites
+//! only see the paced choreographies -- by design, those are always clean.
+
+use osc_integration::sim::{Sim, Source, instruction};
+use osc_protocol::wire::{BaudRate, Opcode, STARVE_HORIZON_BYTE_TIMES};
+
+const ID5: u8 = 5;
+
+fn servo_frames_after(frames: &[osc_integration::sim::WireFrame], at: u64) -> Vec<(u64, Vec<u8>)> {
+    frames
+        .iter()
+        .filter(|f| matches!(f.from, Source::Servo(_)) && f.at >= at)
+        .map(|f| (f.at, f.bytes.clone()))
+        .collect()
+}
+
+#[test]
+fn a_parked_resolver_eats_the_next_frame_and_replies_late() {
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+    sim.run();
+    let t = sim.now_us() + 50;
+    // Superposition residue: a plausible prefix that never completes. The
+    // next frame's own break byte lands as the header's 4th byte, so the
+    // phantom claims LEN 0xFA -- a 253-byte footprint.
+    sim.inject_break_at(t);
+    sim.inject_garble_at(t + 15, 0x05);
+    sim.inject_garble_at(t + 30, 0xFA);
+    // The ping lands inside the park, well under the giveup horizon.
+    sim.host_send_at(t + 100, &instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+
+    // The ping was eaten: no reply within anything resembling a turnaround.
+    // The starve giveup (64 byte-times of no progress = 640 us at 1M) then
+    // sacrificed the phantom, the hunt recovered the eaten ping from the
+    // ring, and the reply left LATE -- past any host response window, which
+    // is how an eaten frame reads as a timeout AND as unexpected wire bytes.
+    let replies = servo_frames_after(&frames, 0);
+    assert_eq!(replies.len(), 1, "the eaten ping still dispatches once");
+    let ping_end_us = frames
+        .iter()
+        .find(|f| matches!(f.from, Source::Host))
+        .expect("the ping was recorded")
+        .end
+        / 48; // ticks -> us
+    let reply_at_us = replies[0].0 / 48;
+    let horizon_us = STARVE_HORIZON_BYTE_TIMES as u64 * 10; // byte-times at 1M
+    assert!(
+        reply_at_us >= ping_end_us + horizon_us,
+        "the reply must wait out the giveup horizon: reply at {reply_at_us} us, \
+         ping ended {ping_end_us} us, horizon {horizon_us} us"
+    );
+    // The sacrificed phantom is the frame-drop the fleet's counters showed.
+    assert_eq!(sim.servo_diag(s).framing_drop_count, 1);
+
+    // With the bus quiet again, the next exchange is a normal turnaround.
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    let replies = servo_frames_after(&frames, 0);
+    assert_eq!(replies.len(), 1, "clean turnaround after quiet");
+}
+
+#[test]
+fn migration_garble_storms_the_switched_receiver() {
+    // End-to-end through the waveform model: a real baud write moves the
+    // servo to 3M (deferred apply at ack drain), then the host's next 1M
+    // frame reaches it as spurious breaks + multiplied characters -- never
+    // a resolvable frame, so the servo cannot answer traffic at the old
+    // rate. This is the migration window every already-switched servo sits
+    // in while its slower siblings are still being written.
+    let mut sim = Sim::new(BaudRate::B1000000);
+    let s = sim.add_servo(ID5);
+    sim.run();
+    // WRITE baud_rate_idx = 3 (table 0x011): acks at 1M, applies after.
+    sim.host_send(&instruction(
+        ID5,
+        Opcode::Write,
+        0,
+        &[0x11, 0x00, BaudRate::B3000000.as_idx()],
+    ));
+    let frames = sim.run();
+    assert_eq!(
+        servo_frames_after(&frames, 0).len(),
+        1,
+        "the ack left at 1M"
+    );
+
+    // The servo now samples the wire at 3M; a 1M ping is a garble storm.
+    sim.host_send(&instruction(ID5, Opcode::Ping, 0, &[]));
+    let frames = sim.run();
+    assert_eq!(
+        servo_frames_after(&frames, 0).len(),
+        0,
+        "cross-rate traffic must never resolve into a dispatch"
+    );
+    let _ = s;
+}


### PR DESCRIPTION
Closes the phase-4 open transport item: the transient fleet-mute under client traffic, root-caused end to end and pinned in DES.

## The mechanism

Garble that happens to spell a plausible frame prefix (break byte + junk + large LEN) parks the servo's resolver on a phantom footprint. Frames that follow FEED the phantom -- ring progress resets the starve clock, so the sec 3.4 giveup (64 byte-times of NO progress) never fires under back-to-back traffic. The eaten frame then dispatches late, past any host response window: the host sees a timeout AND unexpected wire bytes. Everything observed on silicon falls out of this: the 8-19 ms mute during unpaced toward-faster migrations (a slower talker's low runs read as spurious breaks + multiplied characters at the new rate), the survivor always being the last-written servo, the toward-slower direction never muting (fast spans compress below the framing bars), the relapse storms (late replies colliding with new pings), and the one "hard wedge" (a baud-write ack that arrived LATE, read as lost; the blind retry at the old rate then manufactured a rate divergence).

The transport behaves exactly per its design contract (stream-derived anchors, FE = wake only, data is the only death authority). The violation was client choreography firing traffic through the sec 8 post-garble pacing gap.

## What

- **integration**: the sim's 1:1 XOR-garble stub for rate-mismatched reception becomes a waveform-accurate streaming resampler (`sim/resample.rs`, all-integer on the 48-ticks/us grid), unit-pinned by hand-derived vectors (a 1M 0x00 at 3M is a break; 0x55 is three characters). Mismatched-rate delivery routes through per-receiver machines, host ring included. `Sim::idle` schedules bounded quiet.
- **integration tests** (`cross_baud.rs`): the mechanism pins -- a ping into a park is eaten and its reply leaves past the giveup horizon, the sacrificed phantom ticks the drop counter, quiet recovers it; migration garble never resolves into a dispatch. (Link-mode client suites cannot hold a park -- every exchange runs the queue dry, which is unbounded quiet -- so these pins live at the scripted-host layer.)
- **client**: `Pipe::pause` -- the sec 8 pacing primitive (wall time on hardware, sim time on the fake adapter; the ENUM walk's settles now ride it too). `set_baud` gains one settle between the host switch and the reunion sweep, and treats a timed-out baud write as INDETERMINATE (the servo may have applied with the ack late -- the sweep is the verdict, and a retry at the old rate can only garble an applied switch).
- **client examples**: `mute_probe`, the characterization driver that produced the silicon numbers (migration cycles with per-servo dead-time, write-order permutation, solo, rescue-into-mute).

## Proof

Silicon: 4 consecutive fleet migrations, 20/20 first-sweep pings (previously 1/5 toward 3M, every time). DES: lib suite 576 incl. the new pins, client 23 over the fake adapter.