### PR TITLE
descriptors: derive-emitted table ABI, identity registry, typed osc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,3 +211,5 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: cargo build
         run: cargo build
+      - name: cargo test
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: cargo test
         run: cargo test --workspace
       - name: descriptor freshness
-        run: cargo run -p table-export > ../../descriptors/osc-servo-v006.json && git diff --exit-code ../../descriptors
+        run: cargo run -p table-export > ../../descriptors/osc-servo.json && git diff --exit-code ../../descriptors
       - name: cargo check --features mocks
         run: cargo check -p osc-servo-drivers --features mocks
       - name: cargo check --features bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: cargo build --workspace
       - name: cargo test
         run: cargo test --workspace
+      - name: descriptor freshness
+        run: cargo run -p table-export > ../../descriptors/osc-servo-v006.json && git diff --exit-code ../../descriptors
       - name: cargo check --features mocks
         run: cargo check -p osc-servo-drivers --features mocks
       - name: cargo check --features bench

--- a/client/tests/full_stack.rs
+++ b/client/tests/full_stack.rs
@@ -10,6 +10,7 @@ use osc_client::cyclic::{Cycle, Group, Telemetry};
 use osc_client::fake::FakePipe;
 use osc_client::mgmt::{Found, Uid};
 use osc_client::{BaudRate, Error, Id, LinkError, RejectReason};
+use osc_protocol::models::MODEL_OSC_SERVO;
 use osc_protocol::table;
 use osc_protocol::wire::UID_LEN;
 
@@ -223,8 +224,8 @@ fn identity_decodes_the_config_front() {
     assert_eq!(
         got,
         Identity {
-            model: 0x1234, // the sim's seeded default
-            fw: 0x56,
+            model: MODEL_OSC_SERVO, // the sim mirrors the servo's registry identity
+            fw: 1,                  // osc_servo_core::FIRMWARE_VERSION
             hw: 3,
             capabilities: 0x8000_0001,
         }

--- a/descriptors/osc-servo-v006.json
+++ b/descriptors/osc-servo-v006.json
@@ -1,0 +1,583 @@
+{
+  "format": 1,
+  "model": "osc-servo-v006",
+  "model_number": 0,
+  "table_size": 1024,
+  "generator": "cargo run -p table-export (firmware/lib)",
+  "fields": [
+    {
+      "name": "model_number",
+      "addr": 0,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "firmware_version",
+      "addr": 2,
+      "width": 1,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "hardware_revision",
+      "addr": 3,
+      "width": 1,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "capability_flags",
+      "addr": 4,
+      "width": 4,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "id",
+      "addr": 16,
+      "width": 1,
+      "access": "rw",
+      "kind": "uint",
+      "min": 1,
+      "max": 249
+    },
+    {
+      "name": "baud_rate_idx",
+      "addr": 17,
+      "width": 1,
+      "access": "rw",
+      "kind": "uint",
+      "max": 3
+    },
+    {
+      "name": "response_deadline_us",
+      "addr": 18,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pos_min_phys_urad",
+      "addr": 32,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "pos_max_phys_urad",
+      "addr": 36,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "pos_min_soft_urad",
+      "addr": 40,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "pos_max_soft_urad",
+      "addr": 44,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "stall_response",
+      "addr": 48,
+      "width": 1,
+      "access": "rw",
+      "kind": "enum",
+      "variants": [
+        {
+          "name": "Disable",
+          "value": 0
+        },
+        {
+          "name": "Comply",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "name": "stall_effort_threshold",
+      "addr": 50,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "stall_motion_threshold_urad",
+      "addr": 52,
+      "width": 4,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "stall_time_threshold_ms",
+      "addr": 56,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "comply_release_window_ms",
+      "addr": 58,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "motor_thermal_k_q88",
+      "addr": 60,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "motor_thermal_tau_ms",
+      "addr": 62,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "winding_cutoff_cc",
+      "addr": 64,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "winding_recover_cc",
+      "addr": 66,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "v_undervolt_mv",
+      "addr": 68,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pid_kp_q88",
+      "addr": 72,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pid_ki_q88",
+      "addr": 74,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pid_kd_q88",
+      "addr": 76,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pid_i_limit",
+      "addr": 80,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "pos_deadband_urad",
+      "addr": 84,
+      "width": 4,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "pwm_deadband_pct",
+      "addr": 88,
+      "width": 1,
+      "access": "rw",
+      "kind": "uint",
+      "max": 50
+    },
+    {
+      "name": "v_comp_enable",
+      "addr": 89,
+      "width": 1,
+      "access": "rw",
+      "kind": "bool"
+    },
+    {
+      "name": "max_effort",
+      "addr": 90,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "v_nominal_mv",
+      "addr": 92,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "vdd_mv",
+      "addr": 96,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_min",
+      "addr": 128,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_max",
+      "addr": 130,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "lut",
+      "addr": 132,
+      "width": 220,
+      "access": "rw",
+      "kind": "bytes"
+    },
+    {
+      "name": "ke_uvs_per_rad",
+      "addr": 352,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "r_motor_mohm",
+      "addr": 354,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "calib_v_bus_mv",
+      "addr": 356,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "calib_i_ma",
+      "addr": 358,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "torque_enable",
+      "addr": 384,
+      "width": 1,
+      "access": "rw",
+      "kind": "bool"
+    },
+    {
+      "name": "mode",
+      "addr": 385,
+      "width": 1,
+      "access": "rw",
+      "kind": "enum",
+      "variants": [
+        {
+          "name": "OpenLoop",
+          "value": 0
+        },
+        {
+          "name": "PositionPid",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "name": "goal_position",
+      "addr": 388,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "goal_velocity",
+      "addr": 392,
+      "width": 4,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "goal_effort",
+      "addr": 396,
+      "width": 2,
+      "access": "rw",
+      "kind": "int"
+    },
+    {
+      "name": "stream_enable",
+      "addr": 400,
+      "width": 1,
+      "access": "rw",
+      "kind": "bool"
+    },
+    {
+      "name": "stream_decimation",
+      "addr": 401,
+      "width": 1,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "stream_duration_ms",
+      "addr": 402,
+      "width": 2,
+      "access": "rw",
+      "kind": "uint",
+      "min": 1
+    },
+    {
+      "name": "stream_field_mask",
+      "addr": 404,
+      "width": 4,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "stream_dropped",
+      "addr": 408,
+      "width": 4,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "boot_mode",
+      "addr": 412,
+      "width": 1,
+      "access": "rw",
+      "kind": "enum",
+      "variants": [
+        {
+          "name": "App",
+          "value": 0
+        },
+        {
+          "name": "Bootloader",
+          "value": 1
+        }
+      ]
+    },
+    {
+      "name": "fault_flags",
+      "addr": 512,
+      "width": 1,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "status_flags",
+      "addr": 513,
+      "width": 1,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "trim_steps",
+      "addr": 514,
+      "width": 1,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "crc_fail_count",
+      "addr": 516,
+      "width": 4,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "framing_drop_count",
+      "addr": 520,
+      "width": 4,
+      "access": "rw",
+      "kind": "uint"
+    },
+    {
+      "name": "mode_active",
+      "addr": 544,
+      "width": 1,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "fault_code",
+      "addr": 545,
+      "width": 1,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "present_position",
+      "addr": 548,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "present_velocity",
+      "addr": 552,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "present_current",
+      "addr": 556,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "present_temp",
+      "addr": 558,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "present_vbus_mv",
+      "addr": 560,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "vbus_filt_mv",
+      "addr": 564,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "t_winding_dc",
+      "addr": 566,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "pwm_duty_actual",
+      "addr": 568,
+      "width": 2,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "pid_error_last",
+      "addr": 572,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "pid_output_last",
+      "addr": 576,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "internal_goal",
+      "addr": 580,
+      "width": 4,
+      "access": "ro",
+      "kind": "int"
+    },
+    {
+      "name": "sample_tick",
+      "addr": 584,
+      "width": 4,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_pos",
+      "addr": 588,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_current",
+      "addr": 590,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_temp",
+      "addr": 592,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_vbus",
+      "addr": 594,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_vmotor_a",
+      "addr": 596,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_vmotor_b",
+      "addr": 598,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_enc_a",
+      "addr": 600,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "raw_enc_b",
+      "addr": 602,
+      "width": 2,
+      "access": "ro",
+      "kind": "uint"
+    },
+    {
+      "name": "words",
+      "addr": 640,
+      "width": 64,
+      "access": "rw",
+      "kind": "bytes"
+    }
+  ]
+}

--- a/descriptors/osc-servo.json
+++ b/descriptors/osc-servo.json
@@ -1,7 +1,9 @@
 {
   "format": 1,
-  "model": "osc-servo-v006",
-  "model_number": 0,
+  "model": "osc-servo",
+  "class": "servo",
+  "model_number": 257,
+  "firmware_version": 1,
   "table_size": 1024,
   "generator": "cargo run -p table-export (firmware/lib)",
   "fields": [

--- a/docs/osc-native-protocol.md
+++ b/docs/osc-native-protocol.md
@@ -507,6 +507,11 @@ comms RW:
 | 0x208 | `framing_drop_count` | u32   | RW     |                                             |
 | 0x20C | —                    | 20 B  | rsvd   |                                             |
 
+- `model_number` is class-structured `[class:8][model:8]`: the high byte
+  names a device class, the low byte a model within it. `0x0000` is
+  reserved unassigned - what unseeded or dev firmware reports. The
+  registry (class names and assigned numbers) lives in
+  `osc-protocol::models`.
 - Reserved bytes read zero; writes touching them reject with `access`.
   Extension fills reserved slots, announced by `capability_flags` bits —
   a host that doesn't know a bit ignores the bytes it covers.

--- a/firmware/boards/osc-dev-v006/app/src/main.rs
+++ b/firmware/boards/osc-dev-v006/app/src/main.rs
@@ -65,5 +65,7 @@ fn main() -> ! {
             baud: BaudRate::B1000000,
             response_deadline_us: DEFAULT_RESPONSE_DEADLINE_US,
         },
+        model: MODEL_OSC_SERVO,
+        hw_rev: 1,
     })
 }

--- a/firmware/lib/Cargo.toml
+++ b/firmware/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["control-table", "control-table-derive", "core", "drivers", "host", "integration", "log", "osc-protocol", "units"]
+members = ["control-table", "control-table-derive", "core", "drivers", "host", "integration", "log", "osc-protocol", "table-export", "units"]
 
 [workspace.package]
 edition = "2024"

--- a/firmware/lib/control-table-derive/src/block.rs
+++ b/firmware/lib/control-table-derive/src/block.rs
@@ -86,6 +86,7 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let mut cmp_rules: Vec<TokenStream2> = Vec::new();
     let mut allowed_rules: Vec<TokenStream2> = Vec::new();
     let mut writable: Vec<TokenStream2> = Vec::new();
+    let mut field_descs: Vec<TokenStream2> = Vec::new();
     let mut size_terms: Vec<TokenStream2> = Vec::new();
     let mut new_inits: Vec<TokenStream2> = Vec::new();
     let mut kept_idents: Vec<&Ident> = Vec::new();
@@ -153,11 +154,28 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
             writable.push(quote!((#rel_addr, ::core::mem::size_of::<#ty>() as u16)));
         }
 
+        let name_str = name.to_string();
+        let kind = field_kind(ty);
+        let (min, max) = field_bounds(name, &attrs.compares, attrs.abs)?;
+        let writable_flag = !is_ro;
+        field_descs.push(quote! {
+            ::control_table::descriptor::FieldDesc {
+                name: #name_str,
+                addr: #rel_addr,
+                width: ::core::mem::size_of::<#ty>() as u16,
+                writable: #writable_flag,
+                kind: #kind,
+                min: #min,
+                max: #max,
+            }
+        });
+
         kept_upper.push(Ident::new(&name.to_string().to_uppercase(), name.span()));
         kept_idents.push(name);
     }
 
     let n_writable = writable.len();
+    let n_fields = field_descs.len();
     let n_cmp = cmp_rules.len();
     let n_allowed = allowed_rules.len();
     let meta_macro = Ident::new(
@@ -177,6 +195,11 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                 [#(#cmp_rules),*];
             pub const CT_ALLOWED_RULES: [::control_table::rules::AllowedRule; #n_allowed] =
                 [#(#allowed_rules),*];
+
+            // Block-relative field descriptors; the Section derive rebases
+            // `addr` into table-absolute form.
+            pub const CT_FIELDS: [::control_table::descriptor::FieldDesc; #n_fields] =
+                [#(#field_descs),*];
         }
 
         #[allow(clippy::new_without_default)]
@@ -434,6 +457,77 @@ fn cmp_width_signed(ty: &Type) -> syn::Result<(u8, bool)> {
     Err(syn::Error::new(
         ty.span(),
         "compare clauses require a primitive integer (u8/u16/i8/i16/i32)",
+    ))
+}
+
+/// Descriptor `kind` token for a field type, mirroring the runtime helpers:
+/// `bool` -> Bool; unsigned ints -> UInt; signed ints -> Int; floats and
+/// arrays -> Bytes (no Float kind, none exist in tables); any other path type
+/// -> `Enum(<Ty as HasAllowed>::VARIANTS)`.
+fn field_kind(ty: &Type) -> TokenStream2 {
+    if let Type::Array(_) = ty {
+        return quote!(::control_table::descriptor::FieldKind::Bytes);
+    }
+    if let Type::Path(tp) = ty
+        && let Some(ident) = tp.path.get_ident()
+    {
+        match ident.to_string().as_str() {
+            "bool" => return quote!(::control_table::descriptor::FieldKind::Bool),
+            "u8" | "u16" | "u32" | "u64" | "u128" | "usize" => {
+                return quote!(::control_table::descriptor::FieldKind::UInt);
+            }
+            "i8" | "i16" | "i32" | "i64" | "i128" | "isize" => {
+                return quote!(::control_table::descriptor::FieldKind::Int);
+            }
+            "f32" | "f64" => return quote!(::control_table::descriptor::FieldKind::Bytes),
+            _ => {}
+        }
+    }
+    let Type::Path(tp) = ty else {
+        return quote!(::control_table::descriptor::FieldKind::Bytes);
+    };
+    let path = &tp.path;
+    quote!(::control_table::descriptor::FieldKind::Enum(
+        <#path as ::control_table::HasAllowed>::VARIANTS
+    ))
+}
+
+/// Descriptor `(min, max)` tokens from a field's compare clauses. Only
+/// immediate right-hand sides contribute: a register RHS names another field,
+/// and abs bounds are `|x|` bounds, not plain scalar bounds - both export as
+/// `None`. `gt`/`lt` fold to inclusive by +/-1; `eq`/`ne` contribute nothing.
+/// Two immediates on the same side of one field is an error, not last-wins.
+fn field_bounds(
+    name: &Ident,
+    compares: &[(CmpOp, Expr)],
+    abs: bool,
+) -> syn::Result<(TokenStream2, TokenStream2)> {
+    let mut min: Option<TokenStream2> = None;
+    let mut max: Option<TokenStream2> = None;
+    if !abs {
+        for (op, expr) in compares {
+            if let Expr::Reference(_) = expr {
+                continue;
+            }
+            let (slot, val) = match op {
+                CmpOp::Ge => (&mut min, quote!(Some((#expr) as i32))),
+                CmpOp::Gt => (&mut min, quote!(Some(((#expr) as i32) + 1))),
+                CmpOp::Le => (&mut max, quote!(Some((#expr) as i32))),
+                CmpOp::Lt => (&mut max, quote!(Some(((#expr) as i32) - 1))),
+                CmpOp::Eq | CmpOp::Ne => continue,
+            };
+            if slot.is_some() {
+                return Err(syn::Error::new(
+                    name.span(),
+                    "two immediate bounds on the same side of one field",
+                ));
+            }
+            *slot = Some(val);
+        }
+    }
+    Ok((
+        min.unwrap_or_else(|| quote!(None)),
+        max.unwrap_or_else(|| quote!(None)),
     ))
 }
 

--- a/firmware/lib/control-table-derive/src/enums.rs
+++ b/firmware/lib/control-table-derive/src/enums.rs
@@ -16,6 +16,7 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
     };
 
     let mut variant_idents: Vec<&Ident> = Vec::new();
+    let mut variant_names: Vec<String> = Vec::new();
     let mut default_variant: Option<&Ident> = None;
     for v in &e.variants {
         if !matches!(v.fields, Fields::Unit) {
@@ -27,6 +28,7 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         if v.attrs.iter().any(|a| a.path().is_ident("default")) {
             default_variant = Some(&v.ident);
         }
+        variant_names.push(v.ident.to_string());
         variant_idents.push(&v.ident);
     }
 
@@ -51,6 +53,12 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
 
         impl ::control_table::HasAllowed for #enum_ty {
             const ALLOWED: &'static [u8] = <Self>::ALLOWED;
+            const VARIANTS: &'static [::control_table::descriptor::EnumVariant] = &[
+                #(::control_table::descriptor::EnumVariant {
+                    name: #variant_names,
+                    value: Self::#variant_idents as u8,
+                }),*
+            ];
         }
 
         #new_impl

--- a/firmware/lib/control-table-derive/src/section.rs
+++ b/firmware/lib/control-table-derive/src/section.rs
@@ -74,6 +74,7 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
     let n_writable = quote!(0 #(+ <#block_tys>::CT_WRITABLE.len())*);
     let n_cmp = quote!(0 #(+ <#block_tys>::CT_CMP_RULES.len())*);
     let n_allowed = quote!(0 #(+ <#block_tys>::CT_ALLOWED_RULES.len())*);
+    let n_fields = quote!(0 #(+ <#block_tys>::CT_FIELDS.len())*);
 
     // Blocks in declaration order (= address order): preserves the old
     // sorted-by-offset first-failure precedence. Only `addr` is rebased into
@@ -95,6 +96,12 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         .iter()
         .zip(&base_exprs)
         .map(|(ty, base_expr)| rebase_rule(quote!(<#ty>::CT_ALLOWED_RULES), base_expr))
+        .collect();
+
+    let fields_copy: Vec<TokenStream2> = block_tys
+        .iter()
+        .zip(&base_exprs)
+        .map(|(ty, base_expr)| rebase_rule(quote!(<#ty>::CT_FIELDS), base_expr))
         .collect();
 
     let writable_copy: Vec<TokenStream2> = block_tys
@@ -171,6 +178,13 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     [::control_table::rules::AllowedRule { addr: 0, allowed: &[] }; #n_allowed];
                 let mut __n = 0;
                 #(#allowed_copy)*
+                out
+            };
+
+            pub const CT_FIELDS_ABS: [::control_table::descriptor::FieldDesc; #n_fields] = {
+                let mut out = [::control_table::descriptor::FieldDesc::EMPTY; #n_fields];
+                let mut __n = 0;
+                #(#fields_copy)*
                 out
             };
 

--- a/firmware/lib/control-table-derive/src/table.rs
+++ b/firmware/lib/control-table-derive/src/table.rs
@@ -105,6 +105,7 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
 
     let n_cmp = quote!(0 #(+ <#sec_tys>::CT_CMP_RULES_ABS.len())*);
     let n_allowed = quote!(0 #(+ <#sec_tys>::CT_ALLOWED_RULES_ABS.len())*);
+    let n_fields = quote!(0 #(+ <#sec_tys>::CT_FIELDS_ABS.len())*);
 
     let cmp_fill: Vec<TokenStream2> = sec_tys
         .iter()
@@ -122,6 +123,17 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
         .map(|ty| {
             crate::common::fill_loop(
                 quote!(<#ty>::CT_ALLOWED_RULES_ABS),
+                quote!(),
+                quote!(out[__n] = src[i];),
+            )
+        })
+        .collect();
+
+    let fields_fill: Vec<TokenStream2> = sec_tys
+        .iter()
+        .map(|ty| {
+            crate::common::fill_loop(
+                quote!(<#ty>::CT_FIELDS_ABS),
                 quote!(),
                 quote!(out[__n] = src[i];),
             )
@@ -191,6 +203,15 @@ pub fn expand(input: &DeriveInput) -> syn::Result<TokenStream2> {
                     [::control_table::rules::AllowedRule { addr: 0, allowed: &[] }; #n_allowed];
                 let mut __n = 0;
                 #(#allowed_fill)*
+                out
+            };
+
+            // Table-absolute field descriptors for the host-side exporter; not
+            // in the RegisterMap trait - the exporter names the table directly.
+            pub const FIELDS: [::control_table::descriptor::FieldDesc; #n_fields] = {
+                let mut out = [::control_table::descriptor::FieldDesc::EMPTY; #n_fields];
+                let mut __n = 0;
+                #(#fields_fill)*
                 out
             };
         }

--- a/firmware/lib/control-table/src/descriptor.rs
+++ b/firmware/lib/control-table/src/descriptor.rs
@@ -1,0 +1,57 @@
+//! Machine-readable field descriptors emitted alongside the runtime consts by
+//! the Block/Section/Table derives. A host-side exporter walks a table's
+//! `FIELDS` to produce a device-description JSON.
+//!
+//! These consts cost the flash image nothing when firmware never references
+//! them: a Rust const is lazy, materialized only where it is used, so the
+//! exporter-only descriptor data never lands in the servo binary. No feature
+//! gate is needed.
+
+/// One variant of an `Enum`-derived field, name paired with its discriminant.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct EnumVariant {
+    pub name: &'static str,
+    pub value: u8,
+}
+
+/// Field value shape. `Enum` carries the deriving type's variants so the
+/// exporter can render symbolic names.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum FieldKind {
+    UInt,
+    Int,
+    Bool,
+    Enum(&'static [EnumVariant]),
+    Bytes,
+}
+
+/// One field of a control table: identity, table-absolute placement, access,
+/// value shape, and inclusive scalar bounds from immediate compare rules.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct FieldDesc {
+    pub name: &'static str,
+    /// Table-absolute after the Section rebase.
+    pub addr: u16,
+    /// Field width in bytes.
+    pub width: u16,
+    pub writable: bool,
+    pub kind: FieldKind,
+    /// Inclusive, from immediate compare rules only (register-RHS and abs
+    /// bounds do not export).
+    pub min: Option<i32>,
+    pub max: Option<i32>,
+}
+
+impl FieldDesc {
+    /// Zero-fill element for the const concat arrays, mirroring the rules
+    /// arrays' filler.
+    pub const EMPTY: FieldDesc = FieldDesc {
+        name: "",
+        addr: 0,
+        width: 0,
+        writable: false,
+        kind: FieldKind::UInt,
+        min: None,
+        max: None,
+    };
+}

--- a/firmware/lib/control-table/src/lib.rs
+++ b/firmware/lib/control-table/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![cfg_attr(feature = "sync-unsafe-cell", feature(sync_unsafe_cell))]
 
+pub mod descriptor;
 pub mod map;
 mod region;
 pub mod rules;
@@ -33,6 +34,9 @@ pub const BOOL_ALLOWED: &[u8] = &[0, 1];
 )]
 pub trait HasAllowed {
     const ALLOWED: &'static [u8];
+    /// Variant name/value pairs for the field descriptor; only the Enum derive
+    /// implements this trait, so no manual impl carries the burden.
+    const VARIANTS: &'static [descriptor::EnumVariant];
 }
 
 pub use region::{Region, RegionStorage, RegionStorageRaw};
@@ -40,4 +44,5 @@ pub use stage::{STAGE_DATA_CAP, STAGE_ENTRY_CAP, Snapshot, StagedWrites};
 
 pub use control_table_derive::{Block, Enum, Section, Table};
 
+pub use descriptor::{EnumVariant, FieldDesc, FieldKind};
 pub use map::{RegisterFile, RegisterMap, SectionMeta, View};

--- a/firmware/lib/control-table/tests/derive_block.rs
+++ b/firmware/lib/control-table/tests/derive_block.rs
@@ -1,5 +1,6 @@
 #![feature(sync_unsafe_cell)]
 
+use control_table::descriptor::{EnumVariant, FieldKind};
 use control_table::{Block, Enum, Error, RegisterFile, Table, ValidationKind};
 use core::mem::{offset_of, size_of};
 
@@ -41,6 +42,57 @@ fn writable_covers_every_rw_field() {
             (offset_of!(Basic, d) as u16, 1),
         ]
     );
+}
+
+#[test]
+fn ct_fields_carry_name_addr_width_writable_and_kind() {
+    let f = Basic::CT_FIELDS;
+    // Every kept field, in declaration order.
+    assert_eq!(f.len(), 5);
+
+    assert_eq!(f[0].name, "b");
+    assert_eq!(f[0].addr, offset_of!(Basic, b) as u16);
+    assert_eq!(f[0].width, 2);
+    assert!(f[0].writable);
+    assert_eq!(f[0].kind, FieldKind::UInt);
+
+    assert_eq!(f[1].name, "a");
+    assert_eq!(f[1].width, 1);
+    assert_eq!(f[1].kind, FieldKind::UInt);
+
+    assert_eq!(f[2].name, "c");
+    assert_eq!(f[2].kind, FieldKind::Bool);
+
+    assert_eq!(f[3].name, "mode");
+    assert_eq!(f[3].addr, offset_of!(Basic, mode) as u16);
+    assert_eq!(
+        f[3].kind,
+        FieldKind::Enum(&[
+            EnumVariant {
+                name: "Stop",
+                value: 0
+            },
+            EnumVariant {
+                name: "Go",
+                value: 1
+            },
+        ])
+    );
+
+    assert_eq!(f[4].name, "d");
+    // No bounds on any Basic field.
+    assert!(f.iter().all(|d| d.min.is_none() && d.max.is_none()));
+}
+
+#[test]
+fn ct_fields_int_kind_and_ro_flag() {
+    // Access block: ro fields keep a descriptor but export writable = false.
+    let f = Access::CT_FIELDS;
+    let ro = f.iter().find(|d| d.name == "ro_field").unwrap();
+    assert!(!ro.writable);
+    assert_eq!(ro.kind, FieldKind::UInt);
+    let rw = f.iter().find(|d| d.name == "rw_field").unwrap();
+    assert!(rw.writable);
 }
 
 // Behavioral coverage of the generated `ct_check`: enum, an immediate compare, a
@@ -120,6 +172,37 @@ fn ct_check_write_outcomes() {
 
     // ro field rejected by the writable mask.
     assert_eq!(t.write(a::RO, &[0]), Err(Error::AccessError));
+}
+
+#[test]
+fn ct_fields_fold_immediate_bounds_only() {
+    // ratio le=100 -> max Some(100); trim abs -> both None; target register
+    // RHS -> both None.
+    let f = Checks::CT_FIELDS;
+    let ratio = f.iter().find(|d| d.name == "ratio").unwrap();
+    assert_eq!(ratio.min, None);
+    assert_eq!(ratio.max, Some(100));
+    let trim = f.iter().find(|d| d.name == "trim").unwrap();
+    assert_eq!((trim.min, trim.max), (None, None));
+    let target = f.iter().find(|d| d.name == "target").unwrap();
+    assert_eq!((target.min, target.max), (None, None));
+}
+
+#[repr(C)]
+#[derive(Block)]
+struct Exclusive {
+    #[ct_field(gt = 3i16, lt = 10i16)]
+    span: i16,
+}
+
+#[test]
+fn ct_fields_exclusive_bounds_fold_inclusive() {
+    // gt/lt shift by +/-1 into inclusive min/max.
+    let f = Exclusive::CT_FIELDS;
+    assert_eq!(f[0].name, "span");
+    assert_eq!(f[0].kind, FieldKind::Int);
+    assert_eq!(f[0].min, Some(4));
+    assert_eq!(f[0].max, Some(9));
 }
 
 #[repr(C)]

--- a/firmware/lib/control-table/tests/derive_enum.rs
+++ b/firmware/lib/control-table/tests/derive_enum.rs
@@ -1,4 +1,6 @@
 use control_table::Enum;
+use control_table::HasAllowed;
+use control_table::descriptor::EnumVariant;
 
 #[derive(Copy, Clone, Enum)]
 #[repr(u8)]
@@ -34,4 +36,39 @@ fn default_numbered_variants_produce_sequential_allowed() {
 #[test]
 fn single_variant_is_a_one_element_slice() {
     assert_eq!(Single::ALLOWED, &[7u8]);
+}
+
+#[test]
+fn variants_pair_name_with_value() {
+    assert_eq!(
+        <Mode as HasAllowed>::VARIANTS,
+        &[
+            EnumVariant {
+                name: "OpenLoop",
+                value: 0
+            },
+            EnumVariant {
+                name: "PositionPid",
+                value: 1
+            },
+        ]
+    );
+    // Default-numbered discriminants pair with their implicit values.
+    assert_eq!(
+        <DefaultNumbered as HasAllowed>::VARIANTS,
+        &[
+            EnumVariant {
+                name: "A",
+                value: 0
+            },
+            EnumVariant {
+                name: "B",
+                value: 1
+            },
+            EnumVariant {
+                name: "C",
+                value: 2
+            },
+        ]
+    );
 }

--- a/firmware/lib/control-table/tests/derive_table.rs
+++ b/firmware/lib/control-table/tests/derive_table.rs
@@ -1,5 +1,6 @@
 #![feature(sync_unsafe_cell)]
 
+use control_table::descriptor::FieldKind;
 use control_table::{Block, Enum, Error, RegisterFile, RegisterMap, Table, ValidationKind};
 use core::mem::{offset_of, size_of};
 
@@ -231,6 +232,33 @@ fn hook_dispatches_through_table_for_hooked_field() {
     let mut miss = Rec { hit: None };
     tbl.dispatch_events(addr::config::ident::ID, 1, &mut miss);
     assert_eq!(miss.hit, None);
+}
+
+#[test]
+fn table_fields_concat_and_rebase_across_sections() {
+    let f = Table::FIELDS;
+    // Every kept field from both sections: config ident (model, id, spare),
+    // limits (max_ratio, mode, enabled), control goal (target, commit).
+    let by = |n: &str| f.iter().find(|d| d.name == n).unwrap();
+
+    // config section fields carry table-absolute addrs (base 0).
+    assert_eq!(by("model").addr, addr::config::ident::MODEL);
+    assert!(!by("model").writable);
+    assert_eq!(by("model").kind, FieldKind::UInt);
+    assert_eq!(by("max_ratio").addr, addr::config::limits::MAX_RATIO);
+    assert_eq!(by("max_ratio").max, Some(100));
+    assert!(matches!(by("mode").kind, FieldKind::Enum(_)));
+
+    // control section fields rebased past config (base 0x000C).
+    assert_eq!(by("target").addr, addr::control::goal::TARGET);
+    // target's `le` is a register RHS, so no exported bound.
+    assert_eq!((by("target").min, by("target").max), (None, None));
+    assert_eq!(by("commit").addr, addr::control::goal::COMMIT);
+
+    // Addresses strictly ascending across the concat.
+    for w in f.windows(2) {
+        assert!(w[0].addr < w[1].addr);
+    }
 }
 
 #[test]

--- a/firmware/lib/control-table/tests/ui/dup_same_side_bound.rs
+++ b/firmware/lib/control-table/tests/ui/dup_same_side_bound.rs
@@ -1,0 +1,10 @@
+use control_table::Block;
+
+#[repr(C)]
+#[derive(Block)]
+struct Dup {
+    #[ct_field(le = 10u8, lt = 20u8)]
+    x: u8,
+}
+
+fn main() {}

--- a/firmware/lib/control-table/tests/ui/dup_same_side_bound.stderr
+++ b/firmware/lib/control-table/tests/ui/dup_same_side_bound.stderr
@@ -1,0 +1,5 @@
+error: two immediate bounds on the same side of one field
+ --> tests/ui/dup_same_side_bound.rs:7:5
+  |
+7 |     x: u8,
+  |     ^

--- a/firmware/lib/core/src/lib.rs
+++ b/firmware/lib/core/src/lib.rs
@@ -3,6 +3,12 @@
 
 pub mod debug;
 pub mod kernel;
+
+/// Firmware version stamped into the identity block (protocol sec 5.4). A
+/// table-ABI counter, bumped when a client-visible table ABI change lands;
+/// 0 is reserved for an unversioned dev build.
+pub const FIRMWARE_VERSION: u8 = 1;
+
 pub mod log;
 pub mod persist;
 pub mod regions;

--- a/firmware/lib/core/src/persist.rs
+++ b/firmware/lib/core/src/persist.rs
@@ -372,4 +372,20 @@ mod tests {
         assert_eq!(table.with(|t| t.config.common.model_number), 0x1234);
         assert_eq!(table.with(|t| t.config.common.id), 7, "comms overlaid");
     }
+
+    #[test]
+    fn seeded_identity_survives_a_boot_overlay() {
+        // Boot order: seed identity, then overlay a valid saved image. The
+        // image's identity front (0x00EE at MODEL_NUMBER) is skipped, so the
+        // firmware's stamped identity stands while comms overlay.
+        let table = seeded_table();
+        table.seed_identity(0x0101, 3);
+        boot_overlay(&table, &image_of(1), &[0xFF; IMAGE_LEN]);
+        table.with(|t| {
+            assert_eq!(t.config.common.model_number, 0x0101);
+            assert_eq!(t.config.common.hardware_revision, 3);
+            assert_eq!(t.config.common.firmware_version, crate::FIRMWARE_VERSION);
+            assert_eq!(t.config.common.id, 7, "comms overlaid");
+        });
+    }
 }

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -86,6 +86,20 @@ impl ControlTableCell {
             cfg.common.response_deadline_us = defaults.response_deadline_us;
         });
     }
+
+    /// Stamp the RO identity block (protocol sec 5.4). `firmware_version` is
+    /// not a caller argument: it is the compiled-in `crate::FIRMWARE_VERSION`
+    /// fact of this build, so a board cannot claim a version it is not running.
+    /// Caller must be sole writer (install-time, pre-IRQ).
+    pub fn seed_identity(&self, model: u16, hw_rev: u8) {
+        // SAFETY: install-time, pre-IRQ, sole writer.
+        self.with_mut(|t| {
+            let common = &mut t.config.common;
+            common.model_number = model;
+            common.hardware_revision = hw_rev;
+            common.firmware_version = crate::FIRMWARE_VERSION;
+        });
+    }
 }
 
 #[cfg(test)]
@@ -95,7 +109,19 @@ mod tests {
     use super::ControlTable;
     use super::config::addr as config_addr;
     use super::telemetry::addr as telemetry_addr;
+    use control_table::RegionStorage;
     use control_table::descriptor::{EnumVariant, FieldKind};
+
+    #[test]
+    fn seed_identity_stamps_the_block() {
+        let table = crate::ControlTableCell::new();
+        table.seed_identity(0x0101, 3);
+        table.with(|t| {
+            assert_eq!(t.config.common.model_number, 0x0101);
+            assert_eq!(t.config.common.hardware_revision, 3);
+            assert_eq!(t.config.common.firmware_version, crate::FIRMWARE_VERSION);
+        });
+    }
 
     /// Pins the struct layout to the protocol sec 5.4 common register block:
     /// every generated field address equals its protocol const, and the

--- a/firmware/lib/core/src/regions/mod.rs
+++ b/firmware/lib/core/src/regions/mod.rs
@@ -92,8 +92,10 @@ impl ControlTableCell {
 mod tests {
     use osc_protocol::table;
 
+    use super::ControlTable;
     use super::config::addr as config_addr;
     use super::telemetry::addr as telemetry_addr;
+    use control_table::descriptor::{EnumVariant, FieldKind};
 
     /// Pins the struct layout to the protocol sec 5.4 common register block:
     /// every generated field address equals its protocol const, and the
@@ -139,6 +141,68 @@ mod tests {
             telemetry_addr::mode::MODE_ACTIVE,
             table::TELEMETRY_COMMON_END
         );
+    }
+
+    /// Pins the exported field descriptors against the protocol consts: names
+    /// unique, addresses ascending, and the load-bearing identity/enum/bounds
+    /// facts a device-description exporter would rely on.
+    #[test]
+    fn field_descriptors_match_the_protocol() {
+        let f = ControlTable::FIELDS;
+        let by = |n: &str| f.iter().find(|d| d.name == n).unwrap();
+
+        // Names unique, addresses strictly ascending.
+        for (i, d) in f.iter().enumerate() {
+            assert!(
+                f[i + 1..].iter().all(|o| o.name != d.name),
+                "duplicate field name {}",
+                d.name
+            );
+        }
+        for w in f.windows(2) {
+            assert!(
+                w[0].addr < w[1].addr,
+                "addrs not ascending at {}",
+                w[1].name
+            );
+        }
+
+        let id = by("id");
+        assert_eq!(id.addr, table::ID);
+        assert_eq!(id.width, 1);
+        assert!(id.writable);
+        assert_eq!(id.min, Some(1));
+        assert_eq!(id.max, Some(249));
+
+        let model = by("model_number");
+        assert_eq!(model.addr, table::MODEL_NUMBER);
+        assert_eq!(model.width, 2);
+        assert!(!model.writable);
+        assert_eq!(model.kind, FieldKind::UInt);
+
+        assert_eq!(
+            by("stall_response").kind,
+            FieldKind::Enum(&[
+                EnumVariant {
+                    name: "Disable",
+                    value: 0
+                },
+                EnumVariant {
+                    name: "Comply",
+                    value: 1
+                },
+            ])
+        );
+
+        // goal_position's bounds are register-RHS (soft limits); they must not
+        // export as scalar bounds.
+        let goal = by("goal_position");
+        assert!(goal.writable);
+        assert_eq!((goal.min, goal.max), (None, None));
+
+        let lut = by("lut");
+        assert_eq!(lut.kind, FieldKind::Bytes);
+        assert_eq!(lut.width, 220);
     }
 
     /// Pins the profile region to its protocol sec 5.4 address pin and its

--- a/firmware/lib/integration/src/sim/servo.rs
+++ b/firmware/lib/integration/src/sim/servo.rs
@@ -17,10 +17,6 @@ use super::providers::{
 };
 use super::store::RamStore;
 
-/// Default identity a fresh sim servo answers PING with (model + fw).
-pub const DEFAULT_MODEL: u16 = 0x1234;
-pub const DEFAULT_FIRMWARE: u8 = 0x56;
-
 pub struct SimServo {
     shared: Shared,
     session: Session,
@@ -58,12 +54,12 @@ impl SimServo {
         // Default UID: the id repeated -- distinct per servo, predictable for
         // ENUM tests; override via `seed_uid` where prefix structure matters.
         shared.seed_uid([id; 16]);
-        // model/fw are read-only identity fields, seeded directly (not part of
-        // ConfigDefaults) so PING has something to answer with.
-        shared.table.with_mut(|t| {
-            t.config.common.model_number = DEFAULT_MODEL;
-            t.config.common.firmware_version = DEFAULT_FIRMWARE;
-        });
+        // Real identity: the sim mirrors the v006 servo's table ABI, so it
+        // seeds the registry model (not part of ConfigDefaults, same as the
+        // chip) - keeps descriptor-keyed clients testable against the sim.
+        shared
+            .table
+            .seed_identity(osc_protocol::models::MODEL_OSC_SERVO, 1);
 
         // The table is the comms authority (registry `Drivers::install` does
         // the same read on the chip).

--- a/firmware/lib/integration/src/sim/tests.rs
+++ b/firmware/lib/integration/src/sim/tests.rs
@@ -2,10 +2,10 @@
 //! real dispatch -> real TX engine -> recorded reply) before the test-suite
 //! chunks build on this facade.
 
+use osc_protocol::models::MODEL_OSC_SERVO;
 use osc_protocol::wire::{Opcode, ResultCode};
-use osc_servo_core::BaudRate;
+use osc_servo_core::{BaudRate, FIRMWARE_VERSION};
 
-use super::servo::{DEFAULT_FIRMWARE, DEFAULT_MODEL};
 use super::{HandlerCost, Sim, core::TICKS_PER_US};
 use super::{Source, assert_valid, instruction, status};
 
@@ -35,8 +35,8 @@ fn ping_round_trip() {
     let (rinst, payload) = status(reply);
     assert!(rinst.is_status());
     assert_eq!(rinst.result(), Some(ResultCode::Ok));
-    let m = DEFAULT_MODEL.to_le_bytes();
-    assert_eq!(payload, &[m[0], m[1], DEFAULT_FIRMWARE]);
+    let m = MODEL_OSC_SERVO.to_le_bytes();
+    assert_eq!(payload, &[m[0], m[1], FIRMWARE_VERSION]);
 
     // Reply lead: >= reply gap (fixed us, sec 7) and < 200 us after the instruction.
     let lead = reply.at - inst.end;

--- a/firmware/lib/integration/tests/chains.rs
+++ b/firmware/lib/integration/tests/chains.rs
@@ -259,8 +259,8 @@ fn gread_per_target_reads_distinct_spans(baud_idx: u8) {
     assert_eq!(by_id(1).1, 0x1122u16.to_le_bytes());
     // Servo 2: 1-byte firmware version.
     assert_eq!(by_id(2).1, vec![0x5A]);
-    // Servo 3: 3-byte model + firmware (default fw 0x56).
-    assert_eq!(by_id(3).1, vec![0x44, 0x33, 0x56]);
+    // Servo 3: 3-byte model + firmware (the sim's seeded FIRMWARE_VERSION = 1).
+    assert_eq!(by_id(3).1, vec![0x44, 0x33, 0x01]);
 }
 
 #[apply(matrix)]

--- a/firmware/lib/integration/tests/protocol.rs
+++ b/firmware/lib/integration/tests/protocol.rs
@@ -62,20 +62,21 @@ fn read_returns_table_bytes(baud_idx: u8) {
     let mut sim = sim(baud_idx);
     let s = sim.add_servo(ID5);
 
-    // READ config identity span [0, 4): model(2) + fw(1) + reserved(1).
+    // READ config identity span [0, 4): model(2) + fw(1) + hardware_revision(1).
     sim.host_send(&instruction(ID5, Opcode::Read, 0, &[0, 0, 4, 0]));
     let frames = sim.run();
 
     let (inst, payload) = status(sole_reply(&frames));
     assert_eq!(inst.result(), Some(ResultCode::Ok));
-    let (model, fw) = sim.servo_table(s, |t| {
+    let (model, fw, hw) = sim.servo_table(s, |t| {
         (
             t.config.common.model_number,
             t.config.common.firmware_version,
+            t.config.common.hardware_revision,
         )
     });
     let m = model.to_le_bytes();
-    assert_eq!(payload, &[m[0], m[1], fw, 0]);
+    assert_eq!(payload, &[m[0], m[1], fw, hw]);
 }
 
 #[apply(matrix)]
@@ -93,7 +94,9 @@ fn read_front_loaded_reply_matches_and_leaves_table(baud_idx: u8) {
     let (inst, payload) = status(sole_reply(&frames));
     assert_eq!(inst.result(), Some(ResultCode::Ok));
     let m = before.to_le_bytes();
-    assert_eq!(payload, &[m[0], m[1], 0x56, 0]);
+    // Identity span [0,4): model(2) + the sim's seeded fw(1) + hardware_revision(1),
+    // both 1 from `seed_identity`.
+    assert_eq!(payload, &[m[0], m[1], 0x01, 0x01]);
     assert_eq!(sim.servo_diag(s).crc_fail_count, 0);
     assert_eq!(
         sim.servo_table(s, |t| t.config.common.model_number),

--- a/firmware/lib/osc-protocol/src/lib.rs
+++ b/firmware/lib/osc-protocol/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bytes;
 pub mod crc;
 pub mod frame;
 pub mod group;
+pub mod models;
 pub mod reply;
 pub mod table;
 pub mod wire;

--- a/firmware/lib/osc-protocol/src/models.rs
+++ b/firmware/lib/osc-protocol/src/models.rs
@@ -1,0 +1,57 @@
+//! Model-number registry (protocol sec 5.4). A model number is class-structured:
+//! the high byte is the device class, the low byte the model within that class.
+//! It keys a table-ABI family; 0x0000 is reserved unassigned - what unseeded
+//! or dev firmware reports. Low byte 0x00 is likewise unassigned within a class,
+//! mirroring the global 0x0000 rule.
+
+/// Basic-tier servo class.
+pub const CLASS_SERVO: u8 = 0x01;
+
+/// Compose a model number from its class and per-class model bytes.
+pub const fn model_number(class: u8, model: u8) -> u16 {
+    ((class as u16) << 8) | model as u16
+}
+
+/// Extract the device-class byte from a model number.
+pub const fn model_class(n: u16) -> u8 {
+    (n >> 8) as u8
+}
+
+/// Registry-adjacent display name for a class byte; "unknown" off-registry.
+pub const fn class_name(class: u8) -> &'static str {
+    match class {
+        CLASS_SERVO => "servo",
+        _ => "unknown",
+    }
+}
+
+/// Reserved unassigned; unseeded or dev firmware reports it.
+pub const MODEL_UNASSIGNED: u16 = 0;
+/// The osc-servo-core table ABI, shared by every board flashing this firmware
+/// family (osc-dev-v006 today, sg90/mg90s swap boards later); a board takes its
+/// own number only if it diverges the table.
+pub const MODEL_OSC_SERVO: u16 = model_number(CLASS_SERVO, 0x01);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_model_round_trips() {
+        let n = model_number(0x02, 0x37);
+        assert_eq!(model_class(n), 0x02);
+        assert_eq!(n & 0xFF, 0x37);
+    }
+
+    #[test]
+    fn class_name_maps_the_registry() {
+        assert_eq!(class_name(CLASS_SERVO), "servo");
+        assert_eq!(class_name(0xFF), "unknown");
+    }
+
+    #[test]
+    fn osc_servo_number() {
+        assert_eq!(MODEL_OSC_SERVO, 0x0101);
+        assert_eq!(model_class(MODEL_OSC_SERVO), CLASS_SERVO);
+    }
+}

--- a/firmware/lib/table-export/Cargo.toml
+++ b/firmware/lib/table-export/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 osc-servo-core = { workspace = true }
+osc-protocol   = { workspace = true }
 control-table  = { workspace = true }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"

--- a/firmware/lib/table-export/Cargo.toml
+++ b/firmware/lib/table-export/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name    = "table-export"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+osc-servo-core = { workspace = true }
+control-table  = { workspace = true }
+serde          = { version = "1", features = ["derive"] }
+serde_json     = "1"

--- a/firmware/lib/table-export/src/main.rs
+++ b/firmware/lib/table-export/src/main.rs
@@ -1,8 +1,9 @@
 //! Walks `ControlTable::FIELDS` and prints a device-description JSON to
-//! stdout. Checked-in output lives at `descriptors/osc-servo-v006.json`;
+//! stdout. Checked-in output lives at `descriptors/osc-servo.json`;
 //! CI regenerates and diffs it to catch drift from the control table.
 
 use control_table::descriptor::FieldKind;
+use osc_protocol::models::{MODEL_OSC_SERVO, class_name, model_class};
 use osc_servo_core::regions::ControlTable;
 use serde::Serialize;
 
@@ -31,7 +32,9 @@ struct Field {
 struct Descriptor {
     format: u32,
     model: &'static str,
+    class: &'static str,
     model_number: u16,
+    firmware_version: u8,
     table_size: usize,
     generator: &'static str,
     fields: Vec<Field>,
@@ -71,14 +74,12 @@ fn build_descriptor() -> Descriptor {
         })
         .collect();
 
-    // Identity block is unseeded at this point in bringup, so model_number
-    // reads 0 here just as it does on the wire from a fresh servo.
-    let model_number = ControlTable::new().config.common.model_number;
-
     Descriptor {
         format: 1,
-        model: "osc-servo-v006",
-        model_number,
+        model: "osc-servo",
+        class: class_name(model_class(MODEL_OSC_SERVO)),
+        model_number: MODEL_OSC_SERVO,
+        firmware_version: osc_servo_core::FIRMWARE_VERSION,
         table_size: core::mem::size_of::<ControlTable>(),
         generator: "cargo run -p table-export (firmware/lib)",
         fields,
@@ -99,6 +100,9 @@ mod tests {
     fn descriptor_covers_all_fields_and_pins_id_bounds() {
         let json = serde_json::to_string(&super::build_descriptor()).unwrap();
         let value: Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["model_number"], 0x0101);
+        assert!(value["firmware_version"].as_u64().unwrap() >= 1);
 
         let fields = value["fields"].as_array().unwrap();
         assert_eq!(fields.len(), ControlTable::FIELDS.len());

--- a/firmware/lib/table-export/src/main.rs
+++ b/firmware/lib/table-export/src/main.rs
@@ -1,0 +1,110 @@
+//! Walks `ControlTable::FIELDS` and prints a device-description JSON to
+//! stdout. Checked-in output lives at `descriptors/osc-servo-v006.json`;
+//! CI regenerates and diffs it to catch drift from the control table.
+
+use control_table::descriptor::FieldKind;
+use osc_servo_core::regions::ControlTable;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Variant {
+    name: &'static str,
+    value: u8,
+}
+
+#[derive(Serialize)]
+struct Field {
+    name: &'static str,
+    addr: u16,
+    width: u16,
+    access: &'static str,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variants: Option<Vec<Variant>>,
+}
+
+#[derive(Serialize)]
+struct Descriptor {
+    format: u32,
+    model: &'static str,
+    model_number: u16,
+    table_size: usize,
+    generator: &'static str,
+    fields: Vec<Field>,
+}
+
+fn build_descriptor() -> Descriptor {
+    let fields = ControlTable::FIELDS
+        .iter()
+        .map(|d| {
+            let (kind, variants) = match d.kind {
+                FieldKind::UInt => ("uint", None),
+                FieldKind::Int => ("int", None),
+                FieldKind::Bool => ("bool", None),
+                FieldKind::Bytes => ("bytes", None),
+                FieldKind::Enum(vs) => (
+                    "enum",
+                    Some(
+                        vs.iter()
+                            .map(|v| Variant {
+                                name: v.name,
+                                value: v.value,
+                            })
+                            .collect(),
+                    ),
+                ),
+            };
+            Field {
+                name: d.name,
+                addr: d.addr,
+                width: d.width,
+                access: if d.writable { "rw" } else { "ro" },
+                kind,
+                min: d.min,
+                max: d.max,
+                variants,
+            }
+        })
+        .collect();
+
+    // Identity block is unseeded at this point in bringup, so model_number
+    // reads 0 here just as it does on the wire from a fresh servo.
+    let model_number = ControlTable::new().config.common.model_number;
+
+    Descriptor {
+        format: 1,
+        model: "osc-servo-v006",
+        model_number,
+        table_size: core::mem::size_of::<ControlTable>(),
+        generator: "cargo run -p table-export (firmware/lib)",
+        fields,
+    }
+}
+
+fn main() {
+    let json = serde_json::to_string_pretty(&build_descriptor()).unwrap();
+    println!("{json}");
+}
+
+#[cfg(test)]
+mod tests {
+    use osc_servo_core::regions::ControlTable;
+    use serde_json::Value;
+
+    #[test]
+    fn descriptor_covers_all_fields_and_pins_id_bounds() {
+        let json = serde_json::to_string(&super::build_descriptor()).unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+
+        let fields = value["fields"].as_array().unwrap();
+        assert_eq!(fields.len(), ControlTable::FIELDS.len());
+
+        let id = fields.iter().find(|f| f["name"] == "id").unwrap();
+        assert_eq!(id["min"], 1);
+        assert_eq!(id["max"], 249);
+    }
+}

--- a/firmware/servo-ch32/src/cfg/mod.rs
+++ b/firmware/servo-ch32/src/cfg/mod.rs
@@ -18,6 +18,10 @@ pub struct BoardConfig {
     pub wiring: BoardWiring,
     pub calibration: Calibration,
     pub defaults: ConfigDefaults,
+    /// Identity the board stamps into the RO block (protocol sec 5.4); the
+    /// firmware version comes from `osc_servo_core::FIRMWARE_VERSION`, not here.
+    pub model: u16,
+    pub hw_rev: u8,
 }
 
 /// Boot-time-derived values that the `run!` macro folds at compile time so the

--- a/firmware/servo-ch32/src/control/mod.rs
+++ b/firmware/servo-ch32/src/control/mod.rs
@@ -26,6 +26,8 @@ impl Ch32ControlIo {
             wiring,
             calibration,
             defaults,
+            model,
+            hw_rev,
         } = cfg;
 
         crate::log::debug!(
@@ -38,7 +40,8 @@ impl Ch32ControlIo {
         let drv_en_pin = wiring.drv_en.pin.pin();
         let drv_en_active = wiring.drv_en.active;
 
-        let BringupResult { shunt_bias_raw } = crate::runtime::bringup(&wiring, &defaults, &pre);
+        let BringupResult { shunt_bias_raw } =
+            crate::runtime::bringup(&wiring, &defaults, model, hw_rev, &pre);
 
         crate::log::info!("Ch32ControlIo::new: complete");
         Self {

--- a/firmware/servo-ch32/src/prelude.rs
+++ b/firmware/servo-ch32/src/prelude.rs
@@ -8,4 +8,5 @@ pub use crate::cfg::{
 };
 pub use crate::hal::{Pin, opa};
 pub use crate::{BaudRate, ConfigDefaults};
+pub use osc_protocol::models::MODEL_OSC_SERVO;
 pub use osc_servo_core::regions::config::DEFAULT_RESPONSE_DEADLINE_US;

--- a/firmware/servo-ch32/src/runtime/init.rs
+++ b/firmware/servo-ch32/src/runtime/init.rs
@@ -27,6 +27,8 @@ pub struct BringupResult {
 pub fn bringup(
     wiring: &BoardWiring,
     defaults: &ConfigDefaults,
+    model: u16,
+    hw_rev: u8,
     pre: &Precomputed,
 ) -> BringupResult {
     enable_clocks_and_remaps(wiring);
@@ -39,6 +41,7 @@ pub fn bringup(
     // first, then the saved image overlays them (protocol sec 9.4) -- `Drivers::install`
     // reads the effective comms block from the table.
     SHARED.table.seed_config_defaults(defaults);
+    SHARED.table.seed_identity(model, hw_rev);
     config_store::ConfigStore::boot_load();
     SHARED.seed_uid(esig::uid());
 

--- a/tools/osc/Cargo.lock
+++ b/tools/osc/Cargo.lock
@@ -202,6 +202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +233,12 @@ checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nusb"
@@ -267,6 +279,8 @@ dependencies = [
  "clap",
  "osc-client",
  "osc-protocol",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -332,6 +346,49 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -522,3 +579,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/tools/osc/Cargo.toml
+++ b/tools/osc/Cargo.toml
@@ -13,3 +13,5 @@ anyhow       = "1"
 clap         = { version = "4", features = ["derive"] }
 osc-client   = { path = "../../client" }
 osc-protocol = { path = "../../firmware/lib/osc-protocol" }
+serde        = { version = "1", features = ["derive"] }
+serde_json   = "1"

--- a/tools/osc/src/descriptor.rs
+++ b/tools/osc/src/descriptor.rs
@@ -1,0 +1,540 @@
+//! Descriptor-driven typed register access. A descriptor is the firmware's
+//! exported device description (descriptors/osc-servo.json); it maps register
+//! names to table addresses, widths, access, and value kinds so the operator
+//! names `goal_position` instead of `0x0184`. Built-ins are compiled in;
+//! operators drop model-matching JSON in their config dir to override or add.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::{hex, parse_hex};
+
+/// One built-in descriptor, compiled from the checked-in export. A second
+/// built-in is one more entry.
+const BUILTINS: &[&str] = &[include_str!("../../../descriptors/osc-servo.json")];
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Descriptor {
+    pub model: String,
+    pub model_number: u16,
+    pub firmware_version: u8,
+    pub table_size: u16,
+    pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Field {
+    pub name: String,
+    pub addr: u16,
+    pub width: u16,
+    pub access: Access,
+    pub kind: Kind,
+    #[serde(default)]
+    pub variants: Vec<Variant>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Access {
+    Ro,
+    Rw,
+}
+
+impl Access {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Access::Ro => "ro",
+            Access::Rw => "rw",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    Uint,
+    Int,
+    Bool,
+    Enum,
+    Bytes,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Variant {
+    pub name: String,
+    /// Discriminants are u8 by construction (the derive requires repr(u8)).
+    pub value: u8,
+}
+
+/// The known descriptor set: built-ins overlaid by external files sharing a
+/// model number.
+pub struct Registry {
+    descriptors: Vec<Descriptor>,
+}
+
+impl Registry {
+    /// Parse the compiled built-ins, then overlay every external descriptor.
+    /// A built-in that fails to parse is a build-time bug and panics; an
+    /// external file that fails to parse is a hard error naming the file.
+    pub fn load() -> Result<Self> {
+        let mut descriptors: Vec<Descriptor> = BUILTINS
+            .iter()
+            .map(|s| serde_json::from_str(s).expect("built-in descriptor parses"))
+            .collect();
+        for path in external_paths()? {
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading descriptor {}", path.display()))?;
+            let d: Descriptor = serde_json::from_str(&text)
+                .with_context(|| format!("parsing descriptor {}", path.display()))?;
+            // Same model number overrides the built-in: the operator's escape
+            // hatch for a firmware whose table diverged from the shipped one.
+            descriptors.retain(|e| e.model_number != d.model_number);
+            descriptors.push(d);
+        }
+        Ok(Registry { descriptors })
+    }
+
+    /// Pick the descriptor for a servo-reported (model, fw). Returns the
+    /// selection plus any advisory note to print at the call site.
+    pub fn select(&self, model: u16, fw: u8) -> Result<(&Descriptor, Option<String>)> {
+        if let Some(d) = self.descriptors.iter().find(|d| d.model_number == model) {
+            let note = (d.firmware_version != fw).then(|| {
+                format!(
+                    "warning: descriptor {} is fw {}, servo reports fw {} (common block is protocol-stable)",
+                    d.model, d.firmware_version, fw
+                )
+            });
+            return Ok((d, note));
+        }
+        // model 0 is unassigned (unprovisioned or dev firmware). With exactly
+        // one descriptor known there is no ambiguity to resolve.
+        if model == 0
+            && let [only] = self.descriptors.as_slice()
+        {
+            let note = format!(
+                "note: servo model unassigned; assuming {} (the only known descriptor)",
+                only.model
+            );
+            return Ok((only, Some(note)));
+        }
+        let mut known: Vec<String> = self
+            .descriptors
+            .iter()
+            .map(|d| format!("{} ({:#06x})", d.model, d.model_number))
+            .collect();
+        known.sort();
+        bail!(
+            "no descriptor for model {:#06x}; known: {}\ndrop a matching *.json in {}",
+            model,
+            known.join(", "),
+            external_dir().display(),
+        );
+    }
+}
+
+/// External descriptor directory: `$OSC_CONFIG_DIR/descriptors` else
+/// `$HOME/.config/osc/descriptors`.
+fn external_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("OSC_CONFIG_DIR") {
+        return Path::new(&dir).join("descriptors");
+    }
+    let home = std::env::var_os("HOME").unwrap_or_default();
+    Path::new(&home).join(".config/osc/descriptors")
+}
+
+/// Every `*.json` under the external dir, sorted for deterministic overlay.
+/// A missing dir is not an error (operators need not have one).
+fn external_paths() -> Result<Vec<PathBuf>> {
+    let dir = external_dir();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
+    };
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let path = entry?.path();
+        if path.extension().is_some_and(|e| e == "json") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+impl Descriptor {
+    /// Find a field by exact name; on a miss, suggest near matches so a typo
+    /// is one correction away.
+    pub fn field(&self, name: &str) -> Result<&Field> {
+        if let Some(f) = self.fields.iter().find(|f| f.name == name) {
+            return Ok(f);
+        }
+        let near: Vec<&str> = self
+            .fields
+            .iter()
+            .filter(|f| f.name.contains(name) || name.contains(f.name.as_str()))
+            .map(|f| f.name.as_str())
+            .collect();
+        if near.is_empty() {
+            bail!("no field named {name:?}");
+        }
+        bail!("no field named {name:?}; did you mean: {}", near.join(", "));
+    }
+}
+
+impl Field {
+    /// Exclusive end address of this field's bytes.
+    pub fn end(&self) -> u16 {
+        self.addr + self.width
+    }
+}
+
+/// Decode raw table bytes into an operator-facing string per the field's kind.
+pub fn decode(field: &Field, bytes: &[u8]) -> Result<String> {
+    match field.kind {
+        Kind::Uint => Ok(read_uint(field, bytes)?.to_string()),
+        Kind::Int => Ok(read_int(field, bytes)?.to_string()),
+        Kind::Bool => Ok(if bytes.first().copied().unwrap_or(0) != 0 {
+            "on".into()
+        } else {
+            "off".into()
+        }),
+        Kind::Enum => {
+            // Unsigned: a discriminant past 127 must not sign-extend.
+            let n = read_uint(field, bytes)?;
+            Ok(match field.variants.iter().find(|v| v.value as u64 == n) {
+                Some(v) => format!("{} ({})", v.name, n),
+                None => n.to_string(),
+            })
+        }
+        Kind::Bytes => Ok(hex(bytes)),
+    }
+}
+
+/// Encode an operator string into exactly `width` table bytes per the kind.
+/// Bounds are not pre-checked: the servo owns validation and its reject reply
+/// is the truth.
+pub fn encode(field: &Field, s: &str) -> Result<Vec<u8>> {
+    if field.access == Access::Ro {
+        bail!(
+            "field {} is {} (read-only)",
+            field.name,
+            field.access.as_str()
+        );
+    }
+    match field.kind {
+        Kind::Uint => write_uint(field, parse_u64(s)?),
+        Kind::Int => write_int(field, parse_i64(s)?),
+        Kind::Bool => {
+            let on = match s.to_ascii_lowercase().as_str() {
+                "on" | "true" | "1" => true,
+                "off" | "false" | "0" => false,
+                _ => bail!("bool wants on|off|true|false|1|0, got {s:?}"),
+            };
+            Ok(vec![on as u8])
+        }
+        Kind::Enum => {
+            let n = enum_value(field, s)?;
+            write_uint(field, n as u64)
+        }
+        Kind::Bytes => {
+            let bytes = parse_hex(s)?;
+            if bytes.len() != field.width as usize {
+                bail!(
+                    "field {} takes {} hex bytes, got {}",
+                    field.name,
+                    field.width,
+                    bytes.len()
+                );
+            }
+            Ok(bytes)
+        }
+    }
+}
+
+fn read_uint(field: &Field, bytes: &[u8]) -> Result<u64> {
+    scalar_le(field, bytes)
+}
+
+fn read_int(field: &Field, bytes: &[u8]) -> Result<i64> {
+    let raw = scalar_le(field, bytes)?;
+    // Sign-extend from the field width.
+    Ok(match field.width {
+        1 => raw as u8 as i8 as i64,
+        2 => raw as u16 as i16 as i64,
+        4 => raw as u32 as i32 as i64,
+        w => bail!("field {} has unsupported scalar width {w}", field.name),
+    })
+}
+
+/// Read a little-endian unsigned scalar of the field's width from `bytes`.
+fn scalar_le(field: &Field, bytes: &[u8]) -> Result<u64> {
+    let w = field.width as usize;
+    if !matches!(w, 1 | 2 | 4) {
+        bail!("field {} has unsupported scalar width {w}", field.name);
+    }
+    if bytes.len() < w {
+        bail!("field {} wants {w} B, got {}", field.name, bytes.len());
+    }
+    let mut v = 0u64;
+    for (i, &b) in bytes[..w].iter().enumerate() {
+        v |= (b as u64) << (8 * i);
+    }
+    Ok(v)
+}
+
+fn write_uint(field: &Field, v: u64) -> Result<Vec<u8>> {
+    let max = match field.width {
+        1 => u8::MAX as u64,
+        2 => u16::MAX as u64,
+        4 => u32::MAX as u64,
+        w => bail!("field {} has unsupported scalar width {w}", field.name),
+    };
+    if v > max {
+        bail!(
+            "value {v} overflows u{} field {}",
+            field.width * 8,
+            field.name
+        );
+    }
+    Ok(v.to_le_bytes()[..field.width as usize].to_vec())
+}
+
+fn write_int(field: &Field, v: i64) -> Result<Vec<u8>> {
+    let (lo, hi) = match field.width {
+        1 => (i8::MIN as i64, i8::MAX as i64),
+        2 => (i16::MIN as i64, i16::MAX as i64),
+        4 => (i32::MIN as i64, i32::MAX as i64),
+        w => bail!("field {} has unsupported scalar width {w}", field.name),
+    };
+    if v < lo || v > hi {
+        bail!(
+            "value {v} overflows i{} field {}",
+            field.width * 8,
+            field.name
+        );
+    }
+    Ok(v.to_le_bytes()[..field.width as usize].to_vec())
+}
+
+/// Resolve an enum arg: variant name (exact, then case-insensitive), else a
+/// raw discriminant number.
+fn enum_value(field: &Field, s: &str) -> Result<u8> {
+    if let Some(v) = field.variants.iter().find(|v| v.name == s) {
+        return Ok(v.value);
+    }
+    if let Some(v) = field
+        .variants
+        .iter()
+        .find(|v| v.name.eq_ignore_ascii_case(s))
+    {
+        return Ok(v.value);
+    }
+    if let Ok(n) = parse_u64(s) {
+        return u8::try_from(n).with_context(|| format!("enum discriminant {n} overflows u8"));
+    }
+    let names: Vec<&str> = field.variants.iter().map(|v| v.name.as_str()).collect();
+    bail!(
+        "enum {} takes a variant name ({}) or number, got {s:?}",
+        field.name,
+        names.join(", ")
+    );
+}
+
+fn parse_u64(s: &str) -> Result<u64> {
+    match s.strip_prefix("0x") {
+        Some(h) => u64::from_str_radix(h, 16).with_context(|| format!("bad hex {s:?}")),
+        None => s.parse().with_context(|| format!("bad integer {s:?}")),
+    }
+}
+
+fn parse_i64(s: &str) -> Result<i64> {
+    if let Some(h) = s.strip_prefix("0x") {
+        return i64::from_str_radix(h, 16).with_context(|| format!("bad hex {s:?}"));
+    }
+    if let Some(h) = s.strip_prefix("-0x") {
+        return Ok(-i64::from_str_radix(h, 16).with_context(|| format!("bad hex {s:?}"))?);
+    }
+    s.parse().with_context(|| format!("bad integer {s:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn builtin() -> Descriptor {
+        serde_json::from_str(BUILTINS[0]).unwrap()
+    }
+
+    fn field(d: &Descriptor, name: &str) -> Field {
+        d.field(name).unwrap().clone()
+    }
+
+    #[test]
+    fn builtin_parses() {
+        let d = builtin();
+        assert_eq!(d.model_number, 257);
+        assert_eq!(d.model, "osc-servo");
+        assert!(d.fields.len() > 50);
+        let id = d.field("id").unwrap();
+        assert_eq!(id.addr, 16);
+        assert_eq!(id.access, Access::Rw);
+    }
+
+    #[test]
+    fn uint_round_trips() {
+        let d = builtin();
+        let f = field(&d, "response_deadline_us"); // u16
+        let bytes = encode(&f, "1000").unwrap();
+        assert_eq!(bytes, vec![0xE8, 0x03]);
+        assert_eq!(decode(&f, &bytes).unwrap(), "1000");
+        // hex input
+        assert_eq!(encode(&f, "0x03e8").unwrap(), vec![0xE8, 0x03]);
+    }
+
+    #[test]
+    fn int_round_trips_and_signs() {
+        let d = builtin();
+        let f = field(&d, "goal_position"); // i32
+        let bytes = encode(&f, "-100000").unwrap();
+        assert_eq!(decode(&f, &bytes).unwrap(), "-100000");
+        assert_eq!(
+            encode(&f, "-0x10").unwrap(),
+            (-16i32).to_le_bytes().to_vec()
+        );
+    }
+
+    #[test]
+    fn bool_round_trips() {
+        let d = builtin();
+        let f = field(&d, "torque_enable");
+        assert_eq!(encode(&f, "on").unwrap(), vec![1]);
+        assert_eq!(encode(&f, "true").unwrap(), vec![1]);
+        assert_eq!(encode(&f, "0").unwrap(), vec![0]);
+        assert_eq!(decode(&f, &[1]).unwrap(), "on");
+        assert_eq!(decode(&f, &[0]).unwrap(), "off");
+    }
+
+    #[test]
+    fn enum_by_name_and_number() {
+        let d = builtin();
+        let f = field(&d, "mode");
+        assert_eq!(encode(&f, "PositionPid").unwrap(), vec![1]);
+        assert_eq!(encode(&f, "positionpid").unwrap(), vec![1]); // case-insensitive
+        assert_eq!(encode(&f, "1").unwrap(), vec![1]);
+        assert_eq!(decode(&f, &[1]).unwrap(), "PositionPid (1)");
+        // off-registry discriminant falls back to the raw number
+        assert_eq!(decode(&f, &[7]).unwrap(), "7");
+    }
+
+    #[test]
+    fn bytes_round_trips() {
+        let d = builtin();
+        let f = field(&d, "words"); // 64 B
+        let hexstr = "aa bb ".to_string() + &"00 ".repeat(62);
+        let bytes = encode(&f, &hexstr).unwrap();
+        assert_eq!(bytes.len(), 64);
+        assert_eq!(bytes[0], 0xaa);
+        assert!(decode(&f, &bytes).unwrap().starts_with("aa bb"));
+    }
+
+    #[test]
+    fn overflow_rejects() {
+        let d = builtin();
+        let f = field(&d, "response_deadline_us"); // u16
+        assert!(encode(&f, "70000").is_err());
+        let g = field(&d, "goal_effort"); // i16
+        assert!(encode(&g, "40000").is_err());
+    }
+
+    #[test]
+    fn enum_high_discriminant_stays_unsigned() {
+        let f = Field {
+            name: "grade".into(),
+            addr: 0,
+            width: 1,
+            access: Access::Rw,
+            kind: Kind::Enum,
+            variants: vec![Variant {
+                name: "Hi".into(),
+                value: 200,
+            }],
+        };
+        assert_eq!(encode(&f, "Hi").unwrap(), vec![200]);
+        assert_eq!(encode(&f, "200").unwrap(), vec![200]);
+        assert_eq!(decode(&f, &[200]).unwrap(), "Hi (200)");
+    }
+
+    #[test]
+    fn enum_unknown_name_rejects() {
+        let d = builtin();
+        let f = field(&d, "mode");
+        assert!(encode(&f, "Nonsense").is_err());
+    }
+
+    #[test]
+    fn ro_set_rejects() {
+        let d = builtin();
+        let f = field(&d, "present_position"); // ro
+        let err = encode(&f, "0").unwrap_err().to_string();
+        assert!(err.contains("read-only"));
+    }
+
+    #[test]
+    fn bytes_wrong_length_rejects() {
+        let d = builtin();
+        let f = field(&d, "words"); // 64 B
+        assert!(encode(&f, "aabb").is_err());
+    }
+
+    #[test]
+    fn field_miss_suggests() {
+        let d = builtin();
+        let err = d.field("goal_pos").unwrap_err().to_string();
+        assert!(err.contains("goal_position"));
+    }
+
+    // Selection tests build the registry from the built-in only: Registry::load
+    // would read the developer's real external descriptor dir.
+    #[test]
+    fn select_exact_match() {
+        let reg = Registry {
+            descriptors: vec![builtin()],
+        };
+        let (d, note) = reg.select(257, 1).unwrap();
+        assert_eq!(d.model_number, 257);
+        assert!(note.is_none());
+    }
+
+    #[test]
+    fn select_fw_mismatch_warns() {
+        let reg = Registry {
+            descriptors: vec![builtin()],
+        };
+        let (_, note) = reg.select(257, 9).unwrap();
+        assert!(note.unwrap().contains("fw"));
+    }
+
+    #[test]
+    fn select_model_zero_single_descriptor() {
+        // The built-in set is a single descriptor, so model 0 resolves to it.
+        let reg = Registry {
+            descriptors: vec![builtin()],
+        };
+        let (d, note) = reg.select(0, 1).unwrap();
+        assert_eq!(d.model_number, 257);
+        assert!(note.unwrap().contains("unassigned"));
+    }
+
+    #[test]
+    fn select_unknown_model_bails() {
+        let reg = Registry {
+            descriptors: vec![builtin()],
+        };
+        let err = reg.select(0x0999, 1).unwrap_err().to_string();
+        assert!(err.contains("known"));
+        assert!(err.contains("osc-servo"));
+    }
+}

--- a/tools/osc/src/main.rs
+++ b/tools/osc/src/main.rs
@@ -1,9 +1,11 @@
 //! `osc` -- the operator CLI for an osc-native bus, driven through the
 //! osc-adapter: discovery, rescue, id/baud management, calibration,
-//! persistence, profiles, one-shot reads/writes, and the adapter's own
-//! management verbs (rails, bootloader). A thin surface over osc-client --
-//! every choreography lives in the library. Wire measurement is the bench
-//! `tool-*` binaries' job, not this tool's.
+//! persistence, profiles, one-shot reads/writes, typed get/set/dump, and the
+//! adapter's own management verbs (rails, bootloader). A thin surface over
+//! osc-client -- every choreography lives in the library. Wire measurement is
+//! the bench `tool-*` binaries' job, not this tool's.
+
+mod descriptor;
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
@@ -181,6 +183,27 @@ enum Cmd {
     },
     /// Broadcast COMMIT: every held write applies in the same instant.
     Commit,
+    /// Read one register by name, decoded per the device descriptor.
+    Get {
+        /// Register name (see `dump` for the roster).
+        field: String,
+    },
+    /// Write one register by name, encoded per the device descriptor.
+    Set {
+        /// Register name.
+        field: String,
+        /// Value: decimal/0x-hex int, on|off for bool, variant name or number
+        /// for enum, hex bytes for a bytes field.
+        value: String,
+        /// Stage under HOLD; applied by the next COMMIT.
+        #[arg(long)]
+        hold: bool,
+        /// Fire-and-forget: no status frame owed.
+        #[arg(long, conflicts_with = "hold")]
+        noreply: bool,
+    },
+    /// Read the whole control table, one decoded line per descriptor field.
+    Dump,
 }
 
 #[derive(Subcommand, Debug)]
@@ -496,6 +519,98 @@ fn profile(c: &mut Client<NusbPipe>, id: Id, cmd: &ProfileCmd) -> Result<()> {
     }
 }
 
+/// Identity read (protocol sec 5.4 front) plus descriptor selection. Prints
+/// any advisory note at the call site so the codec stays print-free.
+fn select_descriptor<'a>(
+    c: &mut Client<NusbPipe>,
+    id: Id,
+    reg: &'a descriptor::Registry,
+) -> Result<&'a descriptor::Descriptor> {
+    let b = c.read(id, 0, 4)?;
+    if b.len() < 4 {
+        bail!("identity read returned {} B, expected 4", b.len());
+    }
+    let model = u16::from_le_bytes([b[0], b[1]]);
+    let fw = b[2];
+    let (d, note) = reg.select(model, fw)?;
+    if let Some(note) = note {
+        println!("{note}");
+    }
+    Ok(d)
+}
+
+fn get(c: &mut Client<NusbPipe>, id: Id, name: &str) -> Result<()> {
+    let reg = descriptor::Registry::load()?;
+    let d = select_descriptor(c, id, &reg)?;
+    let f = d.field(name)?;
+    let bytes = c.read(id, f.addr, f.width)?;
+    println!(
+        "{} = {}  (addr {:#06x}, {} B, raw {})",
+        f.name,
+        descriptor::decode(f, &bytes)?,
+        f.addr,
+        f.width,
+        hex(&bytes),
+    );
+    Ok(())
+}
+
+fn set(
+    c: &mut Client<NusbPipe>,
+    id: Id,
+    name: &str,
+    value: &str,
+    hold: bool,
+    noreply: bool,
+) -> Result<()> {
+    let reg = descriptor::Registry::load()?;
+    let d = select_descriptor(c, id, &reg)?;
+    let f = d.field(name)?;
+    let data = descriptor::encode(f, value)?;
+    if hold {
+        c.write_hold(id, f.addr, &data)?;
+        println!(
+            "staged {} = {value} at {:#06x} (HOLD; COMMIT applies)",
+            f.name, f.addr
+        );
+    } else if noreply {
+        c.write_noreply(id, f.addr, &data)?;
+        println!("sent {} = {value} at {:#06x} (NOREPLY)", f.name, f.addr);
+    } else {
+        c.write(id, f.addr, &data)?;
+        println!("wrote {} = {value} at {:#06x}", f.name, f.addr);
+    }
+    Ok(())
+}
+
+fn dump(c: &mut Client<NusbPipe>, id: Id) -> Result<()> {
+    let reg = descriptor::Registry::load()?;
+    let d = select_descriptor(c, id, &reg)?;
+    // A status frame carries <= 252 payload bytes; walk the table in chunks
+    // and slice each field's bytes out of the flat image.
+    const CHUNK: u16 = 252;
+    let mut table = vec![0u8; d.table_size as usize];
+    let mut addr = 0u16;
+    while addr < d.table_size {
+        let len = CHUNK.min(d.table_size - addr);
+        let bytes = c.read(id, addr, len)?;
+        let start = addr as usize;
+        table[start..start + bytes.len()].copy_from_slice(&bytes);
+        addr += len;
+    }
+    for f in &d.fields {
+        let bytes = &table[f.addr as usize..f.end() as usize];
+        println!(
+            "{:#06x}  {:<28} {:<2}  {}",
+            f.addr,
+            f.name,
+            f.access.as_str(),
+            descriptor::decode(f, bytes)?,
+        );
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let id = Id::new(cli.id);
@@ -691,5 +806,13 @@ fn main() -> Result<()> {
             Ok(())
         }
         Cmd::Profile { cmd } => profile(&mut connect_bus(&cli)?, id, cmd),
+        Cmd::Get { field } => get(&mut connect_bus(&cli)?, id, field),
+        Cmd::Set {
+            field,
+            value,
+            hold,
+            noreply,
+        } => set(&mut connect_bus(&cli)?, id, field, value, *hold, *noreply),
+        Cmd::Dump => dump(&mut connect_bus(&cli)?, id),
     }
 }


### PR DESCRIPTION
The control-table derives now emit machine-readable field descriptors, a host-side exporter turns them into a checked-in device-description JSON, and the osc CLI reads that JSON for typed register access. One definition (the Rust DSL) now feeds the firmware table, the wire artifact, and the operator tooling.

## Commits

- **control-table: emit field descriptors from the table derives** - Block/Section/Table emit `CT_FIELDS` -> `CT_FIELDS_ABS` -> `FIELDS` (name, table-absolute addr, width, access, kind, scalar bounds folded from immediate compare rules); the Enum derive pairs variant names with discriminants. Rust consts are lazy, so unreferenced descriptor data costs the servo image nothing: the release image is byte-identical before and after (text 28104 / data 300 / bss 2164).
- **tools: export the servo table descriptor to checked-in json** - `table-export` walks `ControlTable::FIELDS` and prints deterministic JSON; `descriptors/osc-servo.json` is committed and a CI step regenerates and diffs it, so the artifact cannot drift from the table.
- **core: class-structured model registry, identity seeded at boot** - `osc-protocol::models` assigns `[class:8][model:8]` numbers (0x0000 reserved; `MODEL_OSC_SERVO` = 0x0101 keys the table-ABI family shared by osc-dev-v006 and future swap boards). `seed_identity` stamps model, hardware revision, and the compiled-in `FIRMWARE_VERSION` at boot; a persist test pins that a restored SAVE image never resurrects old identity. The DES sim seeds the real registry identity, so descriptor-keyed clients are testable against it.
- **tools: descriptor stamps registry identity, artifact renamed osc-servo** - the JSON carries model, class, model_number, firmware_version from the registry.
- **osc: typed get/set/dump keyed by the device descriptor** - `osc get goal_position`, `osc set mode PositionPid`, `osc dump`. Selection: exact model match (firmware-version mismatch warns, since the common block is protocol-stable), model 0 falls back to the sole known descriptor with a note, unknown models fail listing the roster. External descriptors in `$OSC_CONFIG_DIR/descriptors` or `~/.config/osc/descriptors` override built-ins.

## Verification

- CI-verbatim fmt/clippy/test pass in every touched workspace (firmware/lib, servo-ch32, boards/osc-dev-v006, client, tools/osc); the osc-cli CI job gains a test step.
- Descriptor regeneration is deterministic (byte-identical across runs) and the freshness gate enforces it.
- `cargo install --git <repo> --branch table-descriptor osc` builds and installs a working binary with the descriptor compiled in.
- Flash: stage 1 is byte-neutral by construction; identity seeding adds 62 B of text, the only image growth in the band.