### PR TITLE
adapter: rails default on, per-rail verbs, group ops in the osc CLI

### DIFF
--- a/client/src/blocking.rs
+++ b/client/src/blocking.rs
@@ -102,8 +102,20 @@ impl<P: Pipe> Client<P> {
         block_on(self.0.set_response_deadline(us))
     }
 
-    pub fn set_rails(&mut self, v3v3: bool, v5: bool) -> Result<(), Error> {
+    pub fn set_rails(&mut self, v3v3: bool, v5: bool) -> Result<(bool, bool), Error> {
         block_on(self.0.set_rails(v3v3, v5))
+    }
+
+    pub fn set_rail_3v3(&mut self, on: bool) -> Result<(bool, bool), Error> {
+        block_on(self.0.set_rail_3v3(on))
+    }
+
+    pub fn set_rail_5v(&mut self, on: bool) -> Result<(bool, bool), Error> {
+        block_on(self.0.set_rail_5v(on))
+    }
+
+    pub fn rails(&mut self) -> Result<(bool, bool), Error> {
+        block_on(self.0.rails())
     }
 
     pub fn enter_bootloader(&mut self) -> Result<(), Error> {

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -355,13 +355,33 @@ impl<P: Pipe> Client<P> {
         Ok(())
     }
 
-    /// Drive the adapter's DUT power rails (absolute state).
-    pub async fn set_rails(&mut self, v3v3: bool, v5: bool) -> Result<(), Error> {
+    /// Drive both DUT power rails (absolute state); returns the acked
+    /// `(3V3, 5V)` state.
+    pub async fn set_rails(&mut self, v3v3: bool, v5: bool) -> Result<(bool, bool), Error> {
+        self.rails_op(v3v3 as u8 | (v5 as u8) << 1, 0b11).await
+    }
+
+    /// Drive the 3V3 rail, 5V untouched.
+    pub async fn set_rail_3v3(&mut self, on: bool) -> Result<(bool, bool), Error> {
+        self.rails_op(on as u8, 0b01).await
+    }
+
+    /// Drive the 5V rail, 3V3 untouched.
+    pub async fn set_rail_5v(&mut self, on: bool) -> Result<(bool, bool), Error> {
+        self.rails_op((on as u8) << 1, 0b10).await
+    }
+
+    /// Read the rails without driving them.
+    pub async fn rails(&mut self) -> Result<(bool, bool), Error> {
+        self.rails_op(0, 0).await
+    }
+
+    async fn rails_op(&mut self, state: u8, mask: u8) -> Result<(bool, bool), Error> {
         let mut out = Vec::new();
-        Session::encode_set_rails(&mut out, v3v3, v5);
+        Session::encode_set_rails(&mut out, state, mask);
         self.pipe.send(&out).await?;
         match self.next_record().await? {
-            Record::RailsAck { .. } => Ok(()),
+            Record::RailsAck { state } => Ok((state & 1 != 0, state & 2 != 0)),
             other => Err(desync("RAILS ack", &other)),
         }
     }

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -105,9 +105,10 @@ impl Session {
         Self::frame(out, &[rec::REC_ENTER_BOOTLOADER]);
     }
 
-    pub fn encode_set_rails(out: &mut Vec<u8>, v3v3: bool, v5: bool) {
-        let state = v3v3 as u8 | (v5 as u8) << 1;
-        Self::frame(out, &[rec::REC_SET_RAILS, state]);
+    /// `mask` selects which rails the state byte applies to (bit0 = 3V3,
+    /// bit1 = 5V); mask 0 reads the state back without driving anything.
+    pub fn encode_set_rails(out: &mut Vec<u8>, state: u8, mask: u8) {
+        Self::frame(out, &[rec::REC_SET_RAILS, state, mask]);
     }
 
     /// Encode a SUBMIT; returns the seq that will tag its answer.

--- a/client/tests/full_stack.rs
+++ b/client/tests/full_stack.rs
@@ -197,8 +197,19 @@ fn assign_moves_the_matcher_to_its_new_id() {
 #[test]
 fn rails_and_bootloader_ack() {
     let mut c = fleet(&[1]);
-    c.set_rails(true, false).expect("rails");
+    assert_eq!(c.set_rails(true, false).expect("rails"), (true, false));
     c.enter_bootloader().expect("bootloader");
+}
+
+#[test]
+fn rails_masked_sets_compose_and_read_back() {
+    let mut c = fleet(&[1]);
+    // Boot mirror: both rails on.
+    assert_eq!(c.rails().expect("readback"), (true, true));
+    assert_eq!(c.set_rail_5v(false).expect("5v off"), (true, false));
+    assert_eq!(c.set_rail_3v3(false).expect("3v3 off"), (false, false));
+    assert_eq!(c.set_rail_5v(true).expect("5v on"), (false, true));
+    assert_eq!(c.rails().expect("readback"), (false, true));
 }
 
 #[test]

--- a/firmware/host-ch32/src/providers/pins.rs
+++ b/firmware/host-ch32/src/providers/pins.rs
@@ -8,7 +8,9 @@
 //! - PA5 = 3V3 header rail enable, ACTIVE LOW (CH217K U4), driven low at
 //!   boot so the DUT side has power. PA5 shares package pin 2 with PA1
 //!   (double bond): PA1 stays an input.
-//! - PB12 = 5V rail enable, left OFF (reset state).
+//! - PB12 = 5V rail enable, ACTIVE LOW (CH217K U3), driven low at boot --
+//!   both rails default ON so a bare adapter powers its bus; the link's
+//!   RAILS_BOOT_STATE mirror must match.
 //! - PB2 = unbonded die pad (datasheet Note 5): input pull-down to stop
 //!   input-buffer leakage.
 //! - PC9 = blue LED, active low. PA8 is its package-pin-12 twin (double
@@ -29,9 +31,11 @@ pub struct Pins;
 
 impl Pins {
     pub fn init() {
-        // Rail first: LOW = 3V3 on, before anything else so the DUT boots.
+        // Rails first: LOW = on, before anything else so the DUTs boot.
         gpio::set_level(GPIOA, 5, false);
         gpio::configure(GPIOA, 5, PinMode::OUTPUT_2MHZ);
+        gpio::set_level(GPIOB, 12, false);
+        gpio::configure(GPIOB, 12, PinMode::OUTPUT_2MHZ);
 
         gpio::set_level(GPIOB, 10, true); // idle-high before the AF block takes the pin
         gpio::configure(GPIOB, 10, PinMode::AF_OPEN_DRAIN_50MHZ);
@@ -59,7 +63,6 @@ pub fn rail_3v3(on: bool) {
 /// fleet power-cycle: off = ping timeout, on = ping complete).
 pub fn rail_5v(on: bool) {
     gpio::set_level(GPIOB, 12, !on);
-    gpio::configure(GPIOB, 12, PinMode::OUTPUT_2MHZ);
 }
 
 /// Bus wire drive for the TX claim window: push-pull drives both edges at

--- a/firmware/lib/host/src/link/record.rs
+++ b/firmware/lib/host/src/link/record.rs
@@ -29,11 +29,16 @@ pub const REC_SUBMIT: u8 = 0x01;
 /// pipe, disarms the loader, and resets -- the ack is the last record the
 /// port delivers.
 pub const REC_ENTER_BOOTLOADER: u8 = 0x40;
-/// Bench family: drive the adapter's DUT power rails (the adapter feeds
-/// the bus side's 3V3; 5V is a bench convenience). Body: one state byte,
-/// bit0 = 3V3 on, bit1 = 5V on -- absolute state, so queue last-wins is
-/// sound. Answered by [`REC_RAILS_ACK`] echoing the applied state.
+/// Bench family: drive the adapter's DUT power rails. Body:
+/// `state(1) [mask(1)]` -- bit0 = 3V3, bit1 = 5V; only masked bits apply
+/// (absent mask = both, wire-compatible with the mask-less form; mask 0 =
+/// pure readback). The server keeps the state mirror (it is the rails'
+/// only writer, seeded from [`RAILS_BOOT_STATE`]); the chip applies the
+/// composed absolute state. Answered by [`REC_RAILS_ACK`] carrying it.
 pub const REC_SET_RAILS: u8 = 0x60;
+/// Rails state out of adapter boot: both ON (the pins provider asserts
+/// them before anything else) -- a bare adapter powers its bus.
+pub const RAILS_BOOT_STATE: u8 = 0b11;
 /// Instrument raw TX: one law break + the body's raw bytes, engine command
 /// pipeline bypassed (no Shape validation -- malformed frames are the
 /// point). Body: `seq(2 LE) bytes(1..)`. Answered by [`REC_WIRE_DONE`] at

--- a/firmware/lib/host/src/link/server.rs
+++ b/firmware/lib/host/src/link/server.rs
@@ -34,6 +34,14 @@ pub enum AdapterRequest {
     SetRails { v3v3: bool, v5: bool },
 }
 
+/// Adapter-level state the server owns: the queued chip request plus the
+/// rails mirror (the server is the rails' only writer after boot, so acks
+/// and masked sets compose against it).
+struct AdapterState {
+    req: Option<AdapterRequest>,
+    rails: u8,
+}
+
 pub struct LinkServer {
     rx: [u8; RX_CAP],
     rx_len: usize,
@@ -41,7 +49,7 @@ pub struct LinkServer {
     active: Option<u16>,
     /// The seq owning the outstanding instrument wire op.
     wire_active: Option<u16>,
-    adapter_req: Option<AdapterRequest>,
+    adapter: AdapterState,
     out: [u8; OUT_CAP],
 }
 
@@ -58,7 +66,10 @@ impl LinkServer {
             rx_len: 0,
             active: None,
             wire_active: None,
-            adapter_req: None,
+            adapter: AdapterState {
+                req: None,
+                rails: record::RAILS_BOOT_STATE,
+            },
             out: [0; OUT_CAP],
         }
     }
@@ -66,7 +77,7 @@ impl LinkServer {
     /// Drain the pending adapter-level request, if any. The chip polls this
     /// after `on_pipe`; the matching ack record is already in the sink.
     pub fn take_adapter_request(&mut self) -> Option<AdapterRequest> {
-        self.adapter_req.take()
+        self.adapter.req.take()
     }
 
     /// Feed bytes as the pipe delivered them (any framing); complete
@@ -147,7 +158,7 @@ impl LinkServer {
             handle(
                 &mut self.active,
                 &mut self.wire_active,
-                &mut self.adapter_req,
+                &mut self.adapter,
                 &self.rx[2..2 + len],
                 bus,
                 &mut self.out,
@@ -163,7 +174,7 @@ impl LinkServer {
 fn handle<P: Providers>(
     active: &mut Option<u16>,
     wire_active: &mut Option<u16>,
-    adapter_req: &mut Option<AdapterRequest>,
+    adapter: &mut AdapterState,
     rec: &[u8],
     bus: &mut HostBus<P>,
     out: &mut [u8],
@@ -174,15 +185,19 @@ fn handle<P: Providers>(
             sink.record(record::info(out, P::Deadline::TICKS_PER_US));
         }
         record::REC_ENTER_BOOTLOADER => {
-            *adapter_req = Some(AdapterRequest::EnterBootloader);
+            adapter.req = Some(AdapterRequest::EnterBootloader);
             sink.record(record::bootloader_ack(out));
         }
         record::REC_SET_RAILS if rec.len() >= 2 => {
-            *adapter_req = Some(AdapterRequest::SetRails {
-                v3v3: rec[1] & 1 != 0,
-                v5: rec[1] & 2 != 0,
-            });
-            sink.record(record::rails_ack(out, rec[1] & 0x03));
+            let mask = rec.get(2).copied().unwrap_or(0b11) & 0b11;
+            adapter.rails = (adapter.rails & !mask) | (rec[1] & mask);
+            if mask != 0 {
+                adapter.req = Some(AdapterRequest::SetRails {
+                    v3v3: adapter.rails & 1 != 0,
+                    v5: adapter.rails & 2 != 0,
+                });
+            }
+            sink.record(record::rails_ack(out, adapter.rails));
         }
         record::REC_WIRE_SEND
         | record::REC_WIRE_BURST
@@ -500,6 +515,38 @@ mod tests {
                 v5: true
             })
         );
+    }
+
+    #[test]
+    fn masked_rails_set_composes_against_the_mirror() {
+        let mut r = rig();
+        // 5V off, 3V3 untouched: boot mirror is both-on.
+        r.server
+            .on_pipe(&rec(&[REC_SET_RAILS, 0b00, 0b10]), &mut r.bus, &mut r.sink);
+        assert_eq!(r.sink.0, vec![vec![2, 0, REC_RAILS_ACK, 0b01]]);
+        assert_eq!(
+            r.server.take_adapter_request(),
+            Some(AdapterRequest::SetRails {
+                v3v3: true,
+                v5: false
+            })
+        );
+        // 3V3 off through the other mask: composed state goes dark.
+        r.server
+            .on_pipe(&rec(&[REC_SET_RAILS, 0b00, 0b01]), &mut r.bus, &mut r.sink);
+        assert_eq!(*r.sink.0.last().unwrap(), vec![2, 0, REC_RAILS_ACK, 0b00]);
+    }
+
+    #[test]
+    fn zero_mask_reads_the_rails_without_driving_them() {
+        let mut r = rig();
+        r.server
+            .on_pipe(&rec(&[REC_SET_RAILS, 0b11, 0b00]), &mut r.bus, &mut r.sink);
+        assert_eq!(
+            r.sink.0,
+            vec![vec![2, 0, REC_RAILS_ACK, record::RAILS_BOOT_STATE]]
+        );
+        assert_eq!(r.server.take_adapter_request(), None);
     }
 
     #[test]

--- a/scripts/gears.sh
+++ b/scripts/gears.sh
@@ -34,8 +34,8 @@ section "gear 3: bench hardware"
 if [ "${SKIP_BENCH:-0}" = "1" ]; then
   echo "  SKIP_BENCH=1; skipping gear 3"
 elif [ -n "${BENCH_FORCE:-}" ] \
-  || { command -v system_profiler >/dev/null 2>&1 \
-       && system_profiler SPUSBDataType 2>/dev/null | grep -q "osc-adapter"; } \
+  || { command -v ioreg >/dev/null 2>&1 \
+       && ioreg -p IOUSB 2>/dev/null | grep -q "osc-adapter"; } \
   || { command -v lsusb >/dev/null 2>&1 && lsusb 2>/dev/null | grep -qi "1209:0001"; }; then
   # #[serial] already serialises the shared adapter; --test-threads=1 is belt
   # and suspenders. A longer soak: BENCH_BURST_CYCLES=25000.

--- a/tools/osc/src/main.rs
+++ b/tools/osc/src/main.rs
@@ -37,12 +37,19 @@ struct Cli {
 enum Cmd {
     /// Adapter link info (version, tick rate).
     Info,
-    /// Drive the adapter's DUT power rails: on/off for 3V3 then 5V.
-    Rails {
+    /// Read the DUT power rail state (3V3 / 5V) without driving it.
+    Rails,
+    /// Drive the 3V3 rail, 5V untouched.
+    #[command(name = "3v3")]
+    Rail3v3 {
         #[arg(value_parser = on_off, action = clap::ArgAction::Set)]
-        v3v3: bool,
+        on: bool,
+    },
+    /// Drive the 5V rail, 3V3 untouched.
+    #[command(name = "5v")]
+    Rail5v {
         #[arg(value_parser = on_off, action = clap::ArgAction::Set)]
-        v5: bool,
+        on: bool,
     },
     /// Hand the adapter to the WCH bootloader (4348:55e0, wlink-iap).
     Bootloader,
@@ -141,7 +148,39 @@ enum Cmd {
         addr: String,
         /// Payload as hex bytes.
         data: String,
+        /// Stage under HOLD; applied by the next COMMIT.
+        #[arg(long)]
+        hold: bool,
+        /// Fire-and-forget: no status frame owed.
+        #[arg(long, conflicts_with = "hold")]
+        noreply: bool,
     },
+    /// Uniform group read: one status chain in list order (protocol sec 6).
+    Gread {
+        /// Table address (0x-hex or decimal).
+        addr: String,
+        /// Bytes per target.
+        #[arg(default_value_t = 4)]
+        count: u16,
+        /// Targets in chain order; defaults to --id.
+        #[arg(long, value_delimiter = ',')]
+        ids: Vec<u8>,
+    },
+    /// Uniform group write: the same data to every target, no replies.
+    Gwrite {
+        /// Table address (0x-hex or decimal).
+        addr: String,
+        /// Per-target data as hex bytes.
+        data: String,
+        /// Targets; defaults to --id.
+        #[arg(long, value_delimiter = ',')]
+        ids: Vec<u8>,
+        /// Stage under HOLD; the fleet applies on COMMIT.
+        #[arg(long)]
+        hold: bool,
+    },
+    /// Broadcast COMMIT: every held write applies in the same instant.
+    Commit,
 }
 
 #[derive(Subcommand, Debug)]
@@ -166,6 +205,15 @@ fn on_off(s: &str) -> Result<bool, String> {
         "off" => Ok(false),
         other => Err(format!("expected on|off, got {other:?}")),
     }
+}
+
+fn print_rails((v3v3, v5): (bool, bool)) -> Result<()> {
+    println!(
+        "rails: 3V3 {} / 5V {}",
+        if v3v3 { "on" } else { "off" },
+        if v5 { "on" } else { "off" },
+    );
+    Ok(())
 }
 
 fn hex(bytes: &[u8]) -> String {
@@ -461,16 +509,9 @@ fn main() -> Result<()> {
             );
             Ok(())
         }
-        Cmd::Rails { v3v3, v5 } => {
-            let mut c = connect()?;
-            c.set_rails(*v3v3, *v5)?;
-            println!(
-                "rails: 3V3 {} / 5V {}",
-                if *v3v3 { "on" } else { "off" },
-                if *v5 { "on" } else { "off" },
-            );
-            Ok(())
-        }
+        Cmd::Rails => print_rails(connect()?.rails()?),
+        Cmd::Rail3v3 { on } => print_rails(connect()?.set_rail_3v3(*on)?),
+        Cmd::Rail5v { on } => print_rails(connect()?.set_rail_5v(*on)?),
         Cmd::Bootloader => {
             let mut c = connect()?;
             c.enter_bootloader()?;
@@ -576,11 +617,77 @@ fn main() -> Result<()> {
             }
             Ok(())
         }
-        Cmd::Write { addr, data } => {
+        Cmd::Write {
+            addr,
+            data,
+            hold,
+            noreply,
+        } => {
             let mut c = connect_bus(&cli)?;
             let data = parse_hex(data)?;
-            c.write(id, parse_u16(addr)?, &data)?;
-            println!("wrote {} B at {addr}", data.len());
+            let a = parse_u16(addr)?;
+            if *hold {
+                c.write_hold(id, a, &data)?;
+                println!("staged {} B at {addr} (HOLD; COMMIT applies)", data.len());
+            } else if *noreply {
+                c.write_noreply(id, a, &data)?;
+                println!("sent {} B at {addr} (NOREPLY)", data.len());
+            } else {
+                c.write(id, a, &data)?;
+                println!("wrote {} B at {addr}", data.len());
+            }
+            Ok(())
+        }
+        Cmd::Gread { addr, count, ids } => {
+            let mut c = connect_bus(&cli)?;
+            let ids = ids_or_default(ids, cli.id);
+            let chain = c.gread(&ids, parse_u16(addr)?, *count)?;
+            for s in &chain.statuses {
+                println!(
+                    "slot {} id {:<3} {:?}{}  {}",
+                    s.slot,
+                    s.id,
+                    s.result,
+                    if s.alert { " ALERT" } else { "" },
+                    hex(&s.payload),
+                );
+            }
+            match chain.timeout_slot {
+                Some(slot) => bail!("chain timed out at slot {slot}"),
+                None => Ok(()),
+            }
+        }
+        Cmd::Gwrite {
+            addr,
+            data,
+            ids,
+            hold,
+        } => {
+            let mut c = connect_bus(&cli)?;
+            let ids = ids_or_default(ids, cli.id);
+            let data = parse_hex(data)?;
+            let pairs: Vec<(Id, &[u8])> = ids.iter().map(|&id| (id, data.as_slice())).collect();
+            let a = parse_u16(addr)?;
+            if *hold {
+                c.gwrite_hold(a, data.len() as u8, &pairs)?;
+                println!(
+                    "staged {} B x {} target(s) at {addr} (HOLD; COMMIT applies)",
+                    data.len(),
+                    pairs.len(),
+                );
+            } else {
+                c.gwrite(a, data.len() as u8, &pairs)?;
+                println!(
+                    "sent {} B x {} target(s) at {addr}",
+                    data.len(),
+                    pairs.len()
+                );
+            }
+            Ok(())
+        }
+        Cmd::Commit => {
+            connect_bus(&cli)?.commit()?;
+            println!("committed");
             Ok(())
         }
         Cmd::Profile { cmd } => profile(&mut connect_bus(&cli)?, id, cmd),


### PR DESCRIPTION
The adapter now boots with both DUT power rails on, so a freshly plugged (or freshly reflashed) adapter powers its bus without anyone having to remember a rails command - the old default left 5V off and every session started with a dark fleet. The rails verb also grew up: the record takes an optional mask so one rail can be set without knowing the other's state (the link server keeps the state mirror and acks the composed result; a zero mask is a free readback), and the CLI trades the two-argument `rails on on` for verbs that read the way you think them - `osc 3v3 off`, `osc 5v on`, and a bare `osc rails` that just reports the state. While I was in the CLI it also picked up the group data-plane verbs it was missing: `gread` (status chains), `gwrite` with `--hold`, `commit`, and `--hold`/`--noreply` flags on `write` - so the staged fleet-update story is now drivable from the command line, validated on the five-servo rig (stage, confirm nothing applied, commit, read the applied values back). Also swaps gears.sh's adapter detection from system_profiler to ioreg, which is faster and works in sandboxed shells.
