### PR TITLE
host: adapter wire instrument - edge capture + raw TX verbs

### DIFF
--- a/firmware/host-ch32/src/hal/dma.rs
+++ b/firmware/host-ch32/src/hal/dma.rs
@@ -1,7 +1,8 @@
-//! DMA1 primitives -- only the two channels this crate claims: CH3 is the
+//! DMA1 primitives -- the four channels this crate claims: CH3 is the
 //! USART3 RX ring (circular, armed once, never raises an IRQ), CH2 the
 //! USART3 TX arm (one span at a time; completion is the USART TC, never a
-//! channel flag).
+//! channel flag), CH1/CH7 the TIM2 CH3/CH4 edge-capture rings (circular,
+//! armed once, 16-bit).
 
 use ch32_metapac::DMA1;
 pub use ch32_metapac::dma::vals::{Dir, Pl, Size};
@@ -9,10 +10,14 @@ pub use ch32_metapac::dma::vals::{Dir, Pl, Size};
 #[derive(Copy, Clone)]
 #[repr(u8)]
 pub enum Channel {
+    /// TIM2_CH3 capture ring (wire falling edges).
+    CH1 = 1,
     /// USART3_TX arm.
     CH2 = 2,
     /// USART3_RX ring.
     CH3 = 3,
+    /// TIM2_CH4 capture ring (wire rising edges).
+    CH7 = 7,
 }
 
 #[derive(Copy, Clone)]
@@ -21,6 +26,7 @@ pub struct Config {
     pub circ: bool,
     pub minc: bool,
     pub pl: Pl,
+    pub size: Size,
 }
 
 pub fn configure(ch: Channel, cfg: &Config, paddr: u32, maddr: u32, count: u16) {
@@ -33,14 +39,14 @@ pub fn configure(ch: Channel, cfg: &Config, paddr: u32, maddr: u32, count: u16) 
         w.set_dir(cfg.dir);
         w.set_circ(cfg.circ);
         w.set_minc(cfg.minc);
-        w.set_psize(Size::BITS8);
-        w.set_msize(Size::BITS8);
+        w.set_psize(cfg.size);
+        w.set_msize(cfg.size);
         w.set_pl(cfg.pl);
     });
 }
 
 // SAFETY: CH2 is touched from MAIN (engine send under CS) and the release
-// path; CS keeps the EN RMW atomic. CH3 is armed once at bringup.
+// path; CS keeps the EN RMW atomic. CH1/CH3/CH7 are armed once at bringup.
 #[inline(always)]
 pub fn enable(ch: Channel) {
     let n = (ch as u8 - 1) as usize;

--- a/firmware/host-ch32/src/hal/mod.rs
+++ b/firmware/host-ch32/src/hal/mod.rs
@@ -7,5 +7,6 @@ pub mod gpio;
 pub mod pfic;
 pub mod rcc;
 pub mod systick;
+pub mod tim2cap;
 pub mod usart;
 pub mod usbhs;

--- a/firmware/host-ch32/src/hal/tim2cap.rs
+++ b/firmware/host-ch32/src/hal/tim2cap.rs
@@ -1,0 +1,67 @@
+//! TIM2 wire-edge capture -- the instrument's stopwatch (linke-edgecap
+//! spike, silicon-proven). Partial remap 2 routes CH3 onto PB10 (the bus
+//! pin, input path live under USART3 AF); IC3 takes TI3 falling, IC4
+//! cross-selects TI3 rising; each capture DMA-drains to its ring with
+//! zero CPU. Armed once at bringup and never re-armed: re-arming mangles
+//! captures (spike), and the boundary quirks that remain (break-edge
+//! phantoms, the swallowed break fall) are the PC decoder's contract.
+//!
+//! Tick domain: PSC divides PCLK1 144 MHz to 18 MHz = the SysTick domain,
+//! and CNT is aligned to the SysTick count at init -- both count HCLK/8,
+//! so the offset stays constant forever and u16 captures unwrap directly
+//! against engine ticks.
+
+use ch32_metapac::timer::vals::CcmrInputCcs;
+use ch32_metapac::{AFIO, RCC, TIM2};
+
+use super::systick;
+
+/// PCLK1 144 MHz -> the 18 MHz SysTick tick domain.
+const PSC_TO_18MHZ: u16 = 7;
+
+pub fn init() {
+    RCC.apb1pcenr().modify(|w| w.set_tim2en(true));
+    RCC.apb2pcenr().modify(|w| w.set_afioen(true));
+
+    // Partial remap 2: TIM2 CH3/CH4 onto PB10/PB11 (only TI3/PB10 used).
+    // The RMW writes PCFR1's write-only SWCFG bits as 000 = the full-debug
+    // reset default; SWD stays alive (PIN RULES).
+    AFIO.pcfr1().modify(|w| w.set_tim2_rm(0b10));
+
+    TIM2.psc().write_value(PSC_TO_18MHZ);
+    TIM2.atrlr().write_value(0xFFFF);
+    TIM2.swevgr().write(|w| w.set_ug(true)); // latch PSC now
+
+    TIM2.chctlr_input(1).modify(|w| {
+        // metapac value naming: 01 = own TI (IC3 <- TI3), 10 = the 3<->4
+        // swap (IC4 <- TI3). No filter, no capture prescaler: every edge.
+        w.set_ccs(0, CcmrInputCcs::TI4);
+        w.set_ccs(1, CcmrInputCcs::TI3);
+    });
+    TIM2.ccer().modify(|w| {
+        w.set_cce(2, true);
+        w.set_ccp(2, true); // IC3: falling
+        w.set_cce(3, true);
+        w.set_ccp(3, false); // IC4: rising
+    });
+    TIM2.dmaintenr().modify(|w| {
+        w.set_ccde(2, true);
+        w.set_ccde(3, true);
+    });
+
+    // Align CNT to the SysTick domain just before counting starts: a few
+    // ticks of enable latency shift ALL captures by one constant, which
+    // delta measurements cancel and unwrap tolerance absorbs.
+    TIM2.cnt().write_value(systick::ticks() as u16);
+    TIM2.ctlr1().modify(|w| w.set_cen(true));
+}
+
+/// CHCVR3 address (falling captures) for the DMA1_CH1 arm.
+pub fn fall_capture_addr() -> u32 {
+    TIM2.chcvr(2).as_ptr() as u32
+}
+
+/// CHCVR4 address (rising captures) for the DMA1_CH7 arm.
+pub fn rise_capture_addr() -> u32 {
+    TIM2.chcvr(3).as_ptr() as u32
+}

--- a/firmware/host-ch32/src/providers/edges.rs
+++ b/firmware/host-ch32/src/providers/edges.rs
@@ -1,0 +1,139 @@
+//! Edge-capture provider -- binds the engine's `EdgeCapture` to the TIM2
+//! capture rings (DMA1_CH1 falls / DMA1_CH7 rises, armed once at bringup).
+//! Drains are consumer-paced; `poll_accumulate` (main loop) keeps the
+//! written totals honest between drains so a full ring lap can never
+//! masquerade as fresh data.
+//!
+//! Access discipline: every method here runs in MAIN-loop context only
+//! (the link server's dispatch and the run loop) -- no ISR touches the
+//! capture state, so the plain statics need no synchronization beyond the
+//! single-context contract.
+
+use core::cell::SyncUnsafeCell;
+
+use osc_host::traits;
+
+use crate::hal::dma;
+
+/// Entries per ring (2 KB each). At the worst-case sustained edge rate
+/// (alternating bits at 3M = one edge per bit) a ring holds ~340 us of
+/// traffic -- orders past the main loop's poll cadence.
+const CAP_LEN: usize = 1024;
+
+static FALLS: SyncUnsafeCell<[u16; CAP_LEN]> = SyncUnsafeCell::new([0; CAP_LEN]);
+static RISES: SyncUnsafeCell<[u16; CAP_LEN]> = SyncUnsafeCell::new([0; CAP_LEN]);
+
+struct Side {
+    /// Ring write position at the last accumulate, entries.
+    last_pos: u16,
+    /// Entries ever written (accumulated) / handed out.
+    written: u32,
+    drained: u32,
+}
+
+struct State {
+    falls: Side,
+    rises: Side,
+    overflow: bool,
+}
+
+static STATE: SyncUnsafeCell<State> = SyncUnsafeCell::new(State {
+    falls: Side {
+        last_pos: 0,
+        written: 0,
+        drained: 0,
+    },
+    rises: Side {
+        last_pos: 0,
+        written: 0,
+        drained: 0,
+    },
+    overflow: false,
+});
+
+/// Production binding to the TIM2 capture rings.
+pub struct Edges;
+
+impl Edges {
+    pub const LEN: usize = CAP_LEN;
+
+    pub fn falls_addr() -> u32 {
+        // SAFETY: address-of a `'static` cell, handed to the DMA controller.
+        unsafe { (*FALLS.get()).as_ptr() as u32 }
+    }
+
+    pub fn rises_addr() -> u32 {
+        // SAFETY: as above.
+        unsafe { (*RISES.get()).as_ptr() as u32 }
+    }
+
+    /// Fold ring progress into the running totals; the main loop calls this
+    /// every iteration (no self, no CS: the capture state is main-loop-only
+    /// by the module contract, never ISR-shared). Sound while under one
+    /// full lap lands between calls (~340 us at the worst-case edge rate
+    /// vs a us-scale loop).
+    pub fn poll_accumulate() {
+        // SAFETY: main-loop-only access (module contract).
+        let s = unsafe { &mut *STATE.get() };
+        for (side, ch) in [
+            (&mut s.falls, dma::Channel::CH1),
+            (&mut s.rises, dma::Channel::CH7),
+        ] {
+            let pos = CAP_LEN as u16 - dma::remaining(ch);
+            let delta = (pos + CAP_LEN as u16 - side.last_pos) % CAP_LEN as u16;
+            side.last_pos = pos;
+            side.written = side.written.wrapping_add(delta as u32);
+            if side.written.wrapping_sub(side.drained) > CAP_LEN as u32 {
+                s.overflow = true;
+            }
+        }
+    }
+}
+
+fn drain(side: &mut Side, ring: &SyncUnsafeCell<[u16; CAP_LEN]>, buf: &mut [u16]) -> usize {
+    if side.written.wrapping_sub(side.drained) > CAP_LEN as u32 {
+        // Lapped (overflow already flagged): realign to the oldest entry
+        // still intact so the drain returns the newest window in order.
+        side.drained = side.written - CAP_LEN as u32;
+    }
+    let avail = side.written.wrapping_sub(side.drained);
+    let n = buf.len().min(avail as usize);
+    // SAFETY: DMA-owned storage read in place; entries below `written` are
+    // complete (the controller finishes a 16-bit beat atomically).
+    let data = unsafe { &*ring.get() };
+    for (k, slot) in buf[..n].iter_mut().enumerate() {
+        *slot = data[(side.drained as usize + k) % CAP_LEN];
+    }
+    side.drained = side.drained.wrapping_add(n as u32);
+    n
+}
+
+impl traits::EdgeCapture for Edges {
+    fn drain_falls(&mut self, buf: &mut [u16]) -> usize {
+        Self::poll_accumulate();
+        // SAFETY: main-loop-only access (module contract).
+        let s = unsafe { &mut *STATE.get() };
+        drain(&mut s.falls, &FALLS, buf)
+    }
+
+    fn drain_rises(&mut self, buf: &mut [u16]) -> usize {
+        Self::poll_accumulate();
+        // SAFETY: as above.
+        let s = unsafe { &mut *STATE.get() };
+        drain(&mut s.rises, &RISES, buf)
+    }
+
+    fn overflow(&self) -> bool {
+        // SAFETY: as above.
+        unsafe { &*STATE.get() }.overflow
+    }
+
+    fn reset(&mut self) {
+        Self::poll_accumulate();
+        // SAFETY: as above.
+        let s = unsafe { &mut *STATE.get() };
+        s.falls.drained = s.falls.written;
+        s.rises.drained = s.rises.written;
+        s.overflow = false;
+    }
+}

--- a/firmware/host-ch32/src/providers/mod.rs
+++ b/firmware/host-ch32/src/providers/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod clocks;
 pub mod deadline;
+pub mod edges;
 pub mod pins;
 pub mod ring;
 pub mod tx_wire;

--- a/firmware/host-ch32/src/providers/tx_wire.rs
+++ b/firmware/host-ch32/src/providers/tx_wire.rs
@@ -39,6 +39,7 @@ impl traits::TxWire for TxWire {
                 circ: false,
                 minc: true,
                 pl: dma::Pl::HIGH,
+                size: dma::Size::BITS8,
             },
             usart::data_addr(USART3),
             span.as_ptr() as u32,

--- a/firmware/host-ch32/src/runtime/init.rs
+++ b/firmware/host-ch32/src/runtime/init.rs
@@ -5,8 +5,9 @@
 use ch32_metapac::USART3;
 use osc_protocol::wire::BaudRate;
 
-use crate::hal::{dma, pfic, systick, usart, usbhs};
+use crate::hal::{dma, pfic, systick, tim2cap, usart, usbhs};
 use crate::providers::clocks::Clocks;
+use crate::providers::edges::Edges;
 use crate::providers::pins::Pins;
 use crate::providers::ring::RxRing;
 use crate::providers::usart_baud::brr_for;
@@ -39,12 +40,47 @@ pub fn bringup() -> bool {
             // RX outranks the TX arm so an inbound byte's drain is never
             // deferred behind a TX burst (the arbiter preempts per-beat).
             pl: dma::Pl::VERYHIGH,
+            size: dma::Size::BITS8,
         },
         usart::data_addr(USART3),
         RxRing::base_addr(),
         RxRing::LEN as u16,
     );
     dma::enable(dma::Channel::CH3);
+
+    // The instrument's edge stopwatch: TIM2 IC on the bus pin, both
+    // polarities into circular rings, armed once here and never re-armed
+    // (the spike's capture-mangle lesson).
+    for (ch, paddr, maddr) in [
+        (
+            dma::Channel::CH1,
+            tim2cap::fall_capture_addr(),
+            Edges::falls_addr(),
+        ),
+        (
+            dma::Channel::CH7,
+            tim2cap::rise_capture_addr(),
+            Edges::rises_addr(),
+        ),
+    ] {
+        dma::configure(
+            ch,
+            &dma::Config {
+                dir: dma::Dir::FROMPERIPHERAL,
+                circ: true,
+                minc: true,
+                // Below the RX ring, above nothing that matters: capture
+                // beats are sparse (>= 2 bit-times apart per polarity).
+                pl: dma::Pl::MEDIUM,
+                size: dma::Size::BITS16,
+            },
+            paddr,
+            maddr,
+            Edges::LEN as u16,
+        );
+        dma::enable(ch);
+    }
+    tim2cap::init();
 
     usbhs::init_device();
 

--- a/firmware/host-ch32/src/runtime/registry.rs
+++ b/firmware/host-ch32/src/runtime/registry.rs
@@ -10,6 +10,7 @@ use osc_host::traits::Providers;
 use osc_protocol::wire::BaudRate;
 
 use crate::providers::deadline::Deadline;
+use crate::providers::edges::Edges;
 use crate::providers::ring::RxRing;
 use crate::providers::tx_wire::TxWire;
 use crate::providers::usart_baud::UsartBaud;
@@ -23,6 +24,7 @@ impl Providers for LinkEProviders {
     type Deadline = Deadline;
     type Tx = TxWire;
     type Baud = UsartBaud;
+    type Edges = Edges;
 }
 
 pub type Bus = HostBus<LinkEProviders>;
@@ -49,7 +51,9 @@ impl Drivers {
         // SAFETY: see fn doc.
         let bus = unsafe { &mut *BUS.0.get() };
         debug_assert!(bus.is_none(), "Drivers: bus already installed");
-        *bus = Some(HostBus::new(RxRing, Deadline, TxWire, UsartBaud, boot_rate));
+        *bus = Some(HostBus::new(
+            RxRing, Deadline, TxWire, UsartBaud, Edges, boot_rate,
+        ));
     }
 
     /// SAFETY: bringup installs the bus before any IRQ unmasks; runtime

--- a/firmware/host-ch32/src/runtime/run.rs
+++ b/firmware/host-ch32/src/runtime/run.rs
@@ -6,6 +6,7 @@ use osc_host::link::{AdapterRequest, LinkServer, RecordSink};
 use osc_host::traits::tick_reached;
 
 use crate::hal::systick;
+use crate::providers::edges::Edges;
 use crate::providers::pins;
 use crate::runtime::{Drivers, iap, init, usb::UsbDevice};
 
@@ -95,6 +96,9 @@ pub fn run() -> ! {
 
     loop {
         usb.poll();
+        // Keep the edge-capture lap accounting honest (main-loop cadence
+        // is the overflow detector's sampling clock).
+        Edges::poll_accumulate();
 
         // Inbound pipe bytes -> server -> engine. Held NAK-parked until
         // the queue can absorb the worst-case reply burst.

--- a/firmware/lib/host/src/engine/mod.rs
+++ b/firmware/lib/host/src/engine/mod.rs
@@ -20,6 +20,9 @@ use osc_protocol::reply::FrameBuf;
 use osc_protocol::wire::{self, BaudRate, Id, Inst};
 
 use crate::traits::{Deadline, Providers, RxRing, TxWire, UsartBaud, tick_reached};
+
+pub use wireop::WIRE_CAP;
+mod wireop;
 use framer::{Framer, Step};
 use shape::{InvalidReason, Replies, Shape};
 
@@ -103,6 +106,11 @@ pub enum Event<'a> {
         payload: FrameBytes<'a>,
     },
     Done(Terminal),
+    /// An instrument wire op (raw send / burst / pulse) finished; `tick` is
+    /// the wire-release moment.
+    WireDone {
+        tick: u32,
+    },
 }
 
 enum State {
@@ -119,6 +127,10 @@ enum State {
     /// Rescue pulse held dominant until the deadline.
     RescueHold,
     Awaiting,
+    /// Instrument raw TX in flight (wireop); `on_tx_complete` advances it.
+    WireTx,
+    /// Instrument low pulse held until the deadline.
+    WirePulse,
 }
 
 /// Rescue pulse hold: the sec 9.1 300 us sampler floor plus generous
@@ -156,6 +168,9 @@ pub struct HostBus<P: Providers> {
     last_cursor: u16,
     evidence: WireEvidence,
     pending_done: Option<Terminal>,
+    edges: P::Edges,
+    wire_job: wireop::WireJob,
+    pending_wire_done: Option<u32>,
 }
 
 impl<P: Providers> HostBus<P> {
@@ -165,6 +180,7 @@ impl<P: Providers> HostBus<P> {
         deadline: P::Deadline,
         tx: P::Tx,
         baud: P::Baud,
+        edges: P::Edges,
         rate: BaudRate,
     ) -> Self {
         Self {
@@ -185,11 +201,27 @@ impl<P: Providers> HostBus<P> {
             last_cursor: 0,
             evidence: WireEvidence::default(),
             pending_done: None,
+            edges,
+            wire_job: wireop::WireJob::new(),
+            pending_wire_done: None,
         }
     }
 
+    /// The instrument's capture organ, link-layer served (edge drains).
+    pub fn edges(&mut self) -> &mut P::Edges {
+        &mut self.edges
+    }
+
+    /// Current engine tick -- the drain reply's unwrap reference.
+    pub fn now(&self) -> u32 {
+        self.deadline.now()
+    }
+
     pub fn submit(&mut self, cmd: Command<'_>) -> Result<(), SubmitError> {
-        if !matches!(self.state, State::Idle) || self.pending_done.is_some() {
+        if !matches!(self.state, State::Idle)
+            || self.pending_done.is_some()
+            || self.pending_wire_done.is_some()
+        {
             return Err(SubmitError::Busy);
         }
         self.evidence = WireEvidence::default();
@@ -239,6 +271,10 @@ impl<P: Providers> HostBus<P> {
     /// Chip TC ISR: the armed frame span drained (never fired for bare
     /// breaks -- see [`TxWire::send_break`]).
     pub fn on_tx_complete(&mut self) {
+        if matches!(self.state, State::WireTx) {
+            self.wire_advance();
+            return;
+        }
         if !matches!(self.state, State::Transmitting) {
             return;
         }
@@ -300,9 +336,12 @@ impl<P: Providers> HostBus<P> {
         if let Some(done) = self.pending_done.take() {
             return Some(Event::Done(done));
         }
+        if let Some(tick) = self.pending_wire_done.take() {
+            return Some(Event::WireDone { tick });
+        }
         let now = self.deadline.now();
         match self.state {
-            State::Idle | State::Transmitting | State::Training { .. } => {}
+            State::Idle | State::Transmitting | State::Training { .. } | State::WireTx => {}
             State::Pacing => {
                 if tick_reached(now, self.deadline_at) {
                     self.start_tx();
@@ -317,7 +356,15 @@ impl<P: Providers> HostBus<P> {
                     self.finish(Outcome::Sent);
                 }
             }
+            State::WirePulse => {
+                if tick_reached(now, self.deadline_at) {
+                    self.wire_poll_pulse();
+                }
+            }
             State::Awaiting => return self.poll_await(now),
+        }
+        if let Some(tick) = self.pending_wire_done.take() {
+            return Some(Event::WireDone { tick });
         }
         self.pending_done.take().map(Event::Done)
     }

--- a/firmware/lib/host/src/engine/tests.rs
+++ b/firmware/lib/host/src/engine/tests.rs
@@ -9,7 +9,7 @@ use osc_protocol::wire::{BaudRate, Id, Inst, Opcode, ResultCode, UID_LEN};
 
 use super::*;
 use crate::testutil::{
-    FakeBaud, FakeDeadline, FakeRing, FakeWire, TestProviders, WireOp, sealed_status,
+    FakeBaud, FakeDeadline, FakeEdges, FakeRing, FakeWire, TestProviders, WireOp, sealed_status,
 };
 
 struct Rig {
@@ -30,6 +30,7 @@ fn rig() -> Rig {
         clock.clone(),
         wire.clone(),
         baud.clone(),
+        FakeEdges::default(),
         BaudRate::B1000000,
     );
     Rig {
@@ -460,4 +461,123 @@ fn response_deadline_setting_stretches_the_window() {
     let _ = expect_status(&mut r);
     let t = expect_done(&mut r);
     assert_eq!(t.outcome, Outcome::Complete);
+}
+
+fn expect_wire_done(r: &mut Rig) -> u32 {
+    match r.bus.poll() {
+        Some(Event::WireDone { tick }) => tick,
+        other => panic!("expected WireDone, got {other:?}"),
+    }
+}
+
+#[test]
+fn wire_send_is_break_plus_raw_bytes_then_wire_done() {
+    let mut r = rig();
+    // Deliberately not a legal frame -- raw means raw.
+    r.bus.wire_send(&[0xDE, 0xAD]).unwrap();
+    let log = r.wire.log();
+    assert_eq!(log[0], WireOp::Claim);
+    assert_eq!(log[1], WireOp::Break);
+    assert_eq!(log[2], WireOp::Send(vec![0xDE, 0xAD]));
+    assert!(r.bus.poll().is_none(), "in flight until TC");
+
+    r.clock.advance(70);
+    r.bus.on_tx_complete();
+    assert_eq!(r.wire.log().last(), Some(&WireOp::Release));
+    assert_eq!(expect_wire_done(&mut r), 70, "tick = wire release moment");
+    assert!(r.bus.poll().is_none(), "consumed");
+}
+
+#[test]
+fn wire_burst_chains_frames_on_tc() {
+    let mut r = rig();
+    r.bus.wire_burst(&[2, 0xAA, 0xBB, 1, 0xCC]).unwrap();
+    let log = r.wire.log();
+    assert_eq!(
+        log,
+        vec![WireOp::Claim, WireOp::Break, WireOp::Send(vec![0xAA, 0xBB])]
+    );
+
+    r.bus.on_tx_complete();
+    let log = r.wire.log();
+    assert_eq!(&log[3..], &[WireOp::Break, WireOp::Send(vec![0xCC])]);
+    assert!(r.bus.poll().is_none(), "second frame still in flight");
+
+    r.bus.on_tx_complete();
+    assert_eq!(r.wire.log().last(), Some(&WireOp::Release));
+    let _ = expect_wire_done(&mut r);
+}
+
+#[test]
+fn wire_pulse_holds_low_until_its_deadline() {
+    let mut r = rig();
+    r.bus.wire_pulse_low(300).unwrap();
+    let log = r.wire.log();
+    assert_eq!(log, vec![WireOp::Claim, WireOp::HoldLow]);
+
+    r.clock.advance(299);
+    assert!(r.bus.poll().is_none(), "still held");
+    r.clock.advance(1);
+    let tick = expect_wire_done(&mut r);
+    assert_eq!(tick, 300);
+    assert_eq!(r.wire.log().last(), Some(&WireOp::Release));
+}
+
+#[test]
+fn wire_ops_and_commands_reject_each_other_as_busy() {
+    let mut r = rig();
+    r.bus.wire_send(&[0x55]).unwrap();
+    let (id, inst) = ping(1);
+    assert_eq!(
+        r.bus.submit(Command::Exchange {
+            id,
+            inst,
+            payload: &[]
+        }),
+        Err(SubmitError::Busy),
+        "command rejected while a wire op owns the wire"
+    );
+    assert_eq!(r.bus.wire_send(&[0x55]), Err(SubmitError::Busy));
+    r.bus.on_tx_complete();
+    assert_eq!(
+        r.bus.wire_pulse_low(10),
+        Err(SubmitError::Busy),
+        "unconsumed WireDone still owns the engine"
+    );
+    let _ = expect_wire_done(&mut r);
+    r.bus.wire_pulse_low(10).unwrap();
+
+    // And the mirror: a command in flight rejects wire ops.
+    let mut r = rig();
+    r.bus
+        .submit(Command::Exchange {
+            id,
+            inst,
+            payload: &[],
+        })
+        .unwrap();
+    assert_eq!(r.bus.wire_send(&[0x55]), Err(SubmitError::Busy));
+}
+
+#[test]
+fn malformed_wire_ops_reject_without_touching_the_wire() {
+    let mut r = rig();
+    assert!(matches!(r.bus.wire_send(&[]), Err(SubmitError::Invalid(_))));
+    assert!(matches!(
+        r.bus.wire_burst(&[]),
+        Err(SubmitError::Invalid(_))
+    ));
+    assert!(matches!(
+        r.bus.wire_burst(&[0]),
+        Err(SubmitError::Invalid(_)),
+    ));
+    assert!(matches!(
+        r.bus.wire_burst(&[3, 0xAA]),
+        Err(SubmitError::Invalid(_)),
+    ));
+    assert!(matches!(
+        r.bus.wire_pulse_low(0),
+        Err(SubmitError::Invalid(_))
+    ));
+    assert!(r.wire.log().is_empty(), "nothing reached the wire");
 }

--- a/firmware/lib/host/src/engine/wireop.rs
+++ b/firmware/lib/host/src/engine/wireop.rs
@@ -1,0 +1,153 @@
+//! Instrument raw wire ops: the engine-owned side door behind the link
+//! 0x6x family. Deliberately outside the command pipeline -- no Shape
+//! validation (malformed frames are the point), no reply awaits, no sec
+//! 3.4 pacing. What it shares with commands is the wire itself: the same
+//! TxWire provider and drive discipline, the same TC completion routing,
+//! and the one-owner rule -- a wire op and a command reject each other as
+//! Busy through the same State machine.
+
+use crate::traits::{Deadline, Providers, TxWire};
+
+use super::shape::InvalidReason;
+use super::{HostBus, State, SubmitError};
+
+/// Raw TX staging bound (burst streams included).
+pub const WIRE_CAP: usize = 640;
+
+enum Mode {
+    /// One break-framed span: the whole buffer.
+    Single,
+    /// Length-prefixed frames (`len(1) bytes` repeated), fired
+    /// back-to-back: each TC chains the next break + span.
+    Stream,
+}
+
+pub(super) struct WireJob {
+    buf: [u8; WIRE_CAP],
+    len: usize,
+    cursor: usize,
+    mode: Mode,
+}
+
+impl WireJob {
+    pub(super) fn new() -> Self {
+        Self {
+            buf: [0; WIRE_CAP],
+            len: 0,
+            cursor: 0,
+            mode: Mode::Single,
+        }
+    }
+}
+
+impl<P: Providers> HostBus<P> {
+    fn wire_ready(&self) -> Result<(), SubmitError> {
+        if !matches!(self.state, State::Idle)
+            || self.pending_done.is_some()
+            || self.pending_wire_done.is_some()
+        {
+            return Err(SubmitError::Busy);
+        }
+        Ok(())
+    }
+
+    /// One law break + `bytes`, raw. Completion surfaces as
+    /// [`Event::WireDone`](super::Event::WireDone).
+    pub fn wire_send(&mut self, bytes: &[u8]) -> Result<(), SubmitError> {
+        self.wire_ready()?;
+        if bytes.is_empty() {
+            // A bare break never raises TC (TxWire contract) -- an empty
+            // send would wedge WireTx, so it is not a legal op.
+            return Err(SubmitError::Invalid(InvalidReason::BadPayload));
+        }
+        if bytes.len() > WIRE_CAP {
+            return Err(SubmitError::Invalid(InvalidReason::TooLong));
+        }
+        self.wire_job.buf[..bytes.len()].copy_from_slice(bytes);
+        self.wire_job.len = bytes.len();
+        self.wire_job.mode = Mode::Single;
+        self.tx.claim();
+        self.tx.send_break();
+        self.tx.send(&self.wire_job.buf[..self.wire_job.len]);
+        self.state = State::WireTx;
+        Ok(())
+    }
+
+    /// Length-prefixed frames fired back-to-back, each break-framed. The
+    /// inter-frame gap is one TC service -- microseconds, under a character
+    /// time at every operational baud.
+    pub fn wire_burst(&mut self, stream: &[u8]) -> Result<(), SubmitError> {
+        self.wire_ready()?;
+        if stream.len() > WIRE_CAP {
+            return Err(SubmitError::Invalid(InvalidReason::TooLong));
+        }
+        let mut at = 0usize;
+        while at < stream.len() {
+            let flen = stream[at] as usize;
+            if flen == 0 || at + 1 + flen > stream.len() {
+                return Err(SubmitError::Invalid(InvalidReason::BadPayload));
+            }
+            at += 1 + flen;
+        }
+        if at == 0 {
+            return Err(SubmitError::Invalid(InvalidReason::BadPayload));
+        }
+        self.wire_job.buf[..stream.len()].copy_from_slice(stream);
+        self.wire_job.len = stream.len();
+        self.wire_job.cursor = 0;
+        self.wire_job.mode = Mode::Stream;
+        self.tx.claim();
+        self.wire_next_frame();
+        self.state = State::WireTx;
+        Ok(())
+    }
+
+    /// Hold the wire dominant for `us` microseconds (any width -- the
+    /// engine's rescue verb owns the protocol-shaped 1 ms pulse; this is
+    /// the instrument's sweepable version).
+    pub fn wire_pulse_low(&mut self, us: u16) -> Result<(), SubmitError> {
+        self.wire_ready()?;
+        if us == 0 {
+            return Err(SubmitError::Invalid(InvalidReason::BadPayload));
+        }
+        self.tx.claim();
+        self.tx.hold_low();
+        self.state = State::WirePulse;
+        self.arm(
+            self.deadline
+                .now()
+                .wrapping_add(us as u32 * P::Deadline::TICKS_PER_US),
+        );
+        Ok(())
+    }
+
+    /// TC while `WireTx`: chain the next burst frame or close the op.
+    pub(super) fn wire_advance(&mut self) {
+        let more =
+            matches!(self.wire_job.mode, Mode::Stream) && self.wire_job.cursor < self.wire_job.len;
+        if more {
+            self.wire_next_frame();
+        } else {
+            self.wire_finish();
+        }
+    }
+
+    /// Pulse deadline reached: release and close.
+    pub(super) fn wire_poll_pulse(&mut self) {
+        self.wire_finish();
+    }
+
+    fn wire_next_frame(&mut self) {
+        let at = self.wire_job.cursor;
+        let flen = self.wire_job.buf[at] as usize;
+        self.wire_job.cursor = at + 1 + flen;
+        self.tx.send_break();
+        self.tx.send(&self.wire_job.buf[at + 1..at + 1 + flen]);
+    }
+
+    fn wire_finish(&mut self) {
+        self.tx.release();
+        self.state = State::Idle;
+        self.pending_wire_done = Some(self.deadline.now());
+    }
+}

--- a/firmware/lib/host/src/link/record.rs
+++ b/firmware/lib/host/src/link/record.rs
@@ -16,8 +16,10 @@ use crate::engine::{Outcome, Terminal};
 /// Record type bytes. `0x00..=0x3F` client->adapter, `0x80..=0xBF`
 /// adapter->client. Reserved families: `0x40..=0x4F` firmware update
 /// (client->adapter `0x40..=0x47`, adapter->client `0x48..=0x4F`) and
-/// `0x60..=0x6F` bench (the IF1 personality; deliberate protocol-breaking
-/// lives only there).
+/// `0x60..=0x6F` the instrument family (client->adapter `0x60..=0x67`,
+/// adapter->client `0x68..=0x6F`) -- rails, raw wire verbs, edge-capture
+/// drains. Unconditional in every build; deliberate protocol-breaking
+/// lives only here, never in SUBMIT (whose Shape validation stands).
 pub const REC_HELLO: u8 = 0x00;
 pub const REC_SUBMIT: u8 = 0x01;
 /// Hand the adapter to the resident bootloader (the mandatory
@@ -32,6 +34,28 @@ pub const REC_ENTER_BOOTLOADER: u8 = 0x40;
 /// bit0 = 3V3 on, bit1 = 5V on -- absolute state, so queue last-wins is
 /// sound. Answered by [`REC_RAILS_ACK`] echoing the applied state.
 pub const REC_SET_RAILS: u8 = 0x60;
+/// Instrument raw TX: one law break + the body's raw bytes, engine command
+/// pipeline bypassed (no Shape validation -- malformed frames are the
+/// point). Body: `seq(2 LE) bytes(1..)`. Answered by [`REC_WIRE_DONE`] at
+/// wire release, or REJECTED (busy while a SUBMIT command or another wire
+/// op is outstanding, and vice versa -- one wire owner at a time).
+pub const REC_WIRE_SEND: u8 = 0x61;
+/// Instrument burst: length-prefixed frames fired back-to-back, each
+/// break-framed, chained on TC (gap = one TC service, under a character
+/// time at every operational baud). Body: `seq(2 LE) [len(1) bytes]+`.
+pub const REC_WIRE_BURST: u8 = 0x62;
+/// Instrument dominant-low pulse of arbitrary width (the engine's rescue
+/// verb owns the protocol-shaped pulse; this is the sweepable one).
+/// Body: `seq(2 LE) us(2 LE)`.
+pub const REC_WIRE_PULSE: u8 = 0x63;
+/// Drain captured wire edges (both polarities, capture order). Body:
+/// `max(1)` = per-ring entry cap, clamped to [`DRAIN_MAX`]. Answered by
+/// [`REC_EDGES`]. Consumer-paced: drain at least every few ms of wire
+/// activity or the overflow flag goes up (and stays, sticky).
+pub const REC_EDGE_DRAIN: u8 = 0x64;
+/// Drop undrained captures + the overflow flag. Answered by
+/// [`REC_CAPTURE_ACK`].
+pub const REC_CAPTURE_RESET: u8 = 0x65;
 pub const REC_INFO: u8 = 0x80;
 pub const REC_STATUS: u8 = 0x81;
 pub const REC_TERMINAL: u8 = 0x82;
@@ -40,6 +64,21 @@ pub const REC_REJECTED: u8 = 0x83;
 pub const REC_UNKNOWN: u8 = 0x84;
 pub const REC_BOOTLOADER_ACK: u8 = 0x48;
 pub const REC_RAILS_ACK: u8 = 0x68;
+/// A wire op (send/burst/pulse) finished. Body: `seq(2 LE) tick(4 LE)` --
+/// the wire-release engine tick.
+pub const REC_WIRE_DONE: u8 = 0x69;
+/// Edge drain reply. Body: `flags(1: bit0 overflow) now(4 LE)
+/// fall_n(1) rise_n(1) falls(fall_n x u16 LE) rises(rise_n x u16 LE)`.
+/// Edge ticks are the engine tick domain's low 16 bits; `now` is the
+/// 32-bit drain moment, the client's unwrap reference (unwrap ambiguity
+/// resets across gaps longer than one u16 wrap -- irrelevant within an
+/// exchange, which is all the instrument measures).
+pub const REC_EDGES: u8 = 0x6C;
+pub const REC_CAPTURE_ACK: u8 = 0x6D;
+
+/// Per-ring entry cap on one edge drain (keeps the reply inside the
+/// outbound scratch; the BBATCH-style polled-drain precedent).
+pub const DRAIN_MAX: usize = 64;
 
 /// SUBMIT verb byte (body: `seq(2 LE) verb(1) args`).
 pub const VERB_EXCHANGE: u8 = 0x00; // args: id(1) inst(1) payload(rest)
@@ -116,6 +155,38 @@ pub fn rails_ack(dst: &mut [u8], state: u8) -> &[u8] {
     dst[2] = REC_RAILS_ACK;
     dst[3] = state;
     sealed(dst, 2)
+}
+
+pub fn wire_done(dst: &mut [u8], seq: u16, tick: u32) -> &[u8] {
+    dst[2] = REC_WIRE_DONE;
+    dst[3..5].copy_from_slice(&seq.to_le_bytes());
+    dst[5..9].copy_from_slice(&tick.to_le_bytes());
+    sealed(dst, 7)
+}
+
+pub fn edges<'a>(
+    dst: &'a mut [u8],
+    overflow: bool,
+    now: u32,
+    falls: &[u16],
+    rises: &[u16],
+) -> &'a [u8] {
+    dst[2] = REC_EDGES;
+    dst[3] = overflow as u8;
+    dst[4..8].copy_from_slice(&now.to_le_bytes());
+    dst[8] = falls.len() as u8;
+    dst[9] = rises.len() as u8;
+    let mut at = 10;
+    for &t in falls.iter().chain(rises) {
+        dst[at..at + 2].copy_from_slice(&t.to_le_bytes());
+        at += 2;
+    }
+    sealed(dst, at - 2)
+}
+
+pub fn capture_ack(dst: &mut [u8]) -> &[u8] {
+    dst[2] = REC_CAPTURE_ACK;
+    sealed(dst, 1)
 }
 
 /// STATUS: `seq(2) slot(1) id(1) inst(1) payload`. The payload arrives as

--- a/firmware/lib/host/src/link/server.rs
+++ b/firmware/lib/host/src/link/server.rs
@@ -6,9 +6,9 @@
 use osc_protocol::wire::{BaudRate, Id, Inst};
 
 use crate::engine::{Command, Event, HostBus, SubmitError};
-use crate::traits::{Deadline, Providers};
+use crate::traits::{Deadline, EdgeCapture, Providers};
 
-use super::record::{self, SEQ_NONE};
+use super::record::{self, DRAIN_MAX, SEQ_NONE};
 
 /// Where outbound records go (USB IN endpoint queue, a test log, a DES
 /// pipe). Called once per complete record.
@@ -39,6 +39,8 @@ pub struct LinkServer {
     rx_len: usize,
     /// The seq owning the engine's outstanding command.
     active: Option<u16>,
+    /// The seq owning the outstanding instrument wire op.
+    wire_active: Option<u16>,
     adapter_req: Option<AdapterRequest>,
     out: [u8; OUT_CAP],
 }
@@ -55,6 +57,7 @@ impl LinkServer {
             rx: [0; RX_CAP],
             rx_len: 0,
             active: None,
+            wire_active: None,
             adapter_req: None,
             out: [0; OUT_CAP],
         }
@@ -116,6 +119,10 @@ impl LinkServer {
                     let seq = self.active.take().unwrap_or(SEQ_NONE);
                     sink.record(record::terminal(&mut self.out, seq, &t));
                 }
+                Some(Event::WireDone { tick }) => {
+                    let seq = self.wire_active.take().unwrap_or(SEQ_NONE);
+                    sink.record(record::wire_done(&mut self.out, seq, tick));
+                }
                 None => return,
             }
         }
@@ -139,6 +146,7 @@ impl LinkServer {
             }
             handle(
                 &mut self.active,
+                &mut self.wire_active,
                 &mut self.adapter_req,
                 &self.rx[2..2 + len],
                 bus,
@@ -154,6 +162,7 @@ impl LinkServer {
 /// One complete record (type + body).
 fn handle<P: Providers>(
     active: &mut Option<u16>,
+    wire_active: &mut Option<u16>,
     adapter_req: &mut Option<AdapterRequest>,
     rec: &[u8],
     bus: &mut HostBus<P>,
@@ -174,6 +183,52 @@ fn handle<P: Providers>(
                 v5: rec[1] & 2 != 0,
             });
             sink.record(record::rails_ack(out, rec[1] & 0x03));
+        }
+        record::REC_WIRE_SEND | record::REC_WIRE_BURST | record::REC_WIRE_PULSE => {
+            if rec.len() < 3 {
+                sink.record(record::unknown(out, rec[0]));
+                return;
+            }
+            let seq = u16::from_le_bytes([rec[1], rec[2]]);
+            let body = &rec[3..];
+            let res = match rec[0] {
+                record::REC_WIRE_SEND => bus.wire_send(body),
+                record::REC_WIRE_BURST => bus.wire_burst(body),
+                _ if body.len() == 2 => bus.wire_pulse_low(u16::from_le_bytes([body[0], body[1]])),
+                _ => {
+                    sink.record(record::rejected(out, seq, record::REASON_MALFORMED));
+                    return;
+                }
+            };
+            match res {
+                Ok(()) => *wire_active = Some(seq),
+                Err(SubmitError::Busy) => {
+                    sink.record(record::rejected(out, seq, record::REASON_BUSY));
+                }
+                Err(SubmitError::Invalid(_)) => {
+                    sink.record(record::rejected(out, seq, record::REASON_MALFORMED));
+                }
+            }
+        }
+        record::REC_EDGE_DRAIN if rec.len() >= 2 => {
+            let max = (rec[1] as usize).min(DRAIN_MAX);
+            let mut falls = [0u16; DRAIN_MAX];
+            let mut rises = [0u16; DRAIN_MAX];
+            let fn_ = bus.edges().drain_falls(&mut falls[..max]);
+            let rn = bus.edges().drain_rises(&mut rises[..max]);
+            let overflow = bus.edges().overflow();
+            let now = bus.now();
+            sink.record(record::edges(
+                out,
+                overflow,
+                now,
+                &falls[..fn_],
+                &rises[..rn],
+            ));
+        }
+        record::REC_CAPTURE_RESET => {
+            bus.edges().reset();
+            sink.record(record::capture_ack(out));
         }
         record::REC_SUBMIT => {
             if rec.len() < 4 {
@@ -230,7 +285,7 @@ mod tests {
     use super::super::record::*;
     use super::*;
     use crate::testutil::{
-        FakeBaud, FakeDeadline, FakeRing, FakeWire, TestProviders, WireOp, sealed_status,
+        FakeBaud, FakeDeadline, FakeEdges, FakeRing, FakeWire, TestProviders, WireOp, sealed_status,
     };
 
     #[derive(Default)]
@@ -248,6 +303,7 @@ mod tests {
         ring: FakeRing,
         clock: FakeDeadline,
         wire: FakeWire,
+        edges: FakeEdges,
         sink: Sink,
     }
 
@@ -256,11 +312,13 @@ mod tests {
         let clock = FakeDeadline::new();
         let wire = FakeWire::default();
         let baud = FakeBaud::default();
+        let edges = FakeEdges::default();
         let bus = HostBus::new(
             ring.clone(),
             clock.clone(),
             wire.clone(),
             baud.clone(),
+            edges.clone(),
             BaudRate::B1000000,
         );
         Rig {
@@ -269,6 +327,7 @@ mod tests {
             ring,
             clock,
             wire,
+            edges,
             sink: Sink::default(),
         }
     }
@@ -456,5 +515,135 @@ mod tests {
         let term = r.sink.0.last().unwrap();
         assert_eq!(term[5], OUTCOME_TIMEOUT);
         assert_eq!(term[6], 0, "missing slot");
+    }
+
+    #[test]
+    fn wire_send_round_trips_on_its_seq() {
+        let mut r = rig();
+        // seq 0x0BB8, raw bytes DE AD -- no Shape validation applies.
+        r.server.on_pipe(
+            &rec(&[REC_WIRE_SEND, 0xB8, 0x0B, 0xDE, 0xAD]),
+            &mut r.bus,
+            &mut r.sink,
+        );
+        assert!(r.sink.0.is_empty(), "accepted: no reply until TC");
+        assert_eq!(
+            r.wire.log(),
+            vec![WireOp::Claim, WireOp::Break, WireOp::Send(vec![0xDE, 0xAD])]
+        );
+
+        r.clock.advance(55);
+        r.bus.on_tx_complete();
+        r.server.pump(&mut r.bus, &mut r.sink);
+        let done = r.sink.0.last().unwrap();
+        assert_eq!(done[2], REC_WIRE_DONE);
+        assert_eq!(u16::from_le_bytes([done[3], done[4]]), 0x0BB8);
+        assert_eq!(u32::from_le_bytes([done[5], done[6], done[7], done[8]]), 55);
+
+        // Retired: the next wire op is accepted.
+        r.server.on_pipe(
+            &rec(&[REC_WIRE_PULSE, 2, 0, 100, 0]),
+            &mut r.bus,
+            &mut r.sink,
+        );
+        assert_eq!(r.sink.0.len(), 1, "no rejection");
+    }
+
+    #[test]
+    fn wire_ops_and_submits_reject_each_other_busy() {
+        let mut r = rig();
+        r.server
+            .on_pipe(&submit_ping(1, 5), &mut r.bus, &mut r.sink);
+        r.server
+            .on_pipe(&rec(&[REC_WIRE_SEND, 2, 0, 0x55]), &mut r.bus, &mut r.sink);
+        let rej = r.sink.0.last().unwrap();
+        assert_eq!(rej[2], REC_REJECTED);
+        assert_eq!(u16::from_le_bytes([rej[3], rej[4]]), 2);
+        assert_eq!(rej[5], REASON_BUSY);
+
+        let mut r = rig();
+        r.server
+            .on_pipe(&rec(&[REC_WIRE_SEND, 2, 0, 0x55]), &mut r.bus, &mut r.sink);
+        r.server
+            .on_pipe(&submit_ping(1, 5), &mut r.bus, &mut r.sink);
+        let rej = r.sink.0.last().unwrap();
+        assert_eq!(rej[2], REC_REJECTED);
+        assert_eq!(rej[5], REASON_BUSY);
+    }
+
+    #[test]
+    fn malformed_wire_ops_reject_on_their_seq() {
+        let mut r = rig();
+        // Empty send body: a bare break never raises TC.
+        r.server
+            .on_pipe(&rec(&[REC_WIRE_SEND, 7, 0]), &mut r.bus, &mut r.sink);
+        let rej = r.sink.0.last().unwrap();
+        assert_eq!(rej[2], REC_REJECTED);
+        assert_eq!(rej[5], REASON_MALFORMED);
+
+        // Burst stream with a truncated frame.
+        r.server.on_pipe(
+            &rec(&[REC_WIRE_BURST, 8, 0, 5, 0xAA]),
+            &mut r.bus,
+            &mut r.sink,
+        );
+        assert_eq!(r.sink.0.last().unwrap()[5], REASON_MALFORMED);
+
+        // Pulse body must be exactly two bytes.
+        r.server
+            .on_pipe(&rec(&[REC_WIRE_PULSE, 9, 0, 10]), &mut r.bus, &mut r.sink);
+        assert_eq!(r.sink.0.last().unwrap()[5], REASON_MALFORMED);
+        assert!(r.wire.log().is_empty(), "nothing reached the wire");
+    }
+
+    #[test]
+    fn edge_drain_ships_staged_captures_and_the_drain_anchor() {
+        let mut r = rig();
+        r.edges.stage(&[100, 300, 65500], &[110, 310]);
+        r.clock.advance(0x0001_0032);
+        r.server
+            .on_pipe(&rec(&[REC_EDGE_DRAIN, 64]), &mut r.bus, &mut r.sink);
+        let e = r.sink.0.last().unwrap();
+        assert_eq!(e[2], REC_EDGES);
+        assert_eq!(e[3], 0, "no overflow");
+        assert_eq!(
+            u32::from_le_bytes([e[4], e[5], e[6], e[7]]),
+            0x0001_0032,
+            "now = the unwrap anchor"
+        );
+        assert_eq!(e[8], 3, "falls");
+        assert_eq!(e[9], 2, "rises");
+        let t = |i: usize| u16::from_le_bytes([e[10 + 2 * i], e[11 + 2 * i]]);
+        assert_eq!([t(0), t(1), t(2)], [100, 300, 65500]);
+        assert_eq!([t(3), t(4)], [110, 310]);
+
+        // Drained: a second drain answers empty.
+        r.server
+            .on_pipe(&rec(&[REC_EDGE_DRAIN, 64]), &mut r.bus, &mut r.sink);
+        let e = r.sink.0.last().unwrap();
+        assert_eq!((e[8], e[9]), (0, 0));
+    }
+
+    #[test]
+    fn edge_drain_clamps_and_reports_sticky_overflow() {
+        let mut r = rig();
+        let many: Vec<u16> = (0..100).collect();
+        r.edges.stage(&many, &[]);
+        r.edges.set_overflow();
+        r.server
+            .on_pipe(&rec(&[REC_EDGE_DRAIN, 255]), &mut r.bus, &mut r.sink);
+        let e = r.sink.0.last().unwrap();
+        assert_eq!(e[8] as usize, DRAIN_MAX, "clamped per ring");
+        assert_eq!(e[3], 1, "overflow flagged");
+
+        // Reset clears captures + the flag.
+        r.server
+            .on_pipe(&rec(&[REC_CAPTURE_RESET]), &mut r.bus, &mut r.sink);
+        assert_eq!(r.sink.0.last().unwrap()[2], REC_CAPTURE_ACK);
+        assert_eq!(r.edges.resets(), 1);
+        r.server
+            .on_pipe(&rec(&[REC_EDGE_DRAIN, 64]), &mut r.bus, &mut r.sink);
+        let e = r.sink.0.last().unwrap();
+        assert_eq!((e[3], e[8], e[9]), (0, 0, 0));
     }
 }

--- a/firmware/lib/host/src/testutil.rs
+++ b/firmware/lib/host/src/testutil.rs
@@ -154,12 +154,81 @@ impl traits::UsartBaud for FakeBaud {
     }
 }
 
+struct EdgeState {
+    falls: Vec<u16>,
+    rises: Vec<u16>,
+    overflow: bool,
+    resets: u32,
+}
+
+/// Preloadable edge-capture fake: tests stage ticks, drains pop in order.
+#[derive(Clone, Default)]
+pub struct FakeEdges(Rc<RefCell<Option<EdgeState>>>);
+
+impl FakeEdges {
+    fn state(&self) -> core::cell::RefMut<'_, EdgeState> {
+        core::cell::RefMut::map(self.0.borrow_mut(), |s| {
+            s.get_or_insert_with(|| EdgeState {
+                falls: Vec::new(),
+                rises: Vec::new(),
+                overflow: false,
+                resets: 0,
+            })
+        })
+    }
+
+    pub fn stage(&self, falls: &[u16], rises: &[u16]) {
+        let mut s = self.state();
+        s.falls.extend_from_slice(falls);
+        s.rises.extend_from_slice(rises);
+    }
+
+    pub fn set_overflow(&self) {
+        self.state().overflow = true;
+    }
+
+    pub fn resets(&self) -> u32 {
+        self.state().resets
+    }
+}
+
+impl traits::EdgeCapture for FakeEdges {
+    fn drain_falls(&mut self, buf: &mut [u16]) -> usize {
+        let mut s = self.state();
+        let n = buf.len().min(s.falls.len());
+        buf[..n].copy_from_slice(&s.falls[..n]);
+        s.falls.drain(..n);
+        n
+    }
+
+    fn drain_rises(&mut self, buf: &mut [u16]) -> usize {
+        let mut s = self.state();
+        let n = buf.len().min(s.rises.len());
+        buf[..n].copy_from_slice(&s.rises[..n]);
+        s.rises.drain(..n);
+        n
+    }
+
+    fn overflow(&self) -> bool {
+        self.state().overflow
+    }
+
+    fn reset(&mut self) {
+        let mut s = self.state();
+        s.falls.clear();
+        s.rises.clear();
+        s.overflow = false;
+        s.resets += 1;
+    }
+}
+
 pub struct TestProviders;
 impl traits::Providers for TestProviders {
     type Ring = FakeRing;
     type Deadline = FakeDeadline;
     type Tx = FakeWire;
     type Baud = FakeBaud;
+    type Edges = FakeEdges;
 }
 
 pub fn sealed_status(id: u8, result: ResultCode, payload: &[u8]) -> Vec<u8> {

--- a/firmware/lib/host/src/traits.rs
+++ b/firmware/lib/host/src/traits.rs
@@ -55,12 +55,35 @@ pub trait UsartBaud {
     fn apply(&mut self, baud: BaudRate);
 }
 
+/// Timestamped wire-edge capture, the adapter-as-instrument organ: both
+/// polarities of every wire transition, hardware-stamped on the `Deadline`
+/// tick domain's low 16 bits, captured continuously from boot (never
+/// re-armed -- re-arming mangles captures, linke-edgecap spike). Drains
+/// are consumer-paced like the rest of the instrument surface; a ring lap
+/// between drains sets the sticky overflow flag rather than lying.
+///
+/// Capture-fidelity contract the PC decoder must honor (spike-measured):
+/// data-region edges are exact; break edges are not captured faithfully
+/// (phantoms inside the break span, break fall never present), so frames
+/// anchor on their byte-0 start fall and break geometry is law-derived.
+pub trait EdgeCapture {
+    /// Pop up to `buf.len()` falling-edge ticks in capture order.
+    fn drain_falls(&mut self, buf: &mut [u16]) -> usize;
+    /// Pop up to `buf.len()` rising-edge ticks in capture order.
+    fn drain_rises(&mut self, buf: &mut [u16]) -> usize;
+    /// A ring lapped undrained captures since the last reset -- sticky.
+    fn overflow(&self) -> bool;
+    /// Drop unread captures and the overflow flag.
+    fn reset(&mut self);
+}
+
 /// Role bundle for the `HostBus` composite (driver-pattern sec 5.4).
 pub trait Providers {
     type Ring: RxRing;
     type Deadline: Deadline;
     type Tx: TxWire;
     type Baud: UsartBaud;
+    type Edges: EdgeCapture;
 }
 
 /// Wrap-aware "`a` is at or after `b`" on the u32 tick domain.

--- a/firmware/lib/integration/src/sim/host.rs
+++ b/firmware/lib/integration/src/sim/host.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use std::vec::Vec;
 
 use osc_host::engine::{HostBus, Terminal};
-use osc_host::traits::{Deadline, Providers, RxRing, TxWire, UsartBaud};
+use osc_host::traits::{Deadline, EdgeCapture, Providers, RxRing, TxWire, UsartBaud};
 use osc_protocol::wire::BaudRate;
 use osc_servo_drivers::bus::RESCUE_LOW_US;
 
@@ -31,6 +31,10 @@ pub enum HostEvent {
         payload: Vec<u8>,
     },
     Done(Terminal),
+    /// An instrument wire op closed (raw send / burst / pulse).
+    WireDone {
+        tick: u32,
+    },
 }
 
 pub struct HostRing(pub Rc<RingState>);
@@ -186,6 +190,23 @@ impl UsartBaud for HostUsart {
     }
 }
 
+/// Edge capture has no sim model (hardware-stamped pin transitions are
+/// silicon-only by nature): drains answer empty, honestly.
+pub struct HostEdges;
+
+impl EdgeCapture for HostEdges {
+    fn drain_falls(&mut self, _buf: &mut [u16]) -> usize {
+        0
+    }
+    fn drain_rises(&mut self, _buf: &mut [u16]) -> usize {
+        0
+    }
+    fn overflow(&self) -> bool {
+        false
+    }
+    fn reset(&mut self) {}
+}
+
 /// Provider bundle for the sim-hosted engine.
 pub struct SimHostProviders;
 
@@ -194,6 +215,7 @@ impl Providers for SimHostProviders {
     type Deadline = HostDeadline;
     type Tx = HostWire;
     type Baud = HostUsart;
+    type Edges = HostEdges;
 }
 
 /// The attached host: the production engine plus the shared handles the
@@ -225,6 +247,7 @@ impl SimHost {
                 low_since: Cell::new(None),
             },
             HostUsart(baud.clone()),
+            HostEdges,
             rate,
         );
         Self {

--- a/firmware/lib/integration/src/sim/mod.rs
+++ b/firmware/lib/integration/src/sim/mod.rs
@@ -550,6 +550,9 @@ impl Sim {
                     });
                 }
                 Some(osc_host::engine::Event::Done(t)) => h.events.push(HostEvent::Done(t)),
+                Some(osc_host::engine::Event::WireDone { tick }) => {
+                    h.events.push(HostEvent::WireDone { tick })
+                }
                 None => return,
             }
         }

--- a/tools/adapter-cli/src/main.rs
+++ b/tools/adapter-cli/src/main.rs
@@ -55,6 +55,19 @@ enum Cmd {
     Rails { v3v3: String, v5: String },
     /// Hand the adapter to the WCH bootloader (4348:55e0, wlink-iap).
     Bootloader,
+    /// Instrument raw TX: law break + raw hex bytes, engine bypassed.
+    WireSend { hex: String },
+    /// Instrument burst: comma-separated hex frames, back-to-back.
+    WireBurst { frames: String },
+    /// Instrument dominant-low pulse of us microseconds.
+    Pulse { us: u16 },
+    /// Drain captured wire edges (up to max per polarity).
+    Drain {
+        #[arg(default_value_t = 64)]
+        max: u8,
+    },
+    /// Drop undrained captures + the overflow flag.
+    CaptureReset,
 }
 
 fn on_off(s: &str) -> Result<bool> {
@@ -181,6 +194,35 @@ fn encode(args: &Args) -> Result<(Vec<u8>, bool)> {
             (rec(&[record::REC_SET_RAILS, state]), false)
         }
         Cmd::Bootloader => (rec(&[record::REC_ENTER_BOOTLOADER]), false),
+        Cmd::WireSend { hex } => {
+            let mut body = vec![record::REC_WIRE_SEND, seq as u8, (seq >> 8) as u8];
+            body.extend_from_slice(&parse_hex(hex)?);
+            (rec(&body), true)
+        }
+        Cmd::WireBurst { frames } => {
+            let mut body = vec![record::REC_WIRE_BURST, seq as u8, (seq >> 8) as u8];
+            for f in frames.split(',') {
+                let bytes = parse_hex(f)?;
+                if bytes.is_empty() || bytes.len() > 255 {
+                    bail!("burst frame must be 1..=255 bytes");
+                }
+                body.push(bytes.len() as u8);
+                body.extend_from_slice(&bytes);
+            }
+            (rec(&body), true)
+        }
+        Cmd::Pulse { us } => (
+            rec(&[
+                record::REC_WIRE_PULSE,
+                seq as u8,
+                (seq >> 8) as u8,
+                *us as u8,
+                (us >> 8) as u8,
+            ]),
+            true,
+        ),
+        Cmd::Drain { max } => (rec(&[record::REC_EDGE_DRAIN, *max]), false),
+        Cmd::CaptureReset => (rec(&[record::REC_CAPTURE_RESET]), false),
     })
 }
 
@@ -294,6 +336,36 @@ fn print_record(body: Vec<u8>) -> bool {
         }
         record::REC_UNKNOWN => {
             println!("UNKNOWN record type {:#04x} (adapter echo)", body[1]);
+            true
+        }
+        record::REC_WIRE_DONE => {
+            let seq = u16::from_le_bytes([body[1], body[2]]);
+            let tick = u32::from_le_bytes([body[3], body[4], body[5], body[6]]);
+            println!("WIRE DONE seq={seq} tick={tick}");
+            true
+        }
+        record::REC_EDGES => {
+            let now = u32::from_le_bytes([body[2], body[3], body[4], body[5]]);
+            let (fall_n, rise_n) = (body[6] as usize, body[7] as usize);
+            let tick = |i: usize| u16::from_le_bytes([body[8 + 2 * i], body[9 + 2 * i]]);
+            let list = |from: usize, n: usize| {
+                (from..from + n)
+                    .map(|i| tick(i).to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            };
+            println!(
+                "EDGES overflow={} now={} falls[{}]: {}",
+                body[1] & 1 != 0,
+                now,
+                fall_n,
+                list(0, fall_n),
+            );
+            println!("  rises[{}]: {}", rise_n, list(fall_n, rise_n));
+            true
+        }
+        record::REC_CAPTURE_ACK => {
+            println!("CAPTURE RESET");
             true
         }
         other => {


### PR DESCRIPTION
The adapter becomes a wire instrument: hardware-timestamped edge capture of everything on the bus, plus raw TX verbs that bypass the engine's frame validation. This is the measurement surface the bench tooling needs to migrate off the external uart-pirate snooper, and it ships in every adapter build - no feature flag, no second USB interface - so the image that passes the hardware gates is byte-identical to the one in the field, and any adapter can serve as a bus forensics probe.

## Hardware ground truth (measured on V305 silicon)

TIM2 input capture works on PB10 while USART3 owns the pin: partial remap 2 routes CH3 onto the bus pin, IC3 samples it falling, IC4 cross-selects it rising, and both DMA-drain into RAM rings with zero CPU. The capture clock is prescaled to 18 MHz - the SysTick tick domain, where a bit is exactly BRR/8 ticks at every operational baud.

Measured at 1M and 3M, own and foreign traffic: data-region edges capture tick-exact (within one 18 MHz tick); break edges do not. The break fall is never captured, each break instead contributes one phantom fall and rise at fixed sub-break offsets, and a frame's final fall can stamp late by a fixed 12 ticks. The decoding contract follows: anchor every frame on its byte-0 start fall (always exact) and derive break geometry by law arithmetic - the same span-end lift the uart-pirate's LBD boundary model already used, upgraded from stride synthesis to a real capture per interior edge.

## osc-host

- `EdgeCapture` provider trait: continuous capture from boot (re-arming provably mangles captures), consumer-paced drains, a sticky overflow flag when a ring laps undrained.
- Raw wire ops as an engine side door: `wire_send` (law break + arbitrary bytes - malformed frames are the point of an instrument), `wire_burst` (length-prefixed frames chained on TC, inter-frame gap under a character time), `wire_pulse_low` (arbitrary width). One wire owner at a time: raw ops and SUBMIT commands reject each other as busy through the same state machine, and completion surfaces as its own event.
- New records in the reserved instrument family (`0x61..0x65` in, `0x69/0x6C/0x6D` out); edge drains are polled request/reply, capped per polarity, with a 32-bit drain-time tick as the unwrap anchor for the 16-bit capture stamps.
- 15 new unit tests: op lifecycle, both directions of the busy arbitration, malformed rejects, drain layout, overflow and reset semantics.

## osc-host-ch32

- `hal/tim2cap`: the capture plumbing above, with TIM2's counter aligned to the SysTick count at init - both derive from HCLK/8, so the offset is constant for the life of the boot and capture stamps unwrap directly against engine ticks.
- `providers/edges`: two 1024-entry capture rings, drain cursors, and lap-accurate overflow accounting fed by a per-iteration poll in the run loop.
- The DMA layer grows the two capture channels and 16-bit transfer support.

## Validated on silicon

Exercised against the live 5-servo fleet: a PING exchange drains as 25 falls + 25 rises with the turnaround gap plainly visible between the instruction and reply clusters; raw sends, a two-frame burst, pulses, reset, and empty drains all behave; normal exchanges stay clean across instrument use. One demonstration of the surface doing exactly what it says: a 500 us test pulse on the powered fleet is a legitimate rescue declaration, and the fleet obediently dropped to the rescue baud (a rail cycle brings it back).

adapter-cli grew matching smoke verbs (`wire-send`, `wire-burst`, `pulse`, `drain`, `capture-reset`) for driving all of this by hand.
