### PR TITLE
client: edge capture survives host drain stalls

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -67,6 +67,7 @@ const DEFAULT_GUARD: Duration = Duration::from_secs(2);
 pub struct Client<P: Pipe> {
     pub(crate) pipe: P,
     pub(crate) session: Session,
+    pub(crate) anchor: crate::wire::EdgeAnchor,
     info: LinkInfo,
     guard: Duration,
 }
@@ -77,6 +78,7 @@ impl<P: Pipe> Client<P> {
         let mut c = Self {
             pipe,
             session: Session::new(),
+            anchor: Default::default(),
             info: LinkInfo {
                 version: 0,
                 ticks_per_us: 1,

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -50,7 +50,7 @@ pub enum Record {
         tick: u32,
     },
     /// One edge drain: capture-order ticks (engine domain low 16 bits),
-    /// `now` = the 32-bit drain moment, the unwrap reference.
+    /// `now` = the 32-bit drain moment (the unwrap's anchor floor).
     Edges {
         overflow: bool,
         now: u32,

--- a/client/src/wire.rs
+++ b/client/src/wire.rs
@@ -8,9 +8,16 @@
 //!
 //! Capture is continuous from adapter boot, consumer-paced: drain at least
 //! every few ms of wire activity or the sticky overflow flag goes up.
-//! Edge ticks arrive as the engine domain's low 16 bits and unwrap against
-//! the drain moment -- sound within one u16 wrap (~3.6 ms at 18 MHz), which
-//! covers any single exchange; older undrained edges alias.
+//! Edge ticks arrive as the engine domain's low 16 bits, one chronological
+//! ring per polarity. The rings merge by alternation (wire edges strictly
+//! alternate) and compose onto ONE monotone anchor chain: each tick places
+//! at the first u32 at or after its predecessor -- exact for arbitrarily
+//! late drains. Unwrapping against the drain moment instead would alias
+//! any batch older than a u16 wrap (~3.6 ms at 18 MHz) by whole wraps;
+//! multi-ms host scheduling stalls hit that in long suite runs and
+//! scrambled ~0.2% of zero-gap burst decodes. Absolute placement across a
+//! quiet stretch stays exact as long as some EMPTY drain lands within a
+//! wrap of it -- empty drains lift the anchor along `now`.
 
 use crate::client::{Client, desync};
 use crate::error::{Error, LinkError, RejectReason};
@@ -39,7 +46,7 @@ pub struct EdgeDrain {
     /// A capture ring lapped undrained since the last reset -- ticks before
     /// this drain are untrustworthy. Sticky until [`Client::reset_capture`].
     pub overflow: bool,
-    /// The 32-bit engine tick at the drain, the unwrap reference.
+    /// The 32-bit engine tick at the drain (the unwrap's anchor floor).
     pub now: u32,
 }
 
@@ -124,7 +131,7 @@ impl<P: Pipe> Client<P> {
                 falls,
                 rises,
             } => Ok(EdgeDrain {
-                edges: merge_edges(now, &falls, &rises),
+                edges: unwrap_drain(&mut self.anchor, now, &falls, &rises),
                 overflow,
                 now,
             }),
@@ -138,7 +145,10 @@ impl<P: Pipe> Client<P> {
         Session::encode_capture_reset(&mut out);
         self.pipe.send(&out).await?;
         match self.next_record().await? {
-            Record::CaptureAck => Ok(()),
+            Record::CaptureAck => {
+                self.anchor = EdgeAnchor::default();
+                Ok(())
+            }
             other => Err(desync("CAPTURE ack", &other)),
         }
     }
@@ -154,50 +164,288 @@ impl<P: Pipe> Client<P> {
     }
 }
 
-/// Unwrap each 16-bit capture tick to the most recent 32-bit tick at or
-/// before `now` with those low bits, then time-order across polarities.
-fn merge_edges(now: u32, falls: &[u16], rises: &[u16]) -> Vec<WireEdge> {
-    let unwrap = |t: u16| now.wrapping_sub((now as u16).wrapping_sub(t) as u32);
-    let mut edges: Vec<WireEdge> = falls
-        .iter()
-        .map(|&t| (t, Level::Low))
-        .chain(rises.iter().map(|&t| (t, Level::High)))
-        .map(|(t, level)| WireEdge {
-            tick: unwrap(t),
-            level,
-        })
+/// The single unwrap chain over the merged edge stream, cleared by
+/// [`Client::reset_capture`]. One wire has one timeline: separate per-ring
+/// anchors can land the two polarities on different wrap pages whenever a
+/// stalled gap straddles a page boundary between a fall and its rise (a
+/// split timeline decodes every character as zero), so both rings feed
+/// one chain. `tick` is the composed anchor; `lead` is the polarity the
+/// wire produces next -- Low after a reset, because the bus idles high.
+/// `carry` holds falls whose partner rises were still undrained at the
+/// batch end, deferred until those rises arrive.
+pub(crate) struct EdgeAnchor {
+    tick: Option<u32>,
+    lead: Level,
+    carry: Vec<u16>,
+}
+
+impl Default for EdgeAnchor {
+    fn default() -> Self {
+        Self {
+            tick: None,
+            lead: Level::Low,
+            carry: Vec::new(),
+        }
+    }
+}
+
+/// How far behind a drain's `now` the anchor floor sits, capture ticks. An
+/// edge can land in the ring after the drain's snapshot yet before its
+/// `now` latch, so it arrives one batch later with a tick slightly before
+/// that `now` -- the floor must clear the whole snapshot-to-latch window.
+/// ~230 us at 18 MHz, orders above the server's us-scale dispatch and
+/// well under the 3.6 ms wrap.
+const ANCHOR_GUARD: u32 = 4096;
+
+/// Compose one drain's 16-bit ticks into the 32-bit timeline. The two
+/// rings merge by ALTERNATION -- edges on a physical wire strictly
+/// alternate polarity, and `lead` carries the phase across batches -- then
+/// every tick places at the first u32 at or after its predecessor on the
+/// single anchor chain (each ring is chronological, and the merge makes
+/// the pair chronological). Correct for arbitrarily late drains: a batch
+/// delayed past a u16 wrap keeps its exact relative timeline instead of
+/// aliasing by whole wraps, and it cannot split across polarities because
+/// there is only one chain. Absolute placement needs the anchor within a
+/// wrap of the next edge: ONLY an empty drain lifts it (to
+/// `now - ANCHOR_GUARD`) -- empty proves the rings held nothing older,
+/// while a clamped non-empty drain may still hide backlog a floor must
+/// not overtake. Live polling drains empty through quiet stretches, so
+/// real gaps stay exact; only a wire gap over a wrap with no empty drain
+/// inside it compresses, coherently. Tears (the server snapshots rises
+/// before falls, so edges landing between the snapshots ship as surplus
+/// trailing falls with their partner rises a batch behind) DEFER: those
+/// falls cannot be ordered against rises not yet drained, and the
+/// forward-only chain turns any order inversion into a whole-wrap fling.
+fn unwrap_drain(anchor: &mut EdgeAnchor, now: u32, falls: &[u16], rises: &[u16]) -> Vec<WireEdge> {
+    let falls: Vec<u16> = anchor
+        .carry
+        .drain(..)
+        .chain(falls.iter().copied())
         .collect();
-    edges.sort_by_key(|e| e.tick);
-    edges
+    let (mut fi, mut ri) = (0, 0);
+    let mut out = Vec::with_capacity(falls.len() + rises.len());
+    let mut a = anchor.tick;
+    while fi < falls.len() || ri < rises.len() {
+        let level = match (anchor.lead, fi < falls.len(), ri < rises.len()) {
+            (Level::Low, true, _) => Level::Low,
+            // A rise is due but the rises ring ran dry: the falls left
+            // over sit AFTER that undrained rise on the wire. Defer them
+            // to merge with the rises of the next drain.
+            (Level::High, _, false) => break,
+            // Rises available at Low lead: a fall went missing (capture
+            // loss); emit the rise so the stream re-syncs.
+            _ => Level::High,
+        };
+        let t = match level {
+            Level::Low => {
+                fi += 1;
+                falls[fi - 1]
+            }
+            Level::High => {
+                ri += 1;
+                rises[ri - 1]
+            }
+        };
+        let tick = match a {
+            // First edge after a reset seeds at or before `now`.
+            None => now.wrapping_sub((now as u16).wrapping_sub(t) as u32),
+            Some(prev) => prev.wrapping_add(t.wrapping_sub(prev as u16) as u32),
+        };
+        a = Some(tick);
+        out.push(WireEdge { tick, level });
+        anchor.lead = match level {
+            Level::Low => Level::High,
+            Level::High => Level::Low,
+        };
+    }
+    anchor.carry.extend_from_slice(&falls[fi..]);
+    // A pending carry blocks the floor too: the deferred fall is an edge
+    // older than `now` still in flight.
+    if out.is_empty() && anchor.carry.is_empty() {
+        let floor = now.wrapping_sub(ANCHOR_GUARD);
+        if a.is_none_or(|prev| floor.wrapping_sub(prev) < u32::MAX / 2) {
+            a = Some(floor);
+        }
+    }
+    anchor.tick = a;
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn unwrap_anchors_at_or_before_now() {
-        let e = merge_edges(0x0001_0010, &[0x000C], &[0xFFF0]);
-        // 0xFFF0 sits one wrap below now's page; 0x000C on it.
-        assert_eq!(e[0].tick, 0x0000_FFF0);
-        assert_eq!(e[0].level, Level::High);
-        assert_eq!(e[1].tick, 0x0001_000C);
-        assert_eq!(e[1].level, Level::Low);
+    const WRAP: u32 = 0x1_0000;
+
+    fn ticks(edges: &[WireEdge]) -> Vec<u32> {
+        edges.iter().map(|e| e.tick).collect()
     }
 
     #[test]
-    fn merge_orders_across_polarities() {
-        let e = merge_edges(1000, &[100, 300], &[200, 400]);
-        let ticks: Vec<u32> = e.iter().map(|e| e.tick).collect();
-        assert_eq!(ticks, [100, 200, 300, 400]);
+    fn seed_anchors_at_or_before_now() {
+        // The head fall one wrap below now's page seeds the chain; its
+        // rise chains forward onto the next page.
+        let mut a = EdgeAnchor::default();
+        let e = unwrap_drain(&mut a, 0x0001_0010, &[0xFFF0], &[0x000C]);
+        assert_eq!(e[0].tick, 0x0000_FFF0);
+        assert_eq!(e[0].level, Level::Low);
+        assert_eq!(e[1].tick, 0x0001_000C);
+        assert_eq!(e[1].level, Level::High);
+    }
+
+    #[test]
+    fn merge_alternates_across_polarities() {
+        let mut a = EdgeAnchor::default();
+        let e = unwrap_drain(&mut a, 1000, &[100, 300], &[200, 400]);
+        assert_eq!(ticks(&e), [100, 200, 300, 400]);
         assert_eq!(e[1].level, Level::High);
         assert_eq!(e[2].level, Level::Low);
     }
 
     #[test]
-    fn unwrap_survives_now_page_boundary() {
+    fn seed_survives_now_page_boundary() {
         // now just past a wrap; an edge captured just before it.
-        let e = merge_edges(0x0002_0003, &[0xFFFE], &[]);
+        let mut a = EdgeAnchor::default();
+        let e = unwrap_drain(&mut a, 0x0002_0003, &[0xFFFE], &[]);
         assert_eq!(e[0].tick, 0x0001_FFFE);
+    }
+
+    #[test]
+    fn pair_straddling_a_page_boundary_stays_paired() {
+        // The break fall sits at the top of a page, its rise just past
+        // it. Per-ring unwrapping seeded each polarity independently and
+        // could land them a whole wrap apart (a split timeline decodes
+        // every char as zero); the single chain makes the split
+        // impossible by construction.
+        let mut a = EdgeAnchor::default();
+        let e = unwrap_drain(&mut a, 0x0002_0004, &[0xFFF8], &[0x0008]);
+        assert_eq!(e[0].tick, 0x0001_FFF8);
+        assert_eq!(e[0].level, Level::Low);
+        assert_eq!(e[1].tick, 0x0002_0008);
+        assert_eq!(e[1].level, Level::High);
+    }
+
+    #[test]
+    fn stalled_batch_keeps_its_true_timeline() {
+        // The wrap-alias regression: a batch drained 3+ wraps after
+        // capture (host stall). Unwrapped against `now` these edges would
+        // land +3 wraps late and sort after later traffic; the chain
+        // places them where they happened.
+        let mut a = EdgeAnchor {
+            tick: Some(1_000),
+            lead: Level::Low,
+            carry: Vec::new(),
+        };
+        let now = 1_000 + 3 * WRAP + 200;
+        let e = unwrap_drain(&mut a, now, &[2_000, 30_000], &[2_500, 30_500]);
+        assert_eq!(ticks(&e), [2_000, 2_500, 30_000, 30_500]);
+    }
+
+    #[test]
+    fn batch_spanning_wrap_pages_chains_through() {
+        // Chronological capture across a u16 page: low bits fold, the
+        // chain keeps climbing.
+        let mut a = EdgeAnchor {
+            tick: Some(0x0000_F000),
+            lead: Level::Low,
+            carry: Vec::new(),
+        };
+        let e = unwrap_drain(&mut a, 0x0001_2000, &[0xF800, 0x0100], &[0xFC00, 0x0900]);
+        assert_eq!(
+            ticks(&e),
+            [0x0000_F800, 0x0000_FC00, 0x0001_0100, 0x0001_0900]
+        );
+    }
+
+    #[test]
+    fn empty_drains_carry_the_anchor_across_quiet() {
+        // A long quiet stretch (SAVE flash stall) spanned by live polls:
+        // the empty drains lift the anchor, so the edge on the far side
+        // places at its true absolute tick instead of chaining off the
+        // pre-quiet batch and compressing the gap by whole wraps.
+        let mut a = EdgeAnchor::default();
+        assert_eq!(ticks(&unwrap_drain(&mut a, 1_500, &[1_000], &[])), [1_000]);
+        for quiet_now in [WRAP, 2 * WRAP, 3 * WRAP] {
+            assert!(unwrap_drain(&mut a, quiet_now, &[], &[]).is_empty());
+        }
+        let far = 3 * WRAP + 5_000;
+        let e = unwrap_drain(&mut a, far + 100, &[], &[far as u16]);
+        assert_eq!(ticks(&e), [far]);
+        assert_eq!(e[0].level, Level::High, "the quiet span was a low hold");
+    }
+
+    #[test]
+    fn backlogged_batches_chain_without_the_floor() {
+        // A drain clamped at the per-drain cap leaves older edges in the
+        // rings while `now` keeps moving. The floor must not rise over
+        // that backlog: the next batch has to chain off the last drained
+        // edge, not alias up by whole wraps (the 3M hot-loop reply-tail
+        // regression -- its ~110 falls span two clamped drains).
+        let mut a = EdgeAnchor::default();
+        let b1 = unwrap_drain(&mut a, 40_000, &[10_000, 12_000], &[11_000, 13_000]);
+        assert_eq!(ticks(&b1), [10_000, 11_000, 12_000, 13_000]);
+        let b2 = unwrap_drain(&mut a, 40_500, &[14_000, 20_000], &[15_000, 21_000]);
+        assert_eq!(ticks(&b2), [14_000, 15_000, 20_000, 21_000]);
+    }
+
+    #[test]
+    fn anchor_never_advances_past_in_flight_edges() {
+        // An edge captured just after a drain's ring snapshot but before
+        // its `now` latch arrives one batch late with a tick slightly
+        // before that `now`; the guard keeps the floor below it.
+        let mut a = EdgeAnchor::default();
+        assert!(unwrap_drain(&mut a, 50_000, &[], &[]).is_empty());
+        let late = (50_000 - ANCHOR_GUARD / 2) as u16;
+        let e = unwrap_drain(&mut a, 50_100, &[late], &[]);
+        assert_eq!(ticks(&e), [late as u32]);
+    }
+
+    #[test]
+    fn torn_pair_resyncs_across_batches() {
+        // The server snapshots the two rings at slightly different
+        // instants, so a pair can tear: the fall ships this batch, its
+        // rise the next. The lead phase carries over and the rise chains
+        // onto the same timeline.
+        let mut a = EdgeAnchor::default();
+        let b1 = unwrap_drain(&mut a, 1_200, &[1_000, 1_100], &[1_050]);
+        assert_eq!(ticks(&b1), [1_000, 1_050, 1_100]);
+        assert_eq!(b1[2].level, Level::Low, "dangling fall ends the batch");
+        let b2 = unwrap_drain(&mut a, 1_400, &[], &[1_150]);
+        assert_eq!(ticks(&b2), [1_150]);
+        assert_eq!(b2[0].level, Level::High, "the torn rise pairs back up");
+    }
+
+    #[test]
+    fn double_tear_defers_the_unpaired_fall() {
+        // A rise AND the next fall both land between the server's two
+        // ring snapshots: the batch ends fall-fall with the rise a batch
+        // behind. Consuming that second fall in place orders it ahead of
+        // the missing rise and the chain flings the late rise a whole
+        // wrap forward (the debug-suite reply-tail regression); it must
+        // wait and merge with the next batch's rises.
+        let mut a = EdgeAnchor::default();
+        let b1 = unwrap_drain(&mut a, 1_200, &[1_000, 1_040, 1_080], &[1_020]);
+        assert_eq!(ticks(&b1), [1_000, 1_020, 1_040]);
+        let b2 = unwrap_drain(&mut a, 1_400, &[], &[1_060, 1_100]);
+        assert_eq!(ticks(&b2), [1_060, 1_080, 1_100]);
+        assert_eq!(b2[0].level, Level::High);
+        assert_eq!(b2[1].level, Level::Low, "the deferred fall slots back in");
+        assert_eq!(b2[2].level, Level::High);
+    }
+
+    #[test]
+    fn pending_carry_blocks_the_empty_drain_floor() {
+        // A deferred fall is an edge older than `now` still in flight;
+        // quiet drains while it waits must not lift the anchor over it.
+        let mut a = EdgeAnchor::default();
+        let b1 = unwrap_drain(&mut a, 1_200, &[1_000, 1_040, 1_080], &[1_020]);
+        assert_eq!(ticks(&b1), [1_000, 1_020, 1_040]);
+        assert!(unwrap_drain(&mut a, 3 * WRAP, &[], &[]).is_empty());
+        let b3 = unwrap_drain(&mut a, 3 * WRAP + 200, &[], &[1_060, 1_100]);
+        assert_eq!(
+            ticks(&b3),
+            [1_060, 1_080, 1_100],
+            "true timeline, not floor-relative"
+        );
     }
 }

--- a/firmware/lib/host/src/link/record.rs
+++ b/firmware/lib/host/src/link/record.rs
@@ -85,10 +85,11 @@ pub const REC_RAILS_ACK: u8 = 0x68;
 pub const REC_WIRE_DONE: u8 = 0x69;
 /// Edge drain reply. Body: `flags(1: bit0 overflow) now(4 LE)
 /// fall_n(1) rise_n(1) falls(fall_n x u16 LE) rises(rise_n x u16 LE)`.
-/// Edge ticks are the engine tick domain's low 16 bits; `now` is the
-/// 32-bit drain moment, the client's unwrap reference (unwrap ambiguity
-/// resets across gaps longer than one u16 wrap -- irrelevant within an
-/// exchange, which is all the instrument measures).
+/// Edge ticks are the engine tick domain's low 16 bits, ring-ordered
+/// (chronological); `now` is the 32-bit drain moment. The client merges
+/// the rings by alternation and chains every tick off one monotone
+/// anchor, using `now` only as the anchor floor on empty drains -- so a
+/// drain serviced late never aliases its batch.
 pub const REC_EDGES: u8 = 0x6C;
 pub const REC_CAPTURE_ACK: u8 = 0x6D;
 

--- a/firmware/lib/host/src/link/server.rs
+++ b/firmware/lib/host/src/link/server.rs
@@ -241,8 +241,13 @@ fn handle<P: Providers>(
             let max = (rec[1] as usize).min(DRAIN_MAX);
             let mut falls = [0u16; DRAIN_MAX];
             let mut rises = [0u16; DRAIN_MAX];
-            let fn_ = bus.edges().drain_falls(&mut falls[..max]);
+            // Rises snapshot FIRST: an edge pair landing between the two
+            // ring reads then tears as fall-now/rise-later, and the client
+            // defers the surplus falls until their rises drain (the wire
+            // idles high, falls lead). Falls-first would tear the other
+            // way -- a rise shipped a batch ahead of its fall.
             let rn = bus.edges().drain_rises(&mut rises[..max]);
+            let fn_ = bus.edges().drain_falls(&mut falls[..max]);
             let overflow = bus.edges().overflow();
             let now = bus.now();
             sink.record(record::edges(
@@ -670,7 +675,7 @@ mod tests {
         assert_eq!(
             u32::from_le_bytes([e[4], e[5], e[6], e[7]]),
             0x0001_0032,
-            "now = the unwrap anchor"
+            "now = the anchor floor"
         );
         assert_eq!(e[8], 3, "falls");
         assert_eq!(e[9], 2, "rises");

--- a/tools/bench/src/bin/tool-burst.rs
+++ b/tools/bench/src/bin/tool-burst.rs
@@ -18,11 +18,10 @@
 
 use anyhow::Result;
 use bench::cli::{Connect, Target, gate_fail_rate, print_conn};
-use bench::edges::BStamp;
 use bench::osc::{build_instruction, build_read, gread_uniform_payload, gwrite_uniform_payload};
 use bench::run::{
-    BurstCycle, CycleObservation, CycleOutcome, Stats, burst_measure_observed, hot_loop_cycle,
-    plain_flood_cycle,
+    BurstCycle, CycleObservation, CycleOutcome, Stats, burst_measure_observed, dump_stamps,
+    hot_loop_cycle, plain_flood_cycle,
 };
 use clap::Parser;
 use osc_protocol::wire::{Inst, Opcode};
@@ -137,27 +136,6 @@ fn cycle_for(args: &Args, value: i32) -> BurstCycle {
     } else {
         hot_loop_cycle(id, addr, value)
     }
-}
-
-fn dump_stamps(c: u32, stamps: &[BStamp], bit_ticks: u32) {
-    println!("--- cycle {c} stamps ({}):", stamps.len());
-    let mut prev: Option<u32> = None;
-    for st in stamps {
-        // `^` = break stamp (law-derived fall tick); data stamps print bare.
-        let mark = match st.flags {
-            0 => "",
-            2 => "^",
-            _ => "?",
-        };
-        let d = prev.map(|p| st.tick.wrapping_sub(p) as f64 / bit_ticks as f64);
-        match d {
-            Some(d) if d > 12.0 => println!("  {:02x}{mark} +{d:8.1}b", st.byte),
-            Some(_) => print!(" {:02x}{mark}", st.byte),
-            None => print!("  {:02x}{mark}", st.byte),
-        }
-        prev = Some(st.tick);
-    }
-    println!();
 }
 
 fn main() -> Result<()> {

--- a/tools/bench/src/run.rs
+++ b/tools/bench/src/run.rs
@@ -26,7 +26,9 @@ pub struct Report {
 
 /// Run `count` exchanges of `wire` and collect turnaround in us. `settle_ms`
 /// must cover the reply's wire time plus servo latency. `check` validates the
-/// decoded exchange (payload length, result code) before it counts.
+/// decoded exchange (payload length, result code) before it counts. Failures
+/// always print with their stamp stream (see [`burst_measure`]); `verbose`
+/// adds the per-exchange turnaround lines.
 pub fn measure(
     w: &mut Wire,
     wire: &[u8],
@@ -43,7 +45,11 @@ pub fn measure(
     for i in 0..count {
         // No retry: a first-exchange (or any) failure is a real signal, not a
         // flake to paper over.
-        match attempt(w, wire, bit_ticks, settle_ms, &check) {
+        let stamps = send_and_drain(w, wire, settle_ms)?;
+        let res = parse_exchange(&stamps, wire, bit_ticks)
+            .map_err(|e| anyhow!("{e}"))
+            .and_then(|ex| check(&ex).map(|()| ex.turnaround_ticks));
+        match res {
             Ok(ticks) => {
                 let us = ticks as f64 / hz_per_us as f64;
                 ok.push(us);
@@ -53,26 +59,12 @@ pub fn measure(
             }
             Err(e) => {
                 fail += 1;
-                if verbose {
-                    println!("exchange {i:>4}  FAIL: {e}");
-                }
+                println!("exchange {i:>4}  FAIL: {e}");
+                dump_stamps(i, &stamps, bit_ticks);
             }
         }
     }
     Ok(Report { ok, fail })
-}
-
-fn attempt(
-    w: &mut Wire,
-    wire: &[u8],
-    bit_ticks: u32,
-    settle_ms: u64,
-    check: &impl Fn(&Exchange) -> Result<()>,
-) -> Result<u32> {
-    let stamps = send_and_drain(w, wire, settle_ms)?;
-    let ex = parse_exchange(&stamps, wire, bit_ticks).map_err(|e| anyhow!("{e}"))?;
-    check(&ex)?;
-    Ok(ex.turnaround_ticks)
 }
 
 /// Clear stale capture, send `wire`, and poll-drain the exchange across
@@ -251,7 +243,10 @@ impl BurstReport {
 
 /// Bombard the bus with `count` zero-gap bursts and tally the silicon failure
 /// modes. `build(value)` produces each cycle's frames; see
-/// [`burst_measure_observed`] for the value schedule and observer.
+/// [`burst_measure_observed`] for the value schedule and observer. Every
+/// failing cycle prints its outcome and stamp stream -- the tally alone
+/// cannot say WHERE a run glitched or what the wire looked like, and a
+/// suite failure without that evidence costs a whole repro session.
 pub fn burst_measure(
     w: &mut Wire,
     count: u32,
@@ -259,7 +254,34 @@ pub fn burst_measure(
     paced: bool,
     build: impl Fn(i32) -> BurstCycle,
 ) -> Result<BurstReport> {
-    burst_measure_observed(w, count, settle_ms, paced, build, |_| {})
+    burst_measure_observed(w, count, settle_ms, paced, build, |obs| {
+        if !matches!(obs.outcome, CycleOutcome::Ok { .. }) {
+            println!("cycle {:>5}  {:?}", obs.index, obs.outcome);
+            dump_stamps(obs.index, obs.stamps, obs.bit_ticks);
+        }
+    })
+}
+
+/// Print one cycle's stamp stream: byte hex in wire order, `^` marking
+/// break stamps, gaps over 12 bit-times as `+N.Nb` deltas.
+pub fn dump_stamps(c: u32, stamps: &[BStamp], bit_ticks: u32) {
+    println!("--- cycle {c} stamps ({}):", stamps.len());
+    let mut prev: Option<u32> = None;
+    for st in stamps {
+        let mark = match st.flags {
+            0 => "",
+            2 => "^",
+            _ => "?",
+        };
+        let d = prev.map(|p| st.tick.wrapping_sub(p) as f64 / bit_ticks as f64);
+        match d {
+            Some(d) if d > 12.0 => println!("  {:02x}{mark} +{d:8.1}b", st.byte),
+            Some(_) => print!(" {:02x}{mark}", st.byte),
+            None => print!("  {:02x}{mark}", st.byte),
+        }
+        prev = Some(st.tick);
+    }
+    println!();
 }
 
 /// [`burst_measure`] with a per-cycle `observe` callback for verbose/dump.

--- a/tools/bench/src/wire.rs
+++ b/tools/bench/src/wire.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use osc_client::blocking::Client;
 use osc_client::nusb::NusbPipe;
-use osc_client::wire::WireEdge;
+use osc_client::wire::{Level, WireEdge};
 
 use crate::BOOT_BAUD;
 use crate::edges::{BStamp, stamps_from_edges};
@@ -18,12 +18,14 @@ pub struct Wire {
     client: Client<NusbPipe>,
     baud: u32,
     ticks_per_us: u32,
+    stall: StallInjector,
 }
 
-/// Capture-drain poll cadence. Edge ticks are the engine domain's low 16
-/// bits (one wrap = ~3.6 ms at 18 MHz), so every capture must be drained
-/// well inside a wrap of its birth -- the settle window is spent polling,
-/// never sleeping through.
+/// Capture-drain poll cadence. The client's anchor chain keeps a late
+/// batch's timeline exact, but absolute placement across a quiet stretch
+/// needs some drain (even empty) within a u16 tick wrap (~3.6 ms at
+/// 18 MHz) of it -- the settle window is spent polling, never sleeping
+/// through.
 const DRAIN_POLL: Duration = Duration::from_millis(1);
 
 impl Wire {
@@ -37,6 +39,7 @@ impl Wire {
             client,
             baud: BOOT_BAUD,
             ticks_per_us,
+            stall: StallInjector::from_env(),
         };
         if baud != BOOT_BAUD {
             wire.set_baud(baud)?;
@@ -129,9 +132,8 @@ impl Wire {
     }
 
     /// Poll-drain the capture across `settle_ms`, then decode. The window
-    /// is spent draining at [`DRAIN_POLL`] cadence so no capture ages past
-    /// the u16 tick wrap before its drain (a slept-through settle would
-    /// alias every early edge).
+    /// is spent draining at [`DRAIN_POLL`] cadence so quiet stretches stay
+    /// spanned by drains and absolute placement holds (see [`DRAIN_POLL`]).
     pub fn collect_stamps(&mut self, settle_ms: u64) -> Result<Vec<BStamp>> {
         let deadline = Instant::now() + Duration::from_millis(settle_ms);
         let mut edges = Vec::new();
@@ -154,7 +156,19 @@ impl Wire {
     fn drain_edges_dry(&mut self) -> Result<Vec<WireEdge>> {
         let mut all = Vec::new();
         loop {
+            self.stall.maybe_stall();
             let drain = self.client.drain_edges()?;
+            if std::env::var_os("BENCH_DUMP_EDGES").is_some() {
+                eprint!("[drain now={} n={}]", drain.now, drain.edges.len());
+                for e in &drain.edges {
+                    eprint!(
+                        " {}{}",
+                        e.tick,
+                        if e.level == Level::Low { "v" } else { "^" }
+                    );
+                }
+                eprintln!();
+            }
             if drain.overflow {
                 let _ = self.client.reset_capture();
                 bail!("edge capture overflow: undrained ring lapped (capture reset)");
@@ -163,6 +177,40 @@ impl Wire {
                 return Ok(all);
             }
             all.extend(drain.edges);
+        }
+    }
+}
+
+/// Host-stall injector: `BENCH_STALL_EVERY=N` + `BENCH_STALL_MS=M` sleeps
+/// M ms before every Nth drain. Multi-ms scheduler stalls in the drain
+/// path are what age captures past the u16 tick wrap -- injecting them on
+/// demand turns a once-per-thousand-cycles OS event into a deterministic
+/// reproducer for the unwrap's stall immunity.
+struct StallInjector {
+    every: u32,
+    ms: u64,
+    count: u32,
+}
+
+impl StallInjector {
+    fn from_env() -> Self {
+        fn read<T: std::str::FromStr>(k: &str) -> Option<T> {
+            std::env::var(k).ok().and_then(|v| v.parse().ok())
+        }
+        Self {
+            every: read("BENCH_STALL_EVERY").unwrap_or(0),
+            ms: read("BENCH_STALL_MS").unwrap_or(8),
+            count: 0,
+        }
+    }
+
+    fn maybe_stall(&mut self) {
+        if self.every == 0 {
+            return;
+        }
+        self.count += 1;
+        if self.count.is_multiple_of(self.every) {
+            std::thread::sleep(Duration::from_millis(self.ms));
         }
     }
 }

--- a/tools/bench/tests/hardware/hot_loop.rs
+++ b/tools/bench/tests/hardware/hot_loop.rs
@@ -6,12 +6,12 @@
 //! PERFECTLY clean -- zero stale read-backs (a silently-dropped GWRITE/COMMIT/
 //! WRITE) and zero missed/malformed replies.
 //!
-//! The framer still has an intermittent low-baud glitch: a dropped or late frame
-//! that a second pass would recover (an unidentified bug, tracked as a separate
-//! task). We deliberately do NOT budget around it -- a run that hits it FAILS
-//! here, by design, so the bench stays an honest reproducer instead of a
-//! tolerance that hides the bug. Each baud is measured and printed before the
-//! verdict, so a red run names exactly where and how it glitched.
+//! Failures are never budgeted around -- a run that glitches FAILS here, by
+//! design, and every failing cycle dumps its stamp stream so a red run names
+//! exactly where and how it glitched. (That policy earned its keep: the
+//! long-standing "intermittent low-baud glitch" turned out to be observer-side
+//! u16 wrap aliasing in the edge unwrap, pinned by these dumps and fixed by
+//! the client's anchor chain -- the servo was never dropping frames.)
 //!
 //! Turnaround is reported for the record but NOT gated here -- the burst reply
 //! latency folds in GWRITE+COMMIT work plus the ISR tail, a different metric


### PR DESCRIPTION
The flood suite had a residual failure I'd deferred: a fraction of a percent of cycles decoded as garbage, only in long suite runs, and the counters said the servo never saw anything wrong. The stamp dumps the suite now prints on every failing cycle made the displacement legible - failing edges were late by exactly one u16 wrap (65536 ticks, 3.64 ms at 18 MHz). The adapter ships capture ticks as the low 16 bits of its engine clock, and the client placed each batch against the moment it happened to drain it, so whenever macOS stalled the drain loop for a few milliseconds a whole batch slid a wrap into the future and the decoder read interleaved nonsense. The fix chains every tick off one monotone anchor instead: the two polarity rings merge by alternation - edges on one wire strictly alternate - onto a single timeline, each tick lands at the first 32-bit value at or after its predecessor, and only a provably empty drain lifts the anchor. It took three tries to get right, each defect caught by a stall injector I added to the bench (BENCH_STALL_EVERY / BENCH_STALL_MS sleep the drain loop deterministically): a floor that rose over clamped-drain backlog, per-ring anchors that could land the two polarities a wrap apart, and finally the tear - the adapter snapshots the rises ring a few microseconds before the falls ring, so a pair landing between the snapshots ships its fall a batch ahead of its rise, and consuming that fall immediately puts it ahead of a rise the forward-only chain then flings a whole wrap forward. Surplus falls now wait for their rises; the adapter reads rises first so tears only ever have that one shape. The debug reproduction went from 110 failures in 2000 pings to zero, the hardware suite runs green, and 2000-cycle sweeps stay clean with 12 ms stalls injected - about four times worse than macOS ever actually delivered.